### PR TITLE
fix: configure state-sync to use locally-restored snapshots

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -25,7 +25,7 @@ var serveCmd = cli.Command{
 		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		defer seilog.Close()
+		defer func() { _ = seilog.Close() }()
 
 		homeDir := destinations.home
 		if homeDir == "" {

--- a/sidecar/client/client_test.go
+++ b/sidecar/client/client_test.go
@@ -29,7 +29,7 @@ func TestStatus_OK(t *testing.T) {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(StatusResponse{Status: Ready})
+		_ = json.NewEncoder(w).Encode(StatusResponse{Status: Ready})
 	}))
 
 	resp, err := c.Status(context.Background())
@@ -74,7 +74,7 @@ func TestSubmitTask_Accepted(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		json.NewEncoder(w).Encode(TaskSubmitResponse{Id: taskID})
+		_ = json.NewEncoder(w).Encode(TaskSubmitResponse{Id: taskID})
 	}))
 
 	task := SnapshotRestoreTask{
@@ -108,7 +108,7 @@ func TestSubmitTask_Scheduled(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(TaskSubmitResponse{Id: taskID})
+		_ = json.NewEncoder(w).Encode(TaskSubmitResponse{Id: taskID})
 	}))
 
 	id, err := c.SubmitRawTask(context.Background(), TaskRequest{
@@ -127,7 +127,7 @@ func TestSubmitTask_Busy(t *testing.T) {
 	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
-		json.NewEncoder(w).Encode(ErrorResponse{Error: "task already running"})
+		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "task already running"})
 	}))
 
 	_, err := c.SubmitTask(context.Background(), MarkReadyTask{})
@@ -140,7 +140,7 @@ func TestSubmitTask_BadRequest(t *testing.T) {
 	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(ErrorResponse{Error: "unknown task type"})
+		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "unknown task type"})
 	}))
 
 	_, err := c.SubmitRawTask(context.Background(), TaskRequest{Type: "invalid"})
@@ -172,7 +172,7 @@ func TestListTasks_OK(t *testing.T) {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]TaskResult{
+		_ = json.NewEncoder(w).Encode([]TaskResult{
 			{Id: uuid.New(), Type: "mark-ready"},
 		})
 	}))
@@ -196,7 +196,7 @@ func TestGetTask_OK(t *testing.T) {
 			t.Errorf("unexpected method: %s", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(TaskResult{Id: taskID, Type: "config-patch"})
+		_ = json.NewEncoder(w).Encode(TaskResult{Id: taskID, Type: "config-patch"})
 	}))
 
 	result, err := c.GetTask(context.Background(), taskID)
@@ -212,7 +212,7 @@ func TestGetTask_NotFound(t *testing.T) {
 	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(ErrorResponse{Error: "not found"})
+		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "not found"})
 	}))
 
 	_, err := c.GetTask(context.Background(), uuid.New())
@@ -238,7 +238,7 @@ func TestDeleteTask_NotFound(t *testing.T) {
 	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(ErrorResponse{Error: "not found"})
+		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "not found"})
 	}))
 
 	err := c.DeleteTask(context.Background(), uuid.New())

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -334,14 +334,21 @@ func (t ConfigPatchTask) ToTaskRequest() TaskRequest {
 }
 
 // ConfigureStateSyncTask discovers a trust point and configures state sync.
-// No parameters are required; configuration is derived from the peers file.
-type ConfigureStateSyncTask struct{}
+// When UseLocalSnapshot is true, the task uses the locally-restored snapshot
+// height as the trust height and sets use-local-snapshot = true in config.toml.
+type ConfigureStateSyncTask struct {
+	UseLocalSnapshot bool
+}
 
 func (t ConfigureStateSyncTask) TaskType() string { return TaskTypeConfigureStateSync }
 func (t ConfigureStateSyncTask) Validate() error  { return nil }
 
 func (t ConfigureStateSyncTask) ToTaskRequest() TaskRequest {
-	return TaskRequest{Type: t.TaskType()}
+	if !t.UseLocalSnapshot {
+		return TaskRequest{Type: t.TaskType()}
+	}
+	p := map[string]interface{}{"useLocalSnapshot": true}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
 }
 
 // MarkReadyTask signals that bootstrap is complete.

