### PR TITLE
feat: rework genesis handling to support embedded genesis for known chains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/oapi-codegen/runtime v1.2.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/sei-protocol/sei-config v0.0.5
+	github.com/sei-protocol/sei-config v0.0.7
 	github.com/sei-protocol/seilog v0.0.2
 	github.com/urfave/cli/v3 v3.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sei-protocol/sei-config v0.0.5 h1:edMsQk0/WijGwbZIccSGC2FtPkw0N9XIWDSGgsDeAFw=
-github.com/sei-protocol/sei-config v0.0.5/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.7 h1:ysNBOrhbIA3RXAmNBxw++m5nvBWPUDOm6cN7g/9H1Ec=
+github.com/sei-protocol/sei-config v0.0.7/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/seilog v0.0.2 h1:xDWNr1LUHLnOER1o/5f3rq2TQZFCv/mG1ANBaQcw24s=
 github.com/sei-protocol/seilog v0.0.2/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=

--- a/serve.go
+++ b/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/sei-protocol/seictl/sidecar/engine"
@@ -32,6 +33,7 @@ var serveCmd = cli.Command{
 			homeDir = "/sei"
 		}
 		port := cmd.String("port")
+		chainID := os.Getenv("SEI_CHAIN_ID")
 
 		if err := tasks.EnsureDefaultConfig(homeDir); err != nil {
 			return fmt.Errorf("home directory init failed: %w", err)
@@ -45,7 +47,7 @@ var serveCmd = cli.Command{
 			engine.TaskConfigValidate:     tasks.NewConfigValidator(homeDir).Handler(),
 			engine.TaskConfigReload:       tasks.NewConfigReloader(homeDir).Handler(),
 			engine.TaskMarkReady:          tasks.MarkReadyHandler(),
-			engine.TaskConfigureGenesis:   tasks.NewGenesisFetcher(homeDir, nil).Handler(),
+			engine.TaskConfigureGenesis:   tasks.NewGenesisFetcher(homeDir, chainID, nil).Handler(),
 			engine.TaskConfigureStateSync: tasks.NewStateSyncConfigurer(homeDir, nil).Handler(),
 			engine.TaskSnapshotUpload:     tasks.NewSnapshotUploader(homeDir, nil).Handler(),
 		}

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/robfig/cron/v3"
 	seiconfig "github.com/sei-protocol/sei-config"
+	"github.com/sei-protocol/seictl/sidecar/engine"
 )
 
 // TaskBuilder is implemented by every typed task struct. It converts a
@@ -18,17 +19,18 @@ type TaskBuilder interface {
 	ToTaskRequest() TaskRequest
 }
 
+// Task type constants re-exported from engine for external consumers.
 const (
-	TaskTypeSnapshotRestore    = "snapshot-restore"
-	TaskTypeDiscoverPeers      = "discover-peers"
-	TaskTypeConfigPatch        = "config-patch"
-	TaskTypeConfigApply        = "config-apply"
-	TaskTypeConfigValidate     = "config-validate"
-	TaskTypeConfigReload       = "config-reload"
-	TaskTypeMarkReady          = "mark-ready"
-	TaskTypeConfigureGenesis   = "configure-genesis"
-	TaskTypeConfigureStateSync = "configure-state-sync"
-	TaskTypeSnapshotUpload     = "snapshot-upload"
+	TaskTypeSnapshotRestore    = string(engine.TaskSnapshotRestore)
+	TaskTypeDiscoverPeers      = string(engine.TaskDiscoverPeers)
+	TaskTypeConfigPatch        = string(engine.TaskConfigPatch)
+	TaskTypeConfigApply        = string(engine.TaskConfigApply)
+	TaskTypeConfigValidate     = string(engine.TaskConfigValidate)
+	TaskTypeConfigReload       = string(engine.TaskConfigReload)
+	TaskTypeMarkReady          = string(engine.TaskMarkReady)
+	TaskTypeConfigureGenesis   = string(engine.TaskConfigureGenesis)
+	TaskTypeConfigureStateSync = string(engine.TaskConfigureStateSync)
+	TaskTypeSnapshotUpload     = string(engine.TaskSnapshotUpload)
 )
 
 // SnapshotRestoreTask downloads and extracts a snapshot archive from S3.
