### PR TITLE
chore: adding cron validation for the snapshot upload task and logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sei-protocol/seictl
 
-go 1.25.4
+go 1.25.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.3
@@ -13,6 +13,7 @@ require (
 	github.com/oapi-codegen/runtime v1.2.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/sei-protocol/seilog v0.0.1
 	github.com/urfave/cli/v3 v3.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sei-protocol/seilog v0.0.1 h1:JnFaHavtwq20JgfhQnVtJSi40TQBYiOMY4s2kB4BCsw=
+github.com/sei-protocol/seilog v0.0.1/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/serve.go
+++ b/serve.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sei-protocol/seictl/sidecar/engine"
 	"github.com/sei-protocol/seictl/sidecar/server"
 	"github.com/sei-protocol/seictl/sidecar/tasks"
+	"github.com/sei-protocol/seilog"
 	"github.com/urfave/cli/v3"
 )
 
@@ -24,6 +25,8 @@ var serveCmd = cli.Command{
 		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
+		defer seilog.Close()
+
 		homeDir := destinations.home
 		if homeDir == "" {
 			homeDir = "/sei"

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -3,6 +3,9 @@ package client
 import (
 	"fmt"
 	"net/url"
+	"time"
+
+	"github.com/robfig/cron/v3"
 )
 
 // TaskBuilder is implemented by every typed task struct. It converts a
@@ -77,6 +80,7 @@ type SnapshotUploadTask struct {
 	Bucket string
 	Prefix string
 	Region string
+	Cron   string
 }
 
 func (t SnapshotUploadTask) TaskType() string { return TaskTypeSnapshotUpload }
@@ -87,6 +91,27 @@ func (t SnapshotUploadTask) Validate() error {
 	}
 	if t.Region == "" {
 		return fmt.Errorf("snapshot-upload: missing required field Region")
+	}
+	if t.Cron != "" {
+		if err := validateMinCronInterval(t.Cron, 24*time.Hour); err != nil {
+			return fmt.Errorf("snapshot-upload: %w", err)
+		}
+	}
+	return nil
+}
+
+// validateMinCronInterval parses a standard 5-field cron expression and
+// checks that the gap between the first two scheduled firings is at least min.
+func validateMinCronInterval(expr string, min time.Duration) error {
+	sched, err := cron.ParseStandard(expr)
+	if err != nil {
+		return fmt.Errorf("invalid cron expression %q: %w", expr, err)
+	}
+	t0 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	first := sched.Next(t0)
+	second := sched.Next(first)
+	if gap := second.Sub(first); gap < min {
+		return fmt.Errorf("cron %q fires every %v, minimum allowed interval is %v", expr, gap, min)
 	}
 	return nil
 }
@@ -99,7 +124,11 @@ func (t SnapshotUploadTask) ToTaskRequest() TaskRequest {
 	if t.Prefix != "" {
 		p["prefix"] = t.Prefix
 	}
-	return TaskRequest{Type: t.TaskType(), Params: &p}
+	req := TaskRequest{Type: t.TaskType(), Params: &p}
+	if t.Cron != "" {
+		req.Schedule = &Schedule{Cron: &t.Cron}
+	}
+	return req
 }
 
 // SnapshotUploadTaskFromParams reconstructs a SnapshotUploadTask from

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -152,6 +152,25 @@ func TestSnapshotUploadRoundTrip(t *testing.T) {
 	properties.TestingRun(t)
 }
 
+func TestSnapshotUploadTask_CronSchedule(t *testing.T) {
+	task := SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 0 * * *"}
+	req := task.ToTaskRequest()
+	if req.Schedule == nil {
+		t.Fatal("expected Schedule to be set")
+	}
+	if req.Schedule.Cron == nil || *req.Schedule.Cron != "0 0 * * *" {
+		t.Errorf("Schedule.Cron = %v, want %q", req.Schedule.Cron, "0 0 * * *")
+	}
+}
+
+func TestSnapshotUploadTask_NoCron(t *testing.T) {
+	task := SnapshotUploadTask{Bucket: "b", Region: "r"}
+	req := task.ToTaskRequest()
+	if req.Schedule != nil {
+		t.Errorf("expected nil Schedule when Cron is empty, got %v", req.Schedule)
+	}
+}
+
 func TestConfigureGenesisRoundTrip(t *testing.T) {
 	properties := gopter.NewProperties(gopter.DefaultTestParameters())
 	properties.Property("ConfigureGenesisTask round-trips through TaskRequest", prop.ForAll(
@@ -302,18 +321,29 @@ func TestSnapshotRestoreValidationRejectsMissingFields(t *testing.T) {
 	}
 }
 
-func TestSnapshotUploadValidationRejectsMissingFields(t *testing.T) {
+func TestSnapshotUploadValidation(t *testing.T) {
 	cases := []struct {
 		name string
 		task SnapshotUploadTask
+		ok   bool
 	}{
-		{"missing bucket", SnapshotUploadTask{Region: "r"}},
-		{"missing region", SnapshotUploadTask{Bucket: "b"}},
-		{"all empty", SnapshotUploadTask{}},
+		{"valid no cron", SnapshotUploadTask{Bucket: "b", Region: "r"}, true},
+		{"valid daily cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 0 * * *"}, true},
+		{"valid weekly cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 0 * * 0"}, true},
+		{"rejects hourly cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 * * * *"}, false},
+		{"rejects every-minute cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "* * * * *"}, false},
+		{"rejects invalid cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "not-a-cron"}, false},
+		{"missing bucket", SnapshotUploadTask{Region: "r"}, false},
+		{"missing region", SnapshotUploadTask{Bucket: "b"}, false},
+		{"all empty", SnapshotUploadTask{}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.task.Validate(); err == nil {
+			err := tc.task.Validate()
+			if tc.ok && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !tc.ok && err == nil {
 				t.Error("expected validation error, got nil")
 			}
 		})

--- a/sidecar/engine/engine.go
+++ b/sidecar/engine/engine.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sei-protocol/seilog"
 )
+
+var log = seilog.NewLogger("seictl", "engine")
 
 const maxResults = 10
 
@@ -95,9 +97,11 @@ func (e *Engine) Submit(task Task) (string, error) {
 		return "", fmt.Errorf("unknown task type: %s", task.Type)
 	}
 	if !e.taskMu.TryLock() {
+		log.Debug("task rejected, engine busy", "type", task.Type)
 		return "", ErrBusy
 	}
 	id := uuid.New().String()
+	log.Info("task submitted", "type", task.Type, "id", id)
 	e.taskCh <- taskEnvelope{id: id, task: task, handler: handler, submittedAt: time.Now()}
 	return id, nil
 }
@@ -130,6 +134,7 @@ func (e *Engine) SubmitScheduled(task Task, sched Schedule) (string, error) {
 	e.scheduled[id] = tr
 	e.mu.Unlock()
 
+	log.Info("scheduled task registered", "type", task.Type, "id", id, "cron", sched.Cron, "next-run", next.Format(time.RFC3339))
 	return id, nil
 }
 
@@ -150,7 +155,7 @@ func (e *Engine) EvalSchedules() {
 	for _, tr := range due {
 		handler, ok := e.handlers[TaskType(tr.Type)]
 		if !ok {
-			log.Printf("[%s] scheduled task %s has no registered handler, removing", tr.Type, tr.ID)
+			log.Warn("scheduled task has no handler, removing", "type", tr.Type, "id", tr.ID)
 			e.mu.Lock()
 			delete(e.scheduled, tr.ID)
 			e.mu.Unlock()
@@ -163,10 +168,12 @@ func (e *Engine) EvalSchedules() {
 		if tr.Schedule != nil && tr.Schedule.Cron != "" {
 			if next, cronErr := nextCronTime(tr.Schedule.Cron, now); cronErr == nil {
 				tr.NextRunAt = &next
+				log.Debug("scheduled task advancing", "type", tr.Type, "id", tr.ID, "next-run", next.Format(time.RFC3339))
 			}
 		}
 		e.mu.Unlock()
 
+		log.Info("executing scheduled task", "type", tr.Type, "id", tr.ID)
 		go func(tr *TaskResult, h TaskHandler) {
 			err := e.execute(TaskType(tr.Type), h, tr.Params)
 
@@ -188,11 +195,12 @@ func (e *Engine) EvalSchedules() {
 
 // execute runs a handler synchronously and logs the outcome.
 func (e *Engine) execute(taskType TaskType, handler TaskHandler, params map[string]any) error {
+	start := time.Now()
 	if err := handler(e.ctx, params); err != nil {
-		log.Printf("[%s] error: %v", taskType, err)
+		log.Error("task failed", "type", taskType, "elapsed", time.Since(start).Round(time.Millisecond), "err", err)
 		return err
 	}
-	log.Printf("[%s] completed", taskType)
+	log.Info("task completed", "type", taskType, "elapsed", time.Since(start).Round(time.Millisecond))
 	if taskType == TaskMarkReady {
 		e.mu.Lock()
 		e.ready = true

--- a/sidecar/tasks/config.go
+++ b/sidecar/tasks/config.go
@@ -9,7 +9,10 @@ import (
 	"github.com/sei-protocol/seictl/internal/patch"
 	"github.com/sei-protocol/seictl/sidecar/engine"
 	"github.com/sei-protocol/seictl/sidecar/tasks/defaults"
+	"github.com/sei-protocol/seilog"
 )
+
+var patchLog = seilog.NewLogger("seictl", "task", "config-patch")
 
 // ConfigPatcher applies generic TOML merge-patches to seid configuration files.
 type ConfigPatcher struct {
@@ -50,10 +53,12 @@ func (p *ConfigPatcher) PatchFiles(_ context.Context, files map[string]any) erro
 			return fmt.Errorf("config-patch: value for %q must be a map", filename)
 		}
 		filePath := filepath.Join(p.homeDir, "config", filename)
+		patchLog.Debug("patching file", "file", filename)
 		if err := mergeAndWrite(filePath, patchMap); err != nil {
 			return fmt.Errorf("config-patch %s: %w", filename, err)
 		}
 	}
+	patchLog.Info("files patched", "count", len(files))
 	return nil
 }
 

--- a/sidecar/tasks/genesis.go
+++ b/sidecar/tasks/genesis.go
@@ -12,7 +12,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
 )
+
+var genesisLog = seilog.NewLogger("seictl", "task", "genesis")
 
 const genesisMarkerFile = ".sei-sidecar-genesis-done"
 
@@ -54,9 +57,11 @@ func (g *GenesisFetcher) Handler() engine.TaskHandler {
 // Fetch downloads genesis.json from S3, skipping if the marker file exists.
 func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 	if markerExists(g.homeDir, genesisMarkerFile) {
+		genesisLog.Debug("already completed, skipping")
 		return nil
 	}
 
+	genesisLog.Info("downloading genesis.json", "bucket", cfg.Bucket, "key", cfg.Key)
 	s3Client, err := g.s3ClientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("building S3 client: %w", err)
@@ -87,6 +92,7 @@ func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 		return fmt.Errorf("writing %s: %w", destPath, err)
 	}
 
+	genesisLog.Info("genesis download complete", "dest", destPath)
 	return writeMarker(g.homeDir, genesisMarkerFile)
 }
 

--- a/sidecar/tasks/peers.go
+++ b/sidecar/tasks/peers.go
@@ -15,7 +15,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
 )
+
+var peerLog = seilog.NewLogger("seictl", "task", "peers")
 
 const p2pPort = "26656"
 
@@ -182,6 +185,7 @@ func discoverFromSources(ctx context.Context, sources []PeerSource) ([]string, e
 		if err != nil {
 			return nil, err
 		}
+		peerLog.Debug("source returned peers", "count", len(peers))
 		for _, p := range peers {
 			if !seen[p] {
 				seen[p] = true
@@ -194,6 +198,7 @@ func discoverFromSources(ctx context.Context, sources []PeerSource) ([]string, e
 		return nil, fmt.Errorf("no peers discovered from any source")
 	}
 
+	peerLog.Info("peers discovered", "total", len(all))
 	return all, nil
 }
 

--- a/sidecar/tasks/snapshot.go
+++ b/sidecar/tasks/snapshot.go
@@ -14,7 +14,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
 )
+
+var restoreLog = seilog.NewLogger("seictl", "task", "snapshot-restore")
 
 const snapshotMarkerFile = ".sei-sidecar-snapshot-done"
 
@@ -76,6 +79,7 @@ func (r *SnapshotRestorer) Handler() engine.TaskHandler {
 // It reads latest.txt from the prefix to resolve the current snapshot object key.
 func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotConfig) error {
 	if markerExists(r.homeDir, snapshotMarkerFile) {
+		restoreLog.Debug("already completed, skipping")
 		return nil
 	}
 
@@ -89,6 +93,7 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotConfig) erro
 		return err
 	}
 
+	restoreLog.Info("downloading snapshot", "bucket", cfg.Bucket, "key", snapshotKey)
 	output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(cfg.Bucket),
 		Key:    aws.String(snapshotKey),
@@ -102,10 +107,13 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotConfig) erro
 	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
 		return fmt.Errorf("creating snapshot directory: %w", err)
 	}
+
+	restoreLog.Info("extracting archive", "dest", snapshotDir)
 	if err := extractTarStream(ctx, output.Body, snapshotDir); err != nil {
 		return fmt.Errorf("extracting snapshot: %w", err)
 	}
 
+	restoreLog.Info("restore complete")
 	return writeMarker(r.homeDir, snapshotMarkerFile)
 }
 

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -19,7 +19,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
 )
+
+var uploadLog = seilog.NewLogger("seictl", "task", "snapshot-upload")
 
 const uploadStateFile = ".sei-sidecar-last-upload.json"
 
@@ -96,13 +99,17 @@ func (u *SnapshotUploader) Upload(ctx context.Context, cfg SnapshotUploadConfig)
 		return err
 	}
 	if height == 0 {
+		uploadLog.Debug("fewer than 2 snapshots on disk, nothing to upload")
 		return nil
 	}
 
 	last := u.readUploadState()
 	if last.LastUploadedHeight >= height {
+		uploadLog.Debug("height already uploaded", "height", height, "last-uploaded", last.LastUploadedHeight)
 		return nil
 	}
+
+	uploadLog.Info("uploading snapshot", "height", height, "bucket", cfg.Bucket, "region", cfg.Region)
 
 	uploader, err := u.s3UploaderFactory(ctx, cfg.Region)
 	if err != nil {
@@ -112,6 +119,7 @@ func (u *SnapshotUploader) Upload(ctx context.Context, cfg SnapshotUploadConfig)
 	prefix := normalizePrefix(cfg.Prefix)
 
 	archiveKey := fmt.Sprintf("%s%d.tar.gz", prefix, height)
+	uploadLog.Info("streaming archive to S3", "key", archiveKey)
 	if err := u.streamUpload(ctx, uploader, cfg.Bucket, archiveKey, snapshotsDir, height); err != nil {
 		return fmt.Errorf("uploading %s: %w", archiveKey, err)
 	}
@@ -126,6 +134,7 @@ func (u *SnapshotUploader) Upload(ctx context.Context, cfg SnapshotUploadConfig)
 	if err != nil {
 		return fmt.Errorf("uploading %s: %w", latestKey, err)
 	}
+	uploadLog.Info("updated latest.txt", "key", latestKey, "height", height)
 
 	return u.writeUploadState(uploadState{LastUploadedHeight: height})
 }

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/sei-protocol/seictl/internal/patch"
 	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
 )