--- a/sidecar/engine/engine_test.go
+++ b/sidecar/engine/engine_test.go
@@ -108,7 +108,7 @@ func TestMarkReadySetsHealthz(t *testing.T) {
 		t.Fatal("healthz should be false before mark-ready")
 	}
 
-	eng.Submit(Task{Type: TaskMarkReady})
+	_, _ = eng.Submit(Task{Type: TaskMarkReady})
 	waitForHealthz(t, eng)
 
 	if !eng.Healthz() {
@@ -126,7 +126,7 @@ func TestHealthzMonotonicity(t *testing.T) {
 	waitForHealthz(t, eng)
 	waitForResult(t, eng, id)
 
-	eng.Submit(Task{Type: TaskConfigPatch})
+	_, _ = eng.Submit(Task{Type: TaskConfigPatch})
 	waitForStatus(t, eng, "Ready")
 
 	if !eng.Healthz() {
@@ -143,7 +143,7 @@ func TestStatusReflectsReady(t *testing.T) {
 		t.Fatalf("expected Initializing initially, got %q", eng.Status().Status)
 	}
 
-	eng.Submit(Task{Type: TaskMarkReady})
+	_, _ = eng.Submit(Task{Type: TaskMarkReady})
 	waitForStatus(t, eng, "Ready")
 
 	if eng.Status().Status != "Ready" {
@@ -164,7 +164,7 @@ func TestStatusReflectsRunning(t *testing.T) {
 		},
 	})
 
-	eng.Submit(Task{Type: TaskConfigPatch})
+	_, _ = eng.Submit(Task{Type: TaskConfigPatch})
 
 	select {
 	case <-started:
@@ -343,7 +343,7 @@ func TestContextCancellationStopsEngine(t *testing.T) {
 		},
 	})
 
-	eng.Submit(Task{Type: TaskConfigPatch})
+	_, _ = eng.Submit(Task{Type: TaskConfigPatch})
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 

--- a/sidecar/server/server_test.go
+++ b/sidecar/server/server_test.go
@@ -68,7 +68,7 @@ func TestHealthzReturns200AfterMarkReady(t *testing.T) {
 	})
 	srv := NewServer(":0", eng)
 
-	eng.Submit(engine.Task{Type: engine.TaskMarkReady})
+	_, _ = eng.Submit(engine.Task{Type: engine.TaskMarkReady})
 	waitForReady(eng)
 
 	rec := serveHTTP(srv, http.MethodGet, "/v0/healthz", "")
@@ -96,7 +96,7 @@ func TestStatusResponse(t *testing.T) {
 		t.Fatalf("expected Initializing initially, got %q", resp.Status)
 	}
 
-	eng.Submit(engine.Task{Type: engine.TaskMarkReady})
+	_, _ = eng.Submit(engine.Task{Type: engine.TaskMarkReady})
 	waitForReady(eng)
 
 	rec = serveHTTP(srv, http.MethodGet, "/v0/status", "")
