### PR TITLE
Add ad-hoc patch command for TOML and JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ configuration files (TOML) and genesis files (JSON) with ease. More features to 
 
 - **Configuration Management**: Patch Sei daemon configuration files (`app.toml`, `client.toml`, `config.toml`)
 - **Genesis Management**: Apply merge patches to genesis JSON files
+- **Universal Patching**: Apply merge patches to any TOML or JSON file
 - **Smart Target Detection**: Automatically detects which configuration file to modify based on patch content
 - **Flexible Output**: Write to stdout, a specific file, or modify files in-place
 - **Atomic Writes**: Safe file modifications using atomic write operations
@@ -16,18 +17,95 @@ configuration files (TOML) and genesis files (JSON) with ease. More features to 
 
 ## Installation
 
-### Prerequisites
+### Pre-built Binaries (Recommended)
 
-- Go 1.25.2 or higher
+Pre-built binaries are available for Linux, macOS, and Windows. Download the latest release from
+the [releases page](https://github.com/sei-protocol/seictl/releases).
+
+#### Quick Install
+
+**Linux (x86_64)**
+
+```bash
+curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Linux_x86_64.tar.gz
+tar -xzf seictl_Linux_x86_64.tar.gz
+sudo mv seictl /usr/local/bin/
+```
+
+**Linux (ARM64)**
+
+```bash
+curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Linux_arm64.tar.gz
+tar -xzf seictl_Linux_arm64.tar.gz
+sudo mv seictl /usr/local/bin/
+```
+
+**Linux (ARMv7)**
+
+```bash
+curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Linux_armv7.tar.gz
+tar -xzf seictl_Linux_armv7.tar.gz
+sudo mv seictl /usr/local/bin/
+```
+
+**macOS (Apple Silicon)**
+
+```bash
+curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Darwin_arm64.tar.gz
+tar -xzf seictl_Darwin_arm64.tar.gz
+sudo mv seictl /usr/local/bin/
+```
+
+**macOS (Intel)**
+
+```bash
+curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Darwin_x86_64.tar.gz
+tar -xzf seictl_Darwin_x86_64.tar.gz
+sudo mv seictl /usr/local/bin/
+```
+
+**Windows (x86_64)**
+
+```powershell
+# Download from: https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Windows_x86_64.zip
+# Extract and add to PATH
+```
+
+#### Verify Installation
+
+```bash
+seictl --version
+```
+
+#### Verify Download (Optional)
+
+All releases include a `checksums.txt` file for verification, e.g.:
+
+```bash
+# Download checksums
+curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/checksums.txt
+
+# Verify (Linux/macOS)
+sha256sum -c checksums.txt 2>&1 | grep seictl_Linux_x86_64.tar.gz
+```
 
 ### Build from Source
 
+If you prefer to build from source or need a specific configuration:
+
+#### Prerequisites
+
+- Go 1.25.4 or higher
+
+#### Build
+
 ```bash
 git clone https://github.com/sei-protocol/seictl.git
+cd seictl
 go build -o seictl
 ```
 
-### Install
+### Install via Go
 
 ```bash
 go install github.com/sei-protocol/seictl@latest
@@ -44,6 +122,41 @@ seictl [global options] command [command options] [arguments...]
 - `--home <path>`: Sei home directory (default: `~/.sei`, can be set via `SEI_HOME` environment variable)
 
 ## Commands
+
+### Patch Command
+
+#### `patch`
+
+Apply a merge-patch to any TOML or JSON file. This is a universal patching command that works with any file format, not
+just Sei-specific configurations.
+
+```bash
+seictl patch --target <file-path> [patch-file]
+```
+
+**Options:**
+
+- `--target <path>`: Path to the TOML or JSON file to patch (required)
+- `-o, --output <path>`: Write output to specified file
+- `-i, --in-place-rewrite`: Modify the target file in-place
+
+**Examples:**
+
+```bash
+# Patch any TOML file
+seictl patch --target /path/to/config.toml patch.toml
+
+# Patch any JSON file from stdin
+echo '{"new_key": "value"}' | seictl patch --target /path/to/data.json
+
+# Patch and save to a new file
+seictl patch --target myconfig.toml patch.toml -o modified.toml
+
+# Patch and modify in-place
+seictl patch --target settings.json patch.json -i
+```
+
+**Note:** The file extension (`.toml` or `.json`) is used to determine the format automatically.
 
 ### Genesis Commands
 
@@ -228,6 +341,26 @@ EOF
 seictl config patch patch.toml -i
 ```
 
+### Patch a Custom TOML Configuration
+
+```bash
+# Patch any TOML file outside the Sei directory structure
+cat > custom-patch.toml << EOF
+[database]
+host = "localhost"
+port = 5432
+EOF
+
+seictl patch --target /etc/myapp/config.toml custom-patch.toml -i
+```
+
+### Patch a Custom JSON Data File
+
+```bash
+# Modify any JSON file
+echo '{"version": "2.0", "debug": true}' | seictl patch --target /path/to/settings.json -i
+```
+
 ### Using Custom Sei Home Directory
 
 ```bash
@@ -238,6 +371,15 @@ seictl config patch patch.toml
 # Via flag
 seictl --home /custom/path/.sei config patch patch.toml
 ```
+
+## Command Comparison
+
+### When to Use Each Command
+
+- **`patch`**: Use for patching any arbitrary TOML or JSON file on your system. Requires explicit `--target` path.
+- **`genesis patch`**: Use specifically for Sei genesis files. Automatically uses `$HOME/.sei/config/genesis.json`.
+- **`config patch`**: Use specifically for Sei configuration files with automatic target detection. Automatically uses
+  files in `$HOME/.sei/config/`.
 
 ## File Locations
 
@@ -254,8 +396,10 @@ Where `$HOME` is the value of the `--home` flag or the `SEI_HOME` environment va
 
 - **Atomic Writes**: All file modifications use atomic write operations (write to temp file, then rename)
 - **Permission Preservation**: In-place modifications preserve original file permissions
+- **Format Validation**: Validates file extensions before processing (must be `.toml` or `.json`)
 - **Target Validation**: Prevents accidental modification of wrong configuration files
 - **Auto-detection Safety**: Refuses to proceed if patch could apply to multiple targets
+- **Early Validation**: Checks file format and existence before reading patch data
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,52 +24,64 @@ the [releases page](https://github.com/sei-protocol/seictl/releases).
 
 #### Quick Install
 
-**Linux (x86_64)**
+<details>
+<summary><b>Linux (x86_64)</b></summary>
 
 ```bash
 curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Linux_x86_64.tar.gz
 tar -xzf seictl_Linux_x86_64.tar.gz
 sudo mv seictl /usr/local/bin/
 ```
+</details>
 
-**Linux (ARM64)**
+<details>
+<summary><b>Linux (ARM64)</b></summary>
 
 ```bash
 curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Linux_arm64.tar.gz
 tar -xzf seictl_Linux_arm64.tar.gz
 sudo mv seictl /usr/local/bin/
 ```
+</details>
 
-**Linux (ARMv7)**
+<details>
+<summary><b>Linux (ARMv7)</b></summary>
 
 ```bash
 curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Linux_armv7.tar.gz
 tar -xzf seictl_Linux_armv7.tar.gz
 sudo mv seictl /usr/local/bin/
 ```
+</details>
 
-**macOS (Apple Silicon)**
+<details>
+<summary><b>macOS (Apple Silicon)</b></summary>
 
 ```bash
 curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Darwin_arm64.tar.gz
 tar -xzf seictl_Darwin_arm64.tar.gz
 sudo mv seictl /usr/local/bin/
 ```
+</details>
 
-**macOS (Intel)**
+<details>
+<summary><b>macOS (Intel)</b></summary>
 
 ```bash
 curl -LO https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Darwin_x86_64.tar.gz
 tar -xzf seictl_Darwin_x86_64.tar.gz
 sudo mv seictl /usr/local/bin/
 ```
+</details>
 
-**Windows (x86_64)**
+<details>
+<summary><b>Windows (x86_64)</b></summary>
 
 ```powershell
 # Download from: https://github.com/sei-protocol/seictl/releases/latest/download/seictl_Windows_x86_64.zip
 # Extract and add to PATH
 ```
+</details>
 
 #### Verify Installation
 
@@ -299,13 +311,16 @@ swagger = true
 
 ## Examples
 
-### Update Minimum Gas Prices
+<details>
+<summary><b>Update Minimum Gas Prices</b></summary>
 
 ```bash
 echo 'minimum-gas-prices = "0.02usei"' | seictl config patch -i
 ```
+</details>
 
-### Enable API Endpoint
+<details>
+<summary><b>Enable API Endpoint</b></summary>
 
 ```bash
 cat > patch.toml << EOF
@@ -316,14 +331,18 @@ EOF
 
 seictl config --target app patch patch.toml -i
 ```
+</details>
 
-### Modify Genesis Chain ID
+<details>
+<summary><b>Modify Genesis Chain ID</b></summary>
 
 ```bash
 echo '{"chain_id": "sei-mainnet-1"}' | seictl genesis patch -i
 ```
+</details>
 
-### Update Multiple Configuration Sections
+<details>
+<summary><b>Update Multiple Configuration Sections</b></summary>
 
 ```bash
 cat > patch.toml << EOF
@@ -340,8 +359,10 @@ EOF
 
 seictl config patch patch.toml -i
 ```
+</details>
 
-### Patch a Custom TOML Configuration
+<details>
+<summary><b>Patch a Custom TOML Configuration</b></summary>
 
 ```bash
 # Patch any TOML file outside the Sei directory structure
@@ -353,15 +374,19 @@ EOF
 
 seictl patch --target /etc/myapp/config.toml custom-patch.toml -i
 ```
+</details>
 
-### Patch a Custom JSON Data File
+<details>
+<summary><b>Patch a Custom JSON Data File</b></summary>
 
 ```bash
 # Modify any JSON file
 echo '{"version": "2.0", "debug": true}' | seictl patch --target /path/to/settings.json -i
 ```
+</details>
 
-### Using Custom Sei Home Directory
+<details>
+<summary><b>Using Custom Sei Home Directory</b></summary>
 
 ```bash
 # Via environment variable
@@ -371,6 +396,7 @@ seictl config patch patch.toml
 # Via flag
 seictl --home /custom/path/.sei config patch patch.toml
 ```
+</details>
 
 ## Command Comparison
 

--- a/main.go
+++ b/main.go
@@ -27,6 +27,10 @@ var (
 				file string
 			}
 		}
+		patch struct {
+			file   string
+			target string
+		}
 	}{}
 
 	seictlCmd = cli.Command{
@@ -34,6 +38,7 @@ var (
 		Commands: []*cli.Command{
 			&configCmd,
 			&genesisCmd,
+			&patchCmd,
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/patch.go
+++ b/patch.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/urfave/cli/v3"
+)
+
+var patchCmd = cli.Command{
+	Name:                   "patch",
+	Usage:                  "Apply a merge-patch to any TOML or JSON file",
+	MutuallyExclusiveFlags: []cli.MutuallyExclusiveFlags{outputterFlags},
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "target",
+			Usage:       "Path to TOML or JSON file to patch. The file extension is used to determine the format.",
+			Destination: &destinations.patch.target,
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
+			Action: func(_ context.Context, command *cli.Command, s string) error {
+				return command.Set("target", filepath.Clean(s))
+			},
+			Required: true,
+		},
+	},
+	Arguments: []cli.Argument{
+		&cli.StringArg{
+			Name:        "file",
+			Destination: &destinations.patch.file,
+			Config: cli.StringConfig{
+				TrimSpace: true,
+			},
+		},
+	},
+	Action: func(ctx context.Context, command *cli.Command) error {
+		targetExt := strings.ToLower(filepath.Ext(destinations.patch.target))
+		if targetExt != ".toml" && targetExt != ".json" {
+			return fmt.Errorf("unsupported target file extension: %s (must be .toml or .json)", targetExt)
+		}
+
+		var patchBytes []byte
+		if destinations.patch.file == "" {
+			// Read full multi-line input from stdin
+			var buffer bytes.Buffer
+			scanner := bufio.NewScanner(os.Stdin)
+			for scanner.Scan() {
+				buffer.Write(scanner.Bytes())
+				buffer.WriteByte('\n')
+			}
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("reading input from stdin: %w", err)
+			}
+			patchBytes = buffer.Bytes()
+		} else {
+			var err error
+			patchBytes, err = os.ReadFile(destinations.patch.file)
+			if err != nil {
+				return fmt.Errorf("reading patch file: %w", err)
+			}
+		}
+		patchBytes = []byte(strings.TrimSpace(string(patchBytes)))
+		if len(patchBytes) == 0 {
+			return nil
+		}
+
+		targetBytes, err := os.ReadFile(destinations.patch.target)
+		if err != nil {
+			return fmt.Errorf("reading target file: %w", err)
+		}
+
+		target := make(map[string]any)
+		patch := make(map[string]any)
+
+		// Parse based on file extension
+		switch targetExt {
+		case ".toml":
+			if err := toml.Unmarshal(patchBytes, &patch); err != nil {
+				return fmt.Errorf("parsing patch as TOML: %w", err)
+			}
+			if err := toml.Unmarshal(targetBytes, &target); err != nil {
+				return fmt.Errorf("parsing target as TOML: %w", err)
+			}
+		case ".json":
+			if err := json.Unmarshal(patchBytes, &patch); err != nil {
+				return fmt.Errorf("parsing patch as JSON: %w", err)
+			}
+			if err := json.Unmarshal(targetBytes, &target); err != nil {
+				return fmt.Errorf("parsing target as JSON: %w", err)
+			}
+		}
+
+		patchedTarget := mergePatch(target, patch)
+
+		// Marshal the patched result
+		var patchedTargetBuffer bytes.Buffer
+		switch targetExt {
+		case ".toml":
+			encoder := toml.NewEncoder(&patchedTargetBuffer)
+			if err := encoder.Encode(patchedTarget); err != nil {
+				return fmt.Errorf("marshalling patched target as TOML: %w", err)
+			}
+		case ".json":
+			encoder := json.NewEncoder(&patchedTargetBuffer)
+			encoder.SetIndent("", "  ")
+			if err := encoder.Encode(patchedTarget); err != nil {
+				return fmt.Errorf("marshalling patched target as JSON: %w", err)
+			}
+		}
+
+		return output(destinations.patch.target, patchedTargetBuffer)
+	},
+}


### PR DESCRIPTION
Add the ability to apply a patch to any TOML or JSON file. This is to
allow modifying price-feeder config which has no set home or well-known
directory structure for us to program implicit commands for.

Update readme to reflect the changes and while at it mention the
pre-built binaries for user convenience.