@@ -146,7 +148,10 @@ func SnapshotUploadTaskFromParams(params map[string]interface{}) SnapshotUploadT
 	}
 }
 
-// ConfigureGenesisTask downloads genesis.json from an S3 URI.
+// ConfigureGenesisTask configures genesis.json for a node. When URI and Region
+// are set, the sidecar downloads from S3. When they are empty, the sidecar
+// falls back to writing the embedded genesis for the chain ID it was started
+// with (set via SEI_CHAIN_ID environment variable).
 type ConfigureGenesisTask struct {
 	URI    string
 	Region string
@@ -156,10 +161,10 @@ func (t ConfigureGenesisTask) TaskType() string { return TaskTypeConfigureGenesi
 
 func (t ConfigureGenesisTask) Validate() error {
 	if t.URI == "" {
-		return fmt.Errorf("configure-genesis: missing required field URI")
+		return nil
 	}
 	if t.Region == "" {
-		return fmt.Errorf("configure-genesis: missing required field Region")
+		return fmt.Errorf("configure-genesis: Region is required when URI is set")
 	}
 	parsed, err := url.Parse(t.URI)
 	if err != nil {
@@ -175,6 +180,9 @@ func (t ConfigureGenesisTask) Validate() error {
 }
 
 func (t ConfigureGenesisTask) ToTaskRequest() TaskRequest {
+	if t.URI == "" {
+		return TaskRequest{Type: t.TaskType()}
+	}
 	p := map[string]interface{}{
 		"uri":    t.URI,
 		"region": t.Region,

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -171,9 +171,9 @@ func TestSnapshotUploadTask_NoCron(t *testing.T) {
 	}
 }
 
-func TestConfigureGenesisRoundTrip(t *testing.T) {
+func TestConfigureGenesisRoundTrip_S3(t *testing.T) {
 	properties := gopter.NewProperties(gopter.DefaultTestParameters())
-	properties.Property("ConfigureGenesisTask round-trips through TaskRequest", prop.ForAll(
+	properties.Property("ConfigureGenesisTask (S3) round-trips through TaskRequest", prop.ForAll(
 		func(task ConfigureGenesisTask) bool {
 			if err := task.Validate(); err != nil {
 				return false
@@ -188,6 +188,20 @@ func TestConfigureGenesisRoundTrip(t *testing.T) {
 		genConfigureGenesisTask(),
 	))
 	properties.TestingRun(t)
+}
+
+func TestConfigureGenesisRoundTrip_Empty(t *testing.T) {
+	task := ConfigureGenesisTask{}
+	if err := task.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	req := task.ToTaskRequest()
+	if req.Type != TaskTypeConfigureGenesis {
+		t.Errorf("Type = %q, want %q", req.Type, TaskTypeConfigureGenesis)
+	}
+	if req.Params != nil {
+		t.Errorf("expected nil Params for empty genesis task, got %v", req.Params)
+	}
 }
 
 func TestDiscoverPeersRoundTrip(t *testing.T) {
@@ -356,9 +370,9 @@ func TestConfigureGenesisValidation(t *testing.T) {
 		task ConfigureGenesisTask
 		ok   bool
 	}{
-		{"valid", ConfigureGenesisTask{URI: "s3://bucket/key", Region: "us-east-1"}, true},
-		{"missing uri", ConfigureGenesisTask{Region: "us-east-1"}, false},
-		{"missing region", ConfigureGenesisTask{URI: "s3://bucket/key"}, false},
+		{"valid s3", ConfigureGenesisTask{URI: "s3://bucket/key", Region: "us-east-1"}, true},
+		{"empty (uses embedded)", ConfigureGenesisTask{}, true},
+		{"uri without region", ConfigureGenesisTask{URI: "s3://bucket/key"}, false},
 		{"wrong scheme", ConfigureGenesisTask{URI: "https://bucket/key", Region: "us-east-1"}, false},
 		{"no key", ConfigureGenesisTask{URI: "s3://bucket", Region: "us-east-1"}, false},
 		{"no key trailing slash", ConfigureGenesisTask{URI: "s3://bucket/", Region: "us-east-1"}, false},

--- a/sidecar/tasks/config_apply_test.go
+++ b/sidecar/tasks/config_apply_test.go
@@ -49,7 +49,7 @@ func TestConfigApplier_FullWithOverrides(t *testing.T) {
 	handler := applier.Handler()
 
 	err := handler(context.Background(), map[string]any{
-		"mode":        "rpc",
+		"mode":        "full",
 		"incremental": false,
 		"overrides": map[string]any{
 			"evm.http_port": "9545",
@@ -103,7 +103,7 @@ func TestConfigApplier_FullInvalidMode(t *testing.T) {
 
 func TestConfigApplier_Incremental(t *testing.T) {
 	homeDir := t.TempDir()
-	writeDefaultConfig(t, homeDir, seiconfig.ModeRPC)
+	writeDefaultConfig(t, homeDir, seiconfig.ModeFull)
 
 	applier := NewConfigApplier(homeDir)
 	handler := applier.Handler()
@@ -125,7 +125,7 @@ func TestConfigApplier_Incremental(t *testing.T) {
 	if cfg.EVM.HTTPPort != 9999 {
 		t.Errorf("evm.http_port: got %d, want 9999", cfg.EVM.HTTPPort)
 	}
-	if cfg.Mode != seiconfig.ModeRPC {
+	if cfg.Mode != seiconfig.ModeFull {
 		t.Errorf("mode should be preserved: got %q", cfg.Mode)
 	}
 }
@@ -183,7 +183,7 @@ func TestConfigApplier_WritesFiles(t *testing.T) {
 }
 
 func TestConfigApplier_AllModes(t *testing.T) {
-	modes := []string{"validator", "full", "seed", "archive", "rpc", "indexer"}
+	modes := []string{"validator", "full", "seed", "archive"}
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
 			homeDir := t.TempDir()

--- a/sidecar/tasks/config_reload_test.go
+++ b/sidecar/tasks/config_reload_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConfigReloader_HotReloadableField(t *testing.T) {
 	homeDir := t.TempDir()
-	writeDefaultConfig(t, homeDir, seiconfig.ModeRPC)
+	writeDefaultConfig(t, homeDir, seiconfig.ModeFull)
 
 	reloader := NewConfigReloader(homeDir)
 	handler := reloader.Handler()
@@ -35,7 +35,7 @@ func TestConfigReloader_HotReloadableField(t *testing.T) {
 
 func TestConfigReloader_NonHotReloadableField(t *testing.T) {
 	homeDir := t.TempDir()
-	writeDefaultConfig(t, homeDir, seiconfig.ModeRPC)
+	writeDefaultConfig(t, homeDir, seiconfig.ModeFull)
 
 	reloader := NewConfigReloader(homeDir)
 	handler := reloader.Handler()
@@ -55,7 +55,7 @@ func TestConfigReloader_NonHotReloadableField(t *testing.T) {
 
 func TestConfigReloader_UnknownField(t *testing.T) {
 	homeDir := t.TempDir()
-	writeDefaultConfig(t, homeDir, seiconfig.ModeRPC)
+	writeDefaultConfig(t, homeDir, seiconfig.ModeFull)
 
 	reloader := NewConfigReloader(homeDir)
 	handler := reloader.Handler()

--- a/sidecar/tasks/config_validate_test.go
+++ b/sidecar/tasks/config_validate_test.go
@@ -24,7 +24,7 @@ func TestConfigValidator_ValidConfig(t *testing.T) {
 func TestConfigValidator_AllModes(t *testing.T) {
 	modes := []seiconfig.NodeMode{
 		seiconfig.ModeValidator, seiconfig.ModeFull, seiconfig.ModeSeed,
-		seiconfig.ModeArchive, seiconfig.ModeRPC, seiconfig.ModeIndexer,
+		seiconfig.ModeArchive,
 	}
 	for _, mode := range modes {
 		t.Run(string(mode), func(t *testing.T) {

--- a/sidecar/tasks/genesis.go
+++ b/sidecar/tasks/genesis.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	seiconfig "github.com/sei-protocol/sei-config"
 	"github.com/sei-protocol/seictl/sidecar/engine"
 	"github.com/sei-protocol/seilog"
 )
@@ -44,42 +45,62 @@ type GenesisS3Config struct {
 	Region string
 }
 
-// GenesisFetcher downloads genesis.json from S3 and writes it to the config directory.
+// GenesisFetcher writes genesis.json to the config directory. When S3 params
+// are provided in the task, it downloads from S3. Otherwise it writes the
+// embedded genesis for the configured chain ID (from SEI_CHAIN_ID).
 type GenesisFetcher struct {
 	homeDir         string
+	chainID         string
 	s3ClientFactory S3ClientFactory
 }
 
 // NewGenesisFetcher creates a fetcher targeting the given home directory.
-func NewGenesisFetcher(homeDir string, factory S3ClientFactory) *GenesisFetcher {
+// chainID is the chain this sidecar is running for (typically from SEI_CHAIN_ID).
+// When a task has no S3 params, the fetcher writes embedded genesis for this chain.
+func NewGenesisFetcher(homeDir string, chainID string, factory S3ClientFactory) *GenesisFetcher {
 	if factory == nil {
 		factory = DefaultS3ClientFactory
 	}
 	return &GenesisFetcher{
 		homeDir:         homeDir,
+		chainID:         chainID,
 		s3ClientFactory: factory,
 	}
 }
 
-// Handler returns an engine.TaskHandler that parses params and delegates to Fetch.
+// Handler returns an engine.TaskHandler that parses params and delegates to
+// the appropriate genesis source.
 func (g *GenesisFetcher) Handler() engine.TaskHandler {
 	return func(ctx context.Context, params map[string]any) error {
-		cfg, err := parseGenesisConfig(params)
+		if markerExists(g.homeDir, genesisMarkerFile) {
+			genesisLog.Debug("already completed, skipping")
+			return nil
+		}
+
+		s3Cfg, err := parseGenesisS3Config(params)
 		if err != nil {
 			return err
 		}
-		return g.Fetch(ctx, cfg)
+		if s3Cfg != nil {
+			return g.fetchFromS3(ctx, *s3Cfg)
+		}
+		return g.writeEmbeddedGenesis()
 	}
 }
 
 // Fetch downloads genesis.json from S3, skipping if the marker file exists.
+// Retained for backward compatibility with callers that build GenesisS3Config
+// directly.
 func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 	if markerExists(g.homeDir, genesisMarkerFile) {
 		genesisLog.Debug("already completed, skipping")
 		return nil
 	}
+	return g.fetchFromS3(ctx, cfg)
+}
 
-	genesisLog.Info("downloading genesis.json", "bucket", cfg.Bucket, "key", cfg.Key)
+func (g *GenesisFetcher) fetchFromS3(ctx context.Context, cfg GenesisS3Config) error {
+	genesisLog.Info("downloading genesis.json from S3", "bucket", cfg.Bucket, "key", cfg.Key)
 	s3Client, err := g.s3ClientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("building S3 client: %w", err)
@@ -94,6 +115,42 @@ func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 	}
 	defer func() { _ = output.Body.Close() }()
 
+	if err := g.writeGenesisFile(func(f *os.File) error {
+		_, err := io.Copy(f, output.Body)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	genesisLog.Info("genesis download complete (S3)")
+	return writeMarker(g.homeDir, genesisMarkerFile)
+}
+
+func (g *GenesisFetcher) writeEmbeddedGenesis() error {
+	if g.chainID == "" {
+		return fmt.Errorf("configure-genesis: no S3 params and SEI_CHAIN_ID is not set")
+	}
+
+	genesisLog.Info("writing embedded genesis", "chainId", g.chainID)
+	data, err := seiconfig.GenesisForChain(g.chainID)
+	if err != nil {
+		return fmt.Errorf("configure-genesis: %w", err)
+	}
+
+	if err := g.writeGenesisFile(func(f *os.File) error {
+		_, err := f.Write(data)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	genesisLog.Info("genesis written from embedded data", "chainId", g.chainID)
+	return writeMarker(g.homeDir, genesisMarkerFile)
+}
+
+// writeGenesisFile creates the config directory and genesis.json file, calling
+// writeFn to populate its contents.
+func (g *GenesisFetcher) writeGenesisFile(writeFn func(*os.File) error) error {
 	destDir := filepath.Join(g.homeDir, "config")
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
@@ -106,38 +163,39 @@ func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 	}
 	defer func() { _ = f.Close() }()
 
-	if _, err := io.Copy(f, output.Body); err != nil {
+	if err := writeFn(f); err != nil {
 		return fmt.Errorf("writing %s: %w", destPath, err)
 	}
-
-	genesisLog.Info("genesis download complete", "dest", destPath)
-	return writeMarker(g.homeDir, genesisMarkerFile)
+	return nil
 }
 
-func parseGenesisConfig(params map[string]any) (GenesisS3Config, error) {
+// parseGenesisS3Config extracts S3 configuration from task params. Returns nil
+// (not an error) when no S3 params are present, indicating the handler should
+// use the embedded genesis.
+func parseGenesisS3Config(params map[string]any) (*GenesisS3Config, error) {
 	uri, _ := params["uri"].(string)
-	region, _ := params["region"].(string)
-
 	if uri == "" {
-		return GenesisS3Config{}, fmt.Errorf("configure-genesis: missing required param 'uri'")
+		return nil, nil
 	}
+
+	region, _ := params["region"].(string)
 	if region == "" {
-		return GenesisS3Config{}, fmt.Errorf("configure-genesis: missing required param 'region'")
+		return nil, fmt.Errorf("configure-genesis: 'region' is required when 'uri' is set")
 	}
 
 	parsed, err := url.Parse(uri)
 	if err != nil {
-		return GenesisS3Config{}, fmt.Errorf("configure-genesis: invalid uri %q: %w", uri, err)
+		return nil, fmt.Errorf("configure-genesis: invalid uri %q: %w", uri, err)
 	}
 	if parsed.Scheme != "s3" {
-		return GenesisS3Config{}, fmt.Errorf("configure-genesis: uri must use s3:// scheme, got %q", parsed.Scheme)
+		return nil, fmt.Errorf("configure-genesis: uri must use s3:// scheme, got %q", parsed.Scheme)
 	}
 
 	bucket := parsed.Host
 	key := strings.TrimPrefix(parsed.Path, "/")
 	if bucket == "" || key == "" {
-		return GenesisS3Config{}, fmt.Errorf("configure-genesis: uri must be s3://bucket/key, got %q", uri)
+		return nil, fmt.Errorf("configure-genesis: uri must be s3://bucket/key, got %q", uri)
 	}
 
-	return GenesisS3Config{Bucket: bucket, Key: key, Region: region}, nil
+	return &GenesisS3Config{Bucket: bucket, Key: key, Region: region}, nil
 }

--- a/sidecar/tasks/genesis_test.go
+++ b/sidecar/tasks/genesis_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,6 +70,28 @@ func TestGenesisFetcher_NoChainIDNoS3(t *testing.T) {
 	err := handler(context.Background(), map[string]any{})
 	if err == nil {
 		t.Fatal("expected error when both chainID and S3 params are missing")
+	}
+}
+
+func TestGenesisFetcher_S3TakesPriority(t *testing.T) {
+	homeDir := t.TempDir()
+	called := false
+	mockFactory := func(ctx context.Context, region string) (S3GetObjectAPI, error) {
+		called = true
+		return nil, fmt.Errorf("mock: intentional S3 error to prove S3 path was taken")
+	}
+	fetcher := NewGenesisFetcher(homeDir, "pacific-1", mockFactory)
+	handler := fetcher.Handler()
+
+	err := handler(context.Background(), map[string]any{
+		"uri":    "s3://custom-bucket/custom/genesis.json",
+		"region": "us-west-2",
+	})
+	if !called {
+		t.Fatal("expected S3 client factory to be called when S3 params are present")
+	}
+	if err == nil {
+		t.Fatal("expected error from mock S3 factory")
 	}
 }
 

--- a/sidecar/tasks/genesis_test.go
+++ b/sidecar/tasks/genesis_test.go
@@ -1,0 +1,111 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenesisFetcher_EmbeddedChain(t *testing.T) {
+	homeDir := t.TempDir()
+	fetcher := NewGenesisFetcher(homeDir, "pacific-1", nil)
+	handler := fetcher.Handler()
+
+	err := handler(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(homeDir, "config", "genesis.json"))
+	if err != nil {
+		t.Fatalf("reading genesis.json: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("genesis.json is empty")
+	}
+
+	var doc struct {
+		ChainID string `json:"chain_id"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("genesis.json is not valid JSON: %v", err)
+	}
+	if doc.ChainID != "pacific-1" {
+		t.Errorf("chain_id = %q, want %q", doc.ChainID, "pacific-1")
+	}
+}
+
+func TestGenesisFetcher_EmbeddedChain_Idempotent(t *testing.T) {
+	homeDir := t.TempDir()
+	fetcher := NewGenesisFetcher(homeDir, "atlantic-2", nil)
+	handler := fetcher.Handler()
+
+	if err := handler(context.Background(), map[string]any{}); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := handler(context.Background(), map[string]any{}); err != nil {
+		t.Fatalf("second call (should skip via marker): %v", err)
+	}
+}
+
+func TestGenesisFetcher_UnknownChainNoS3(t *testing.T) {
+	homeDir := t.TempDir()
+	fetcher := NewGenesisFetcher(homeDir, "nonexistent-99", nil)
+	handler := fetcher.Handler()
+
+	err := handler(context.Background(), map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for unknown chain with no S3 params")
+	}
+}
+
+func TestGenesisFetcher_NoChainIDNoS3(t *testing.T) {
+	homeDir := t.TempDir()
+	fetcher := NewGenesisFetcher(homeDir, "", nil)
+	handler := fetcher.Handler()
+
+	err := handler(context.Background(), map[string]any{})
+	if err == nil {
+		t.Fatal("expected error when both chainID and S3 params are missing")
+	}
+}
+
+func TestParseGenesisS3Config_WithURI(t *testing.T) {
+	cfg, err := parseGenesisS3Config(map[string]any{
+		"uri":    "s3://my-bucket/path/to/genesis.json",
+		"region": "us-west-2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil S3 config")
+	}
+	if cfg.Bucket != "my-bucket" {
+		t.Errorf("bucket = %q, want %q", cfg.Bucket, "my-bucket")
+	}
+	if cfg.Key != "path/to/genesis.json" {
+		t.Errorf("key = %q, want %q", cfg.Key, "path/to/genesis.json")
+	}
+}
+
+func TestParseGenesisS3Config_NoURI(t *testing.T) {
+	cfg, err := parseGenesisS3Config(map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil S3 config, got %+v", cfg)
+	}
+}
+
+func TestParseGenesisS3Config_URIWithoutRegion(t *testing.T) {
+	_, err := parseGenesisS3Config(map[string]any{
+		"uri": "s3://bucket/key",
+	})
+	if err == nil {
+		t.Fatal("expected error when uri is set without region")
+	}
+}


### PR DESCRIPTION
## Summary

- **Embedded genesis support**: When no S3 params are provided and the chain ID is a well-known network (`pacific-1`, `atlantic-2`, `arctic-1`), the sidecar writes the embedded genesis from `sei-config` instead of requiring an S3 source.
- **Chain ID via environment variable**: `GenesisFetcher` now accepts `chainID` (sourced from `SEI_CHAIN_ID` env var) in its constructor, removing the need to pass it through task parameters.
- **Simplified client task**: `ConfigureGenesisTask` is reduced to just `URI` and `Region` fields; an empty task signals embedded genesis usage.
- **Deduplicated task type constants**: Client-side `TaskType` constants now re-export from the engine package, eliminating drift.
- **Stale mode cleanup**: Removed references to deprecated `ModeRPC`/`ModeIndexer` in tests, aligning with upstream `sei-config` changes.

## Test plan

- [x] `TestGenesisFetcher_EmbeddedChain` — known chain writes correct genesis.json
- [x] `TestGenesisFetcher_EmbeddedChain_Idempotent` — second call skips via marker
- [x] `TestGenesisFetcher_UnknownChainNoS3` — unknown chain with no S3 errors
- [x] `TestGenesisFetcher_NoChainIDNoS3` — empty chain ID with no S3 errors
- [x] `TestGenesisFetcher_S3TakesPriority` — S3 params override embedded genesis
- [x] `TestParseGenesisS3Config_*` — URI parsing, missing region, empty params
- [x] All existing sidecar task tests pass with updated mode references