@@ -236,7 +236,7 @@ func TestListTasksAfterSubmit(t *testing.T) {
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
-	json.NewDecoder(rec.Body).Decode(&resp)
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
 	waitForTaskResult(eng, resp["id"])
 
 	rec = serveHTTP(srv, http.MethodGet, "/v0/tasks", "")
@@ -257,7 +257,7 @@ func TestGetTask(t *testing.T) {
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
-	json.NewDecoder(rec.Body).Decode(&resp)
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
 	id := resp["id"]
 	waitForTaskResult(eng, id)
 
@@ -267,7 +267,7 @@ func TestGetTask(t *testing.T) {
 	}
 
 	var result engine.TaskResult
-	json.NewDecoder(rec.Body).Decode(&result)
+	_ = json.NewDecoder(rec.Body).Decode(&result)
 	if result.ID != id {
 		t.Fatalf("expected ID %q, got %q", id, result.ID)
 	}
@@ -290,7 +290,7 @@ func TestDeleteTask(t *testing.T) {
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
-	json.NewDecoder(rec.Body).Decode(&resp)
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
 	id := resp["id"]
 	waitForTaskResult(eng, id)
 
@@ -313,7 +313,7 @@ func TestDeleteScheduledTask(t *testing.T) {
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch","schedule":{"cron":"*/5 * * * *"}}`)
 	var resp map[string]string
-	json.NewDecoder(rec.Body).Decode(&resp)
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
 	id := resp["id"]
 
 	rec = serveHTTP(srv, http.MethodDelete, "/v0/tasks/"+id, "")

--- a/sidecar/tasks/genesis.go
+++ b/sidecar/tasks/genesis.go
@@ -74,7 +74,7 @@ func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 	if err != nil {
 		return fmt.Errorf("s3 GetObject %s/%s: %w", cfg.Bucket, cfg.Key, err)
 	}
-	defer output.Body.Close()
+	defer func() { _ = output.Body.Close() }()
 
 	destDir := filepath.Join(g.homeDir, "config")
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
@@ -86,7 +86,7 @@ func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", destPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(f, output.Body); err != nil {
 		return fmt.Errorf("writing %s: %w", destPath, err)

--- a/sidecar/tasks/peers.go
+++ b/sidecar/tasks/peers.go
@@ -326,7 +326,7 @@ func defaultQueryNodeID(ctx context.Context, ip string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("GET /status: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/sidecar/tasks/snapshot.go
+++ b/sidecar/tasks/snapshot.go
@@ -101,7 +101,7 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotConfig) erro
 	if err != nil {
 		return fmt.Errorf("s3 GetObject %s: %w", snapshotKey, err)
 	}
-	defer output.Body.Close()
+	defer func() { _ = output.Body.Close() }()
 
 	snapshotDir := filepath.Join(r.homeDir, "data", "snapshots")
 	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
@@ -126,7 +126,7 @@ func resolveSnapshotKey(ctx context.Context, s3Client S3GetObjectAPI, cfg Snapsh
 	if err != nil {
 		return "", fmt.Errorf("reading latest.txt: %w", err)
 	}
-	defer out.Body.Close()
+	defer func() { _ = out.Body.Close() }()
 
 	data, err := io.ReadAll(out.Body)
 	if err != nil {
@@ -173,7 +173,7 @@ func extractTarStream(ctx context.Context, r io.Reader, destDir string) error {
 	if err != nil {
 		return fmt.Errorf("creating gzip reader: %w", err)
 	}
-	defer gzr.Close()
+	defer func() { _ = gzr.Close() }()
 	tr := tar.NewReader(gzr)
 	for {
 		if err := ctx.Err(); err != nil {
@@ -227,7 +227,7 @@ func extractFile(r io.Reader, path string, mode os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(f, r); err != nil {
 		return fmt.Errorf("writing file %s: %w", path, err)

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -208,7 +208,7 @@ func writeArchive(ctx context.Context, wc io.WriteCloser, snapshotsDir string, h
 		if retErr != nil {
 			wc.(*io.PipeWriter).CloseWithError(retErr)
 		} else {
-			wc.Close()
+			_ = wc.Close()
 		}
 	}()
 
@@ -267,7 +267,7 @@ func addDirToTar(ctx context.Context, tw *tar.Writer, dir, base string) error {
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		_, err = io.Copy(tw, f)
 		return err
 	})
@@ -286,7 +286,7 @@ func addFileToTar(tw *tar.Writer, path, name string, info os.FileInfo) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, err = io.Copy(tw, f)
 	return err
 }

--- a/sidecar/tasks/snapshot_upload_test.go
+++ b/sidecar/tasks/snapshot_upload_test.go
@@ -24,7 +24,7 @@ func newMockS3Uploader() *mockS3Uploader {
 func (m *mockS3Uploader) UploadObject(_ context.Context, input *transfermanager.UploadObjectInput, _ ...func(*transfermanager.Options)) (*transfermanager.UploadObjectOutput, error) {
 	var buf bytes.Buffer
 	if input.Body != nil {
-		io.Copy(&buf, input.Body)
+		_, _ = io.Copy(&buf, input.Body)
 	}
 	key := *input.Bucket + "/" + *input.Key
 	m.uploads[key] = buf.Bytes()
@@ -128,7 +128,7 @@ func TestUpload_SkipsWhenAlreadyUploaded(t *testing.T) {
 
 	state := uploadState{LastUploadedHeight: 1000}
 	data, _ := json.Marshal(state)
-	os.WriteFile(filepath.Join(homeDir, uploadStateFile), data, 0o644)
+	_ = os.WriteFile(filepath.Join(homeDir, uploadStateFile), data, 0o644)
 
 	mock := newMockS3Uploader()
 	uploader := NewSnapshotUploader(homeDir, mockUploaderFactory(mock))
@@ -153,7 +153,7 @@ func TestUpload_UploadsNewerSnapshot(t *testing.T) {
 
 	state := uploadState{LastUploadedHeight: 1000}
 	data, _ := json.Marshal(state)
-	os.WriteFile(filepath.Join(homeDir, uploadStateFile), data, 0o644)
+	_ = os.WriteFile(filepath.Join(homeDir, uploadStateFile), data, 0o644)
 
 	mock := newMockS3Uploader()
 	uploader := NewSnapshotUploader(homeDir, mockUploaderFactory(mock))

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,9 +27,10 @@ const (
 
 // StateSyncConfig holds the trust point and RPC servers for Tendermint state sync.
 type StateSyncConfig struct {
-	TrustHeight int64
-	TrustHash   string
-	RpcServers  string
+	TrustHeight      int64
+	TrustHash        string
+	RpcServers       string
+	UseLocalSnapshot bool
 }
 
 // HTTPDoer abstracts HTTP requests for testability.
@@ -51,14 +54,17 @@ func NewStateSyncConfigurer(homeDir string, client HTTPDoer) *StateSyncConfigure
 
 // Handler returns an engine.TaskHandler.
 func (s *StateSyncConfigurer) Handler() engine.TaskHandler {
-	return func(ctx context.Context, _ map[string]any) error {
-		return s.Configure(ctx)
+	return func(ctx context.Context, params map[string]any) error {
+		useLocal, _ := params["useLocalSnapshot"].(bool)
+		return s.Configure(ctx, useLocal)
 	}
 }
 
 // Configure reads persistent-peers from config.toml, queries a peer for a
 // trust point, and writes the state sync settings back to config.toml.
-func (s *StateSyncConfigurer) Configure(ctx context.Context) error {
+// When useLocalSnapshot is true, the trust height is derived from the
+// locally-restored snapshot and use-local-snapshot is set in config.toml.
+func (s *StateSyncConfigurer) Configure(ctx context.Context, useLocalSnapshot bool) error {
 	if markerExists(s.homeDir, stateSyncMarkerFile) {
 		ssLog.Debug("already completed, skipping")
 		return nil
@@ -78,24 +84,32 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context) error {
 		return fmt.Errorf("configure-state-sync: could not extract RPC hosts from peers")
 	}
 
-	ssLog.Info("querying latest height", "host", rpcHosts[0])
-	latestHeight, err := s.queryLatestHeight(ctx, rpcHosts[0])
-	if err != nil {
-		return fmt.Errorf("configure-state-sync: querying latest height: %w", err)
+	var trustHeight int64
+	if useLocalSnapshot {
+		h, err := discoverLocalSnapshotHeight(s.homeDir)
+		if err != nil {
+			return fmt.Errorf("configure-state-sync: discovering local snapshot height: %w", err)
+		}
+		trustHeight = h
+		ssLog.Info("using local snapshot height as trust height", "height", trustHeight)
+	} else {
+		ssLog.Info("querying latest height", "host", rpcHosts[0])
+		latestHeight, err := s.queryLatestHeight(ctx, rpcHosts[0])
+		if err != nil {
+			return fmt.Errorf("configure-state-sync: querying latest height: %w", err)
+		}
+		trustHeight = latestHeight - trustHeightOffset
+		if trustHeight < 1 {
+			trustHeight = 1
+		}
 	}
 
-	trustHeight := latestHeight - trustHeightOffset
-	if trustHeight < 1 {
-		trustHeight = 1
-	}
-
-	ssLog.Info("querying trust hash", "trust-height", trustHeight, "latest-height", latestHeight)
+	ssLog.Info("querying trust hash", "trust-height", trustHeight, "host", rpcHosts[0])
 	trustHash, err := s.queryBlockHash(ctx, rpcHosts[0], trustHeight)
 	if err != nil {
 		return fmt.Errorf("configure-state-sync: querying block hash at height %d: %w", trustHeight, err)
 	}
 
-	// Tendermint requires at least two comma-separated RPC servers for state sync.
 	for len(rpcHosts) < 2 {
 		rpcHosts = append(rpcHosts, rpcHosts[0])
 	}
@@ -105,17 +119,49 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context) error {
 	}
 
 	cfg := StateSyncConfig{
-		TrustHeight: trustHeight,
-		TrustHash:   trustHash,
-		RpcServers:  strings.Join(rpcServers, ","),
+		TrustHeight:      trustHeight,
+		TrustHash:        trustHash,
+		RpcServers:       strings.Join(rpcServers, ","),
+		UseLocalSnapshot: useLocalSnapshot,
 	}
 
-	ssLog.Info("writing config", "trust-height", trustHeight, "trust-hash", trustHash, "rpc-servers", cfg.RpcServers)
+	ssLog.Info("writing config", "trust-height", trustHeight, "trust-hash", trustHash,
+		"rpc-servers", cfg.RpcServers, "use-local-snapshot", useLocalSnapshot)
 	if err := writeStateSyncToConfig(s.homeDir, cfg); err != nil {
 		return fmt.Errorf("configure-state-sync: writing config.toml: %w", err)
 	}
 
 	return writeMarker(s.homeDir, stateSyncMarkerFile)
+}
+
+// discoverLocalSnapshotHeight scans the Tendermint snapshots directory for the
+// highest available snapshot height. Snapshots are stored as
+// <home>/data/snapshots/<height>/<format>/.
+func discoverLocalSnapshotHeight(homeDir string) (int64, error) {
+	snapshotDir := filepath.Join(homeDir, "data", "snapshots")
+	entries, err := os.ReadDir(snapshotDir)
+	if err != nil {
+		return 0, fmt.Errorf("reading snapshots directory: %w", err)
+	}
+
+	var maxHeight int64
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		h, err := strconv.ParseInt(e.Name(), 10, 64)
+		if err != nil {
+			continue
+		}
+		if h > maxHeight {
+			maxHeight = h
+		}
+	}
+
+	if maxHeight == 0 {
+		return 0, fmt.Errorf("no snapshot found in %s", snapshotDir)
+	}
+	return maxHeight, nil
 }
 
 // extractRPCHosts extracts up to maxHosts host addresses from peer strings
@@ -193,7 +239,7 @@ func (s *StateSyncConfigurer) doGet(ctx context.Context, url string) ([]byte, er
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -207,10 +253,11 @@ func writeStateSyncToConfig(homeDir string, cfg StateSyncConfig) error {
 	configPath := filepath.Join(homeDir, "config", "config.toml")
 	ssPatch := map[string]any{
 		"statesync": map[string]any{
-			"enable":       true,
-			"trust-height": cfg.TrustHeight,
-			"trust-hash":   cfg.TrustHash,
-			"rpc-servers":  cfg.RpcServers,
+			"enable":             true,
+			"trust-height":       cfg.TrustHeight,
+			"trust-hash":         cfg.TrustHash,
+			"rpc-servers":        cfg.RpcServers,
+			"use-local-snapshot": cfg.UseLocalSnapshot,
 		},
 	}
 	return mergeAndWrite(configPath, ssPatch)

--- a/sidecar/tasks/statesync_test.go
+++ b/sidecar/tasks/statesync_test.go
@@ -26,7 +26,7 @@ func (m *mockHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 
 func generateBlockHash() string {
 	b := make([]byte, 32)
-	rand.Read(b)
+	_, _ = rand.Read(b)
 	return fmt.Sprintf("%X", b)
 }
 
@@ -66,7 +66,7 @@ func TestStateSyncConfigurer_Success(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, mock)
-	if err := configurer.Configure(context.Background()); err != nil {
+	if err := configurer.Configure(context.Background(), false); err != nil {
 		t.Fatalf("Configure failed: %v", err)
 	}
 
@@ -88,6 +88,9 @@ func TestStateSyncConfigurer_Success(t *testing.T) {
 	if ss["rpc-servers"] != "1.2.3.4:26657,5.6.7.8:26657" {
 		t.Errorf("expected rpc-servers, got %v", ss["rpc-servers"])
 	}
+	if ss["use-local-snapshot"] != false {
+		t.Errorf("expected use-local-snapshot = false, got %v", ss["use-local-snapshot"])
+	}
 }
 
 func TestStateSyncConfigurer_MarkerSkips(t *testing.T) {
@@ -98,7 +101,7 @@ func TestStateSyncConfigurer_MarkerSkips(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
-	if err := configurer.Configure(context.Background()); err != nil {
+	if err := configurer.Configure(context.Background(), false); err != nil {
 		t.Fatalf("expected nil error when marker exists, got: %v", err)
 	}
 }
@@ -108,7 +111,7 @@ func TestStateSyncConfigurer_NoPeers(t *testing.T) {
 	setupPeersInConfig(t, homeDir, nil)
 
 	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
-	err := configurer.Configure(context.Background())
+	err := configurer.Configure(context.Background(), false)
 	if err == nil {
 		t.Fatal("expected error when no peers in config")
 	}
@@ -131,7 +134,7 @@ func TestStateSyncConfigurer_LowHeight(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, mock)
-	if err := configurer.Configure(context.Background()); err != nil {
+	if err := configurer.Configure(context.Background(), false); err != nil {
 		t.Fatalf("Configure failed: %v", err)
 	}
 
@@ -177,7 +180,7 @@ func TestStateSyncConfigurer_InvalidBlockHash(t *testing.T) {
 			}
 
 			configurer := NewStateSyncConfigurer(homeDir, mock)
-			err := configurer.Configure(context.Background())
+			err := configurer.Configure(context.Background(), false)
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -275,6 +278,92 @@ func TestStateSyncConfigurer_Handler(t *testing.T) {
 	ss := configDoc["statesync"].(map[string]any)
 	if ss["trust-height"] != int64(3000) {
 		t.Errorf("expected trustHeight 3000, got %v", ss["trust-height"])
+	}
+}
+
+func TestStateSyncConfigurer_LocalSnapshot(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656", "nodeId2@5.6.7.8:26656"})
+
+	snapshotHeight := int64(198030000)
+	snapshotDir := filepath.Join(homeDir, "data", "snapshots", "198030000", "1")
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
+		t.Fatalf("creating snapshot dir: %v", err)
+	}
+
+	hash := generateBlockHash()
+	mock := &mockHTTPDoer{
+		responses: map[string]*http.Response{
+			"http://1.2.3.4:26657/block?height=198030000": jsonResponse(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash)),
+		},
+	}
+
+	configurer := NewStateSyncConfigurer(homeDir, mock)
+	if err := configurer.Configure(context.Background(), true); err != nil {
+		t.Fatalf("Configure with local snapshot failed: %v", err)
+	}
+
+	configDoc := readTOML(t, filepath.Join(homeDir, "config", "config.toml"))
+	ss := configDoc["statesync"].(map[string]any)
+
+	if ss["trust-height"] != snapshotHeight {
+		t.Errorf("expected trust-height = %d (snapshot height), got %v", snapshotHeight, ss["trust-height"])
+	}
+	if ss["trust-hash"] != hash {
+		t.Errorf("expected trust-hash = %s, got %v", hash, ss["trust-hash"])
+	}
+	if ss["use-local-snapshot"] != true {
+		t.Errorf("expected use-local-snapshot = true, got %v", ss["use-local-snapshot"])
+	}
+	if ss["enable"] != true {
+		t.Error("expected statesync.enable = true")
+	}
+}
+
+func TestStateSyncConfigurer_LocalSnapshotNoDir(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656"})
+
+	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
+	err := configurer.Configure(context.Background(), true)
+	if err == nil {
+		t.Fatal("expected error when no snapshot directory exists")
+	}
+	if !strings.Contains(err.Error(), "discovering local snapshot height") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDiscoverLocalSnapshotHeight(t *testing.T) {
+	homeDir := t.TempDir()
+
+	snapshotBase := filepath.Join(homeDir, "data", "snapshots")
+	for _, dir := range []string{"198030000/1", "198020000/1", "notaheight"} {
+		if err := os.MkdirAll(filepath.Join(snapshotBase, dir), 0o755); err != nil {
+			t.Fatalf("creating dir: %v", err)
+		}
+	}
+
+	h, err := discoverLocalSnapshotHeight(homeDir)
+	if err != nil {
+		t.Fatalf("discoverLocalSnapshotHeight failed: %v", err)
+	}
+	if h != 198030000 {
+		t.Errorf("expected height 198030000, got %d", h)
+	}
+}
+
+func TestDiscoverLocalSnapshotHeight_Empty(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, "data", "snapshots"), 0o755); err != nil {
+		t.Fatalf("creating dir: %v", err)
+	}
+
+	_, err := discoverLocalSnapshotHeight(homeDir)
+	if err == nil {
+		t.Fatal("expected error for empty snapshots directory")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Local snapshot-aware state-sync**: When a node has a locally-restored S3 snapshot, the `configure-state-sync` task now sets `use-local-snapshot = true` and derives `trust-height` from the snapshot height (by scanning `data/snapshots/`) instead of the chain tip minus 2000. This prevents Tendermint from ignoring the pre-staged snapshot and redundantly fetching all chunks over P2P.
- **Parameterized `ConfigureStateSyncTask`**: The controller passes `UseLocalSnapshot: true` when the SeiNode spec includes a snapshot config (`hasLocalSnapshot(node)`). The task remains zero-config for nodes without a local snapshot.
- **Lint cleanup**: Fixes all 24 `golangci-lint` errcheck violations across the codebase.

## Root Cause

The `configure-state-sync` task was writing `use-local-snapshot = false` (the default) and deriving `trust-height` from the chain tip, causing nodes with locally-restored S3 snapshots to perform full P2P state-sync (~4800 chunks over hours) instead of applying the already-present local snapshot.

## Changes

| File | Change |
|------|--------|
| `sidecar/client/tasks.go` | Add `UseLocalSnapshot` field to `ConfigureStateSyncTask`, wire into params |
| `sidecar/tasks/statesync.go` | Branch on `useLocalSnapshot` param: discover snapshot height from `data/snapshots/`, set `use-local-snapshot` in config.toml |
| `sidecar/tasks/statesync_test.go` | Add 4 new tests for local snapshot path and height discovery |
| 9 other files | Fix errcheck lint violations (`_ =` for intentionally-discarded errors) |

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New tests cover: local snapshot config written correctly, missing snapshot dir errors, height discovery picks max, empty dir errors
- [x] Controller change in `sei-k8s-controller` task_builders.go passes `UseLocalSnapshot: hasLocalSnapshot(node)` (separate PR)
- [x] Deploy to brandon cluster and verify nodes use local snapshotn