### PR TITLE
Update module path to dedicated repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sei-protocol/platform/tools/seictl
+module github.com/sei-protocol/seictl
 
 go 1.25.2
 


### PR DESCRIPTION
Originally moved from platform repo; update the module path to match new home.