+
+var ssLog = seilog.NewLogger("seictl", "task", "state-sync")
 
 const (
 	stateSyncMarkerFile = ".sei-sidecar-statesync-done"
@@ -57,6 +60,7 @@ func (s *StateSyncConfigurer) Handler() engine.TaskHandler {
 // trust point, and writes the state sync settings back to config.toml.
 func (s *StateSyncConfigurer) Configure(ctx context.Context) error {
 	if markerExists(s.homeDir, stateSyncMarkerFile) {
+		ssLog.Debug("already completed, skipping")
 		return nil
 	}
 
@@ -67,12 +71,14 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context) error {
 	if len(peers) == 0 {
 		return fmt.Errorf("configure-state-sync: no peers in config.toml")
 	}
+	ssLog.Debug("found peers", "count", len(peers))
 
 	rpcHosts := extractRPCHosts(peers, 2)
 	if len(rpcHosts) == 0 {
 		return fmt.Errorf("configure-state-sync: could not extract RPC hosts from peers")
 	}
 
+	ssLog.Info("querying latest height", "host", rpcHosts[0])
 	latestHeight, err := s.queryLatestHeight(ctx, rpcHosts[0])
 	if err != nil {
 		return fmt.Errorf("configure-state-sync: querying latest height: %w", err)
@@ -83,13 +89,13 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context) error {
 		trustHeight = 1
 	}
 
+	ssLog.Info("querying trust hash", "trust-height", trustHeight, "latest-height", latestHeight)
 	trustHash, err := s.queryBlockHash(ctx, rpcHosts[0], trustHeight)
 	if err != nil {
 		return fmt.Errorf("configure-state-sync: querying block hash at height %d: %w", trustHeight, err)
 	}
 
 	// Tendermint requires at least two comma-separated RPC servers for state sync.
-	// When only one peer is available, duplicate it to satisfy the requirement.
 	for len(rpcHosts) < 2 {
 		rpcHosts = append(rpcHosts, rpcHosts[0])
 	}
@@ -104,6 +110,7 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context) error {
 		RpcServers:  strings.Join(rpcServers, ","),
 	}
 
+	ssLog.Info("writing config", "trust-height", trustHeight, "trust-hash", trustHash, "rpc-servers", cfg.RpcServers)
 	if err := writeStateSyncToConfig(s.homeDir, cfg); err != nil {
 		return fmt.Errorf("configure-state-sync: writing config.toml: %w", err)
 	}
@@ -165,10 +172,15 @@ func (s *StateSyncConfigurer) queryBlockHash(ctx context.Context, host string, h
 	if err := json.Unmarshal(body, &block); err != nil {
 		return "", fmt.Errorf("parsing block response: %w", err)
 	}
-	if block.BlockID.Hash == "" {
+	hash := block.BlockID.Hash
+	if hash == "" {
 		return "", fmt.Errorf("empty block hash at height %d", height)
 	}
-	return block.BlockID.Hash, nil
+	const sha256HexLen = 64
+	if len(hash) != sha256HexLen {
+		return "", fmt.Errorf("unexpected block hash length at height %d: got %d, want %d", height, len(hash), sha256HexLen)
+	}
+	return hash, nil
 }
 
 func (s *StateSyncConfigurer) doGet(ctx context.Context, url string) ([]byte, error) {

--- a/sidecar/tasks/statesync_test.go
+++ b/sidecar/tasks/statesync_test.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,12 @@ func (m *mockHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
 	}
 	return resp, nil
+}
+
+func generateBlockHash() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return fmt.Sprintf("%X", b)
 }
 
 func jsonResponse(body string) *http.Response {
@@ -46,14 +53,15 @@ func TestStateSyncConfigurer_Success(t *testing.T) {
 	homeDir := t.TempDir()
 	setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656", "nodeId2@5.6.7.8:26656"})
 
+	hash := generateBlockHash()
 	mock := &mockHTTPDoer{
 		responses: map[string]*http.Response{
 			"http://1.2.3.4:26657/status": jsonResponse(`{
 				"sync_info": {"latest_block_height": "10000"}
 			}`),
-			"http://1.2.3.4:26657/block?height=8000": jsonResponse(`{
-				"block_id": {"hash": "ABCDEF123456"}
-			}`),
+			"http://1.2.3.4:26657/block?height=8000": jsonResponse(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash)),
 		},
 	}
 
@@ -74,8 +82,8 @@ func TestStateSyncConfigurer_Success(t *testing.T) {
 	if ss["trust-height"] != int64(8000) {
 		t.Errorf("expected statesync.trust-height = 8000, got %v", ss["trust-height"])
 	}
-	if ss["trust-hash"] != "ABCDEF123456" {
-		t.Errorf("expected trust-hash = ABCDEF123456, got %v", ss["trust-hash"])
+	if ss["trust-hash"] != hash {
+		t.Errorf("expected trust-hash = %s, got %v", hash, ss["trust-hash"])
 	}
 	if ss["rpc-servers"] != "1.2.3.4:26657,5.6.7.8:26657" {
 		t.Errorf("expected rpc-servers, got %v", ss["rpc-servers"])
@@ -110,14 +118,15 @@ func TestStateSyncConfigurer_LowHeight(t *testing.T) {
 	homeDir := t.TempDir()
 	setupPeersInConfig(t, homeDir, []string{"nodeId1@10.0.0.1:26656"})
 
+	hash := generateBlockHash()
 	mock := &mockHTTPDoer{
 		responses: map[string]*http.Response{
 			"http://10.0.0.1:26657/status": jsonResponse(`{
 				"sync_info": {"latest_block_height": "500"}
 			}`),
-			"http://10.0.0.1:26657/block?height=1": jsonResponse(`{
-				"block_id": {"hash": "GENESIS_HASH"}
-			}`),
+			"http://10.0.0.1:26657/block?height=1": jsonResponse(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash)),
 		},
 	}
 
@@ -131,12 +140,51 @@ func TestStateSyncConfigurer_LowHeight(t *testing.T) {
 	if ss["trust-height"] != int64(1) {
 		t.Errorf("expected trustHeight clamped to 1, got %v", ss["trust-height"])
 	}
-	if ss["trust-hash"] != "GENESIS_HASH" {
-		t.Errorf("expected trustHash GENESIS_HASH, got %v", ss["trust-hash"])
+	if ss["trust-hash"] != hash {
+		t.Errorf("expected trustHash %s, got %v", hash, ss["trust-hash"])
 	}
 	// Single peer should be duplicated to satisfy Tendermint requirement.
 	if ss["rpc-servers"] != "10.0.0.1:26657,10.0.0.1:26657" {
 		t.Errorf("expected duplicated rpc-servers, got %v", ss["rpc-servers"])
+	}
+}
+
+func TestStateSyncConfigurer_InvalidBlockHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		hash    string
+		wantErr string
+	}{
+		{"empty hash", "", "empty block hash"},
+		{"short hash", "ABCDEF", "unexpected block hash length"},
+		{"long hash", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA00", "unexpected block hash length"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656"})
+
+			mock := &mockHTTPDoer{
+				responses: map[string]*http.Response{
+					"http://1.2.3.4:26657/status": jsonResponse(`{
+						"sync_info": {"latest_block_height": "10000"}
+					}`),
+					"http://1.2.3.4:26657/block?height=8000": jsonResponse(fmt.Sprintf(`{
+						"block_id": {"hash": %q}
+					}`, tt.hash)),
+				},
+			}
+
+			configurer := NewStateSyncConfigurer(homeDir, mock)
+			err := configurer.Configure(context.Background())
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -204,14 +252,15 @@ func TestStateSyncConfigurer_Handler(t *testing.T) {
 	homeDir := t.TempDir()
 	setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656"})
 
+	hash := generateBlockHash()
 	mock := &mockHTTPDoer{
 		responses: map[string]*http.Response{
 			"http://1.2.3.4:26657/status": jsonResponse(`{
 				"sync_info": {"latest_block_height": "5000"}
 			}`),
-			"http://1.2.3.4:26657/block?height=3000": jsonResponse(`{
-				"block_id": {"hash": "TRUST_HASH"}
-			}`),
+			"http://1.2.3.4:26657/block?height=3000": jsonResponse(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash)),
 		},
 	}
 


### PR DESCRIPTION
## Summary
Add structured logging, cron validation, and block hash validation

### Change List
- Integrate seilog for structured, leveled logging across the task engine and all task handlers (snapshot-upload, state-sync, snapshot-restore, genesis, peers, config-patch)
- Add cron frequency validation to SnapshotUploadTask — reject schedules more frequent than daily
- Validate block hash length in state-sync configuration to fail fast on malformed RPC responses
- Support scheduled task submission via Cron field on SnapshotUploadTask