### PR TITLE
feat: track in-progress tasks in sidecar engine

### DIFF
--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -177,7 +177,7 @@ components:
 
     TaskResult:
       type: object
-      required: [id, type, submittedAt]
+      required: [id, type, status, submittedAt]
       properties:
         id:
           type: string
@@ -185,6 +185,10 @@ components:
         type:
           type: string
           description: Task type that was executed.
+        status:
+          type: string
+          enum: [running, completed, failed]
+          description: Current task lifecycle state.
         params:
           type: object
           additionalProperties: true

--- a/sidecar/client/client_test.go
+++ b/sidecar/client/client_test.go
@@ -29,15 +29,15 @@ func TestStatus_OK(t *testing.T) {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(StatusResponse{Status: Ready})
+		_ = json.NewEncoder(w).Encode(StatusResponse{Status: StatusResponseStatusReady})
 	}))
 
 	resp, err := c.Status(context.Background())
 	if err != nil {
 		t.Fatalf("Status() error = %v", err)
 	}
-	if resp.Status != Ready {
-		t.Errorf("Status = %q, want %q", resp.Status, Ready)
+	if resp.Status != StatusResponseStatusReady {
+		t.Errorf("Status = %q, want %q", resp.Status, StatusResponseStatusReady)
 	}
 }
 

--- a/sidecar/client/sidecar.gen.go
+++ b/sidecar/client/sidecar.gen.go
@@ -20,9 +20,16 @@ import (
 
 // Defines values for StatusResponseStatus.
 const (
-	Initializing StatusResponseStatus = "Initializing"
-	Ready        StatusResponseStatus = "Ready"
-	Running      StatusResponseStatus = "Running"
+	StatusResponseStatusInitializing StatusResponseStatus = "Initializing"
+	StatusResponseStatusReady        StatusResponseStatus = "Ready"
+	StatusResponseStatusRunning      StatusResponseStatus = "Running"
+)
+
+// Defines values for TaskResultStatus.
+const (
+	TaskResultStatusCompleted TaskResultStatus = "completed"
+	TaskResultStatusFailed    TaskResultStatus = "failed"
+	TaskResultStatusRunning   TaskResultStatus = "running"
 )
 
 // ErrorResponse defines model for ErrorResponse.
@@ -69,12 +76,18 @@ type TaskResult struct {
 	Params    *map[string]interface{} `json:"params,omitempty"`
 
 	// Schedule Defines when a task should recur. Currently only cron is supported; blockHeight is reserved for future use.
-	Schedule    *Schedule `json:"schedule,omitempty"`
-	SubmittedAt time.Time `json:"submittedAt"`
+	Schedule *Schedule `json:"schedule,omitempty"`
+
+	// Status Current task lifecycle state.
+	Status      TaskResultStatus `json:"status"`
+	SubmittedAt time.Time        `json:"submittedAt"`
 
 	// Type Task type that was executed.
 	Type string `json:"type"`
 }
+
+// TaskResultStatus Current task lifecycle state.
+type TaskResultStatus string
 
 // TaskSubmitResponse defines model for TaskSubmitResponse.
 type TaskSubmitResponse struct {

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -500,7 +500,7 @@ func TestStatusResponseJSONRoundTrip(t *testing.T) {
 			}
 			return decoded.Status == sr.Status
 		},
-		gen.OneConstOf(Initializing, Running, Ready),
+		gen.OneConstOf(StatusResponseStatusInitializing, StatusResponseStatusRunning, StatusResponseStatusReady),
 	))
 	properties.TestingRun(t)
 }

--- a/sidecar/engine/engine.go
+++ b/sidecar/engine/engine.go
@@ -38,6 +38,7 @@ type Engine struct {
 	running   atomic.Bool
 	mu        sync.RWMutex
 	ready     bool
+	inflight  *TaskResult
 	results   []*TaskResult
 	scheduled map[string]*TaskResult
 }
@@ -66,21 +67,20 @@ func (e *Engine) loop() {
 			err := e.execute(env.task.Type, env.handler, env.task.Params)
 
 			now := time.Now()
-			result := &TaskResult{
-				ID:          env.id,
-				Type:        string(env.task.Type),
-				Params:      env.task.Params,
-				SubmittedAt: env.submittedAt,
-				CompletedAt: &now,
-			}
-			if err != nil {
-				result.Error = err.Error()
-			}
-
 			e.mu.Lock()
-			e.results = append(e.results, result)
-			if len(e.results) > maxResults {
-				e.results = e.results[len(e.results)-maxResults:]
+			if e.inflight != nil {
+				e.inflight.CompletedAt = &now
+				if err != nil {
+					e.inflight.Error = err.Error()
+					e.inflight.Status = TaskStatusFailed
+				} else {
+					e.inflight.Status = TaskStatusCompleted
+				}
+				e.results = append(e.results, e.inflight)
+				if len(e.results) > maxResults {
+					e.results = e.results[len(e.results)-maxResults:]
+				}
+				e.inflight = nil
 			}
 			e.mu.Unlock()
 
@@ -101,8 +101,20 @@ func (e *Engine) Submit(task Task) (string, error) {
 		return "", ErrBusy
 	}
 	id := uuid.New().String()
+	now := time.Now()
+
+	e.mu.Lock()
+	e.inflight = &TaskResult{
+		ID:          id,
+		Type:        string(task.Type),
+		Status:      TaskStatusRunning,
+		Params:      task.Params,
+		SubmittedAt: now,
+	}
+	e.mu.Unlock()
+
 	log.Info("task submitted", "type", task.Type, "id", id)
-	e.taskCh <- taskEnvelope{id: id, task: task, handler: handler, submittedAt: time.Now()}
+	e.taskCh <- taskEnvelope{id: id, task: task, handler: handler, submittedAt: now}
 	return id, nil
 }
 
@@ -124,6 +136,7 @@ func (e *Engine) SubmitScheduled(task Task, sched Schedule) (string, error) {
 	tr := &TaskResult{
 		ID:          id,
 		Type:        string(task.Type),
+		Status:      TaskStatusRunning,
 		Params:      task.Params,
 		Schedule:    &sched,
 		SubmittedAt: now,
@@ -188,6 +201,9 @@ func (e *Engine) EvalSchedules() {
 			s.Error = ""
 			if err != nil {
 				s.Error = err.Error()
+				s.Status = TaskStatusFailed
+			} else {
+				s.Status = TaskStatusCompleted
 			}
 		}(tr, handler)
 	}
@@ -231,12 +247,16 @@ func (e *Engine) Status() StatusResponse {
 }
 
 // RecentResults returns the most recent task results (newest first),
-// combining completed one-shot results and active scheduled tasks.
+// combining in-flight, completed one-shot results, and active scheduled tasks.
 func (e *Engine) RecentResults() []TaskResult {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	all := make([]TaskResult, 0, len(e.results)+len(e.scheduled))
+	cap := len(e.results) + len(e.scheduled) + 1
+	all := make([]TaskResult, 0, cap)
+	if e.inflight != nil {
+		all = append(all, *e.inflight)
+	}
 	for i := len(e.results) - 1; i >= 0; i-- {
 		all = append(all, *e.results[i])
 	}
@@ -250,11 +270,15 @@ func (e *Engine) RecentResults() []TaskResult {
 	return all
 }
 
-// GetResult returns a task by ID (one-shot result or scheduled), or nil.
+// GetResult returns a task by ID (in-flight, completed, or scheduled), or nil.
 func (e *Engine) GetResult(id string) *TaskResult {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
+	if e.inflight != nil && e.inflight.ID == id {
+		cp := *e.inflight
+		return &cp
+	}
 	if s, ok := e.scheduled[id]; ok {
 		cp := *s
 		return &cp

--- a/sidecar/engine/engine_test.go
+++ b/sidecar/engine/engine_test.go
@@ -194,6 +194,9 @@ func TestGetResultReturnsCompleted(t *testing.T) {
 	if result.Type != string(TaskConfigPatch) {
 		t.Fatalf("expected type %q, got %q", TaskConfigPatch, result.Type)
 	}
+	if result.Status != TaskStatusCompleted {
+		t.Fatalf("expected status %q, got %q", TaskStatusCompleted, result.Status)
+	}
 	if result.Error != "" {
 		t.Fatalf("expected no error, got %q", result.Error)
 	}
@@ -208,6 +211,9 @@ func TestGetResultReturnsFailure(t *testing.T) {
 	id, _ := eng.Submit(Task{Type: TaskConfigPatch})
 	result := waitForResult(t, eng, id)
 
+	if result.Status != TaskStatusFailed {
+		t.Fatalf("expected status %q, got %q", TaskStatusFailed, result.Status)
+	}
 	if result.Error != handlerErr.Error() {
 		t.Fatalf("expected error %q, got %q", handlerErr.Error(), result.Error)
 	}
@@ -352,4 +358,78 @@ func TestContextCancellationStopsEngine(t *testing.T) {
 		t.Fatalf("expected 1 execution, got %d", executed)
 	}
 	mu.Unlock()
+}
+
+func TestGetResultReturnsRunning(t *testing.T) {
+	started := make(chan struct{})
+	blocked := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := NewEngine(ctx, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(_ context.Context, _ map[string]any) error {
+			close(started)
+			<-blocked
+			return nil
+		},
+	})
+
+	id, _ := eng.Submit(Task{Type: TaskConfigPatch})
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for task to start")
+	}
+
+	result := eng.GetResult(id)
+	if result == nil {
+		t.Fatal("expected non-nil result for in-flight task")
+	}
+	if result.Status != TaskStatusRunning {
+		t.Fatalf("expected status %q, got %q", TaskStatusRunning, result.Status)
+	}
+	if result.CompletedAt != nil {
+		t.Fatal("expected CompletedAt to be nil for running task")
+	}
+
+	close(blocked)
+	completed := waitForResult(t, eng, id)
+	if completed.Status != TaskStatusCompleted {
+		t.Fatalf("expected status %q after completion, got %q", TaskStatusCompleted, completed.Status)
+	}
+}
+
+func TestRecentResultsIncludesInflight(t *testing.T) {
+	started := make(chan struct{})
+	blocked := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := NewEngine(ctx, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(_ context.Context, _ map[string]any) error {
+			close(started)
+			<-blocked
+			return nil
+		},
+	})
+
+	id, _ := eng.Submit(Task{Type: TaskConfigPatch})
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for task to start")
+	}
+
+	results := eng.RecentResults()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (in-flight), got %d", len(results))
+	}
+	if results[0].ID != id {
+		t.Fatalf("expected ID %q, got %q", id, results[0].ID)
+	}
+	if results[0].Status != TaskStatusRunning {
+		t.Fatalf("expected status %q, got %q", TaskStatusRunning, results[0].Status)
+	}
+
+	close(blocked)
 }

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -30,6 +30,15 @@ type Task struct {
 // TaskHandler executes a specific task type.
 type TaskHandler func(ctx context.Context, params map[string]any) error
 
+// TaskStatus represents the lifecycle state of a task.
+type TaskStatus string
+
+const (
+	TaskStatusRunning   TaskStatus = "running"
+	TaskStatusCompleted TaskStatus = "completed"
+	TaskStatusFailed    TaskStatus = "failed"
+)
+
 // Schedule defines when a task should recur. Exactly one field should be set.
 // Cron is supported today; BlockHeight is reserved for future use.
 type Schedule struct {
@@ -43,6 +52,7 @@ type Schedule struct {
 type TaskResult struct {
 	ID          string         `json:"id"`
 	Type        string         `json:"type"`
+	Status      TaskStatus     `json:"status"`
 	Params      map[string]any `json:"params,omitempty"`
 	Schedule    *Schedule      `json:"schedule,omitempty"`
 	Error       string         `json:"error,omitempty"`

--- a/sidecar/server/server_test.go
+++ b/sidecar/server/server_test.go
@@ -273,6 +273,61 @@ func TestGetTask(t *testing.T) {
 	}
 }
 
+func TestGetTaskInProgress(t *testing.T) {
+	started := make(chan struct{})
+	blocked := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := engine.NewEngine(ctx, map[engine.TaskType]engine.TaskHandler{
+		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error {
+			close(started)
+			<-blocked
+			return nil
+		},
+	})
+	srv := NewServer(":0", eng)
+
+	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+	var resp map[string]string
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	id := resp["id"]
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for task to start")
+	}
+
+	rec = serveHTTP(srv, http.MethodGet, "/v0/tasks/"+id, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for in-progress task, got %d", rec.Code)
+	}
+
+	var result engine.TaskResult
+	_ = json.NewDecoder(rec.Body).Decode(&result)
+	if result.Status != engine.TaskStatusRunning {
+		t.Fatalf("expected status %q, got %q", engine.TaskStatusRunning, result.Status)
+	}
+	if result.CompletedAt != nil {
+		t.Fatal("expected CompletedAt to be nil for running task")
+	}
+
+	close(blocked)
+	waitForTaskResult(eng, id)
+
+	rec = serveHTTP(srv, http.MethodGet, "/v0/tasks/"+id, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for completed task, got %d", rec.Code)
+	}
+	_ = json.NewDecoder(rec.Body).Decode(&result)
+	if result.Status != engine.TaskStatusCompleted {
+		t.Fatalf("expected status %q after completion, got %q", engine.TaskStatusCompleted, result.Status)
+	}
+}
+
 func TestGetTaskNotFound(t *testing.T) {
 	eng := newTestEngine(t, nil)
 	srv := NewServer(":0", eng)


### PR DESCRIPTION
## Summary

- **In-flight task visibility**: `GetTask(id)` now returns 200 with `status: "running"` while a one-shot task is executing, instead of 404. The controller can now distinguish "task is running" from "task does not exist".
- **Explicit status field**: Added `TaskStatus` type (`running`, `completed`, `failed`) and a required `status` field to `TaskResult`, replacing the inferred-from-`CompletedAt` approach.
- **Engine tracking**: One-shot tasks are stored as `inflight` immediately on submit, then moved to the completed results list when done. `GetResult` and `RecentResults` both include the in-flight task.
- **OpenAPI spec updated**: `TaskResult.status` is a required enum field; client regenerated accordingly.

## Test plan

- [x] `TestGetResultReturnsRunning` -- in-flight task visible via `GetResult` with status "running"
- [x] `TestGetResultReturnsCompleted` -- completed tasks have status "completed"
- [x] `TestGetResultReturnsFailure` -- failed tasks have status "failed"
- [x] `TestRecentResultsIncludesInflight` -- `RecentResults` includes running task
- [x] `TestGetTaskInProgress` -- HTTP `GET /v0/tasks/{id}` returns 200 (not 404) while task runs
- [x] All existing engine, server, client, and task tests pass