### PR TITLE
fix: harden RPC status check and prevent scheduled task overlap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/oapi-codegen/runtime v1.2.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/sei-protocol/sei-config v0.0.7
+	github.com/sei-protocol/sei-config v0.0.8
 	github.com/sei-protocol/seilog v0.0.2
 	github.com/urfave/cli/v3 v3.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sei-protocol/sei-config v0.0.7 h1:ysNBOrhbIA3RXAmNBxw++m5nvBWPUDOm6cN7g/9H1Ec=
-github.com/sei-protocol/sei-config v0.0.7/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.8 h1:8HPxXvcJ4eBmHXLxUlpTe2/KZtBvsM+GeENnl65ldCQ=
+github.com/sei-protocol/sei-config v0.0.8/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/seilog v0.0.2 h1:xDWNr1LUHLnOER1o/5f3rq2TQZFCv/mG1ANBaQcw24s=
 github.com/sei-protocol/seilog v0.0.2/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=

--- a/sidecar/engine/engine.go
+++ b/sidecar/engine/engine.go
@@ -31,26 +31,28 @@ type taskEnvelope struct {
 // with a TryLock gate. Scheduled tasks run in their own goroutines when their
 // cron fires. Both share the unified TaskResult model.
 type Engine struct {
-	handlers  map[TaskType]TaskHandler
-	ctx       context.Context
-	taskCh    chan taskEnvelope
-	taskMu    sync.Mutex
-	running   atomic.Bool
-	mu        sync.RWMutex
-	ready     bool
-	inflight  *TaskResult
-	results   []*TaskResult
-	scheduled map[string]*TaskResult
+	handlers     map[TaskType]TaskHandler
+	ctx          context.Context
+	taskCh       chan taskEnvelope
+	taskMu       sync.Mutex
+	running      atomic.Bool
+	mu           sync.RWMutex
+	ready        bool
+	inflight     *TaskResult
+	results      []*TaskResult
+	scheduled    map[string]*TaskResult
+	runningTasks map[string]struct{}
 }
 
 // NewEngine creates a new Engine and starts its worker loop. The engine
 // runs until ctx is cancelled.
 func NewEngine(ctx context.Context, handlers map[TaskType]TaskHandler) *Engine {
 	e := &Engine{
-		handlers:  handlers,
-		ctx:       ctx,
-		taskCh:    make(chan taskEnvelope, 1),
-		scheduled: make(map[string]*TaskResult),
+		handlers:     handlers,
+		ctx:          ctx,
+		taskCh:       make(chan taskEnvelope, 1),
+		scheduled:    make(map[string]*TaskResult),
+		runningTasks: make(map[string]struct{}),
 	}
 	go e.loop()
 	return e
@@ -175,9 +177,14 @@ func (e *Engine) EvalSchedules() {
 			continue
 		}
 
-		// Advance NextRunAt before launching so a concurrent EvalSchedules
-		// call won't fire the same task again while it's still running.
 		e.mu.Lock()
+		if _, alreadyRunning := e.runningTasks[tr.ID]; alreadyRunning {
+			e.mu.Unlock()
+			log.Debug("scheduled task still running, skipping", "type", tr.Type, "id", tr.ID)
+			continue
+		}
+		e.runningTasks[tr.ID] = struct{}{}
+
 		if tr.Schedule != nil && tr.Schedule.Cron != "" {
 			if next, cronErr := nextCronTime(tr.Schedule.Cron, now); cronErr == nil {
 				tr.NextRunAt = &next
@@ -192,6 +199,7 @@ func (e *Engine) EvalSchedules() {
 
 			e.mu.Lock()
 			defer e.mu.Unlock()
+			delete(e.runningTasks, tr.ID)
 			s, ok := e.scheduled[tr.ID]
 			if !ok {
 				return

--- a/sidecar/engine/engine_test.go
+++ b/sidecar/engine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -334,6 +335,50 @@ func TestEvalSchedulesFiresDueTasks(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected scheduled task to execute")
 	}
+}
+
+func TestEvalSchedulesSkipsAlreadyRunning(t *testing.T) {
+	started := make(chan struct{})
+	blocked := make(chan struct{})
+	callCount := int32(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := NewEngine(ctx, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(_ context.Context, _ map[string]any) error {
+			atomic.AddInt32(&callCount, 1)
+			started <- struct{}{}
+			<-blocked
+			return nil
+		},
+	})
+
+	id, _ := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, Schedule{Cron: "* * * * *"})
+
+	eng.mu.Lock()
+	past := time.Now().Add(-1 * time.Minute)
+	eng.scheduled[id].NextRunAt = &past
+	eng.mu.Unlock()
+
+	eng.EvalSchedules()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for task to start")
+	}
+
+	eng.mu.Lock()
+	past2 := time.Now().Add(-1 * time.Minute)
+	eng.scheduled[id].NextRunAt = &past2
+	eng.mu.Unlock()
+
+	eng.EvalSchedules()
+	time.Sleep(50 * time.Millisecond)
+
+	if c := atomic.LoadInt32(&callCount); c != 1 {
+		t.Fatalf("expected handler called once (overlap prevented), got %d", c)
+	}
+
+	close(blocked)
 }
 
 func TestContextCancellationStopsEngine(t *testing.T) {

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	seiconfig "github.com/sei-protocol/sei-config"
 	"github.com/sei-protocol/seictl/sidecar/engine"
 	"github.com/sei-protocol/seilog"
 )
@@ -23,11 +24,12 @@ import (
 var exportLog = seilog.NewLogger("seictl", "task", "result-export")
 
 const (
-	exportStateFile    = ".sei-sidecar-last-export.json"
-	defaultRPCEndpoint = "http://localhost:26657"
-	defaultPageSize    = 1000
-	exportRPCTimeout   = 10 * time.Second
+	exportStateFile  = ".sei-sidecar-last-export.json"
+	defaultPageSize  = 1000
+	exportRPCTimeout = 10 * time.Second
 )
+
+var defaultRPCEndpoint = fmt.Sprintf("http://localhost:%d", seiconfig.PortRPC)
 
 // ResultExportConfig holds the parameters for the result-export task.
 type ResultExportConfig struct {
@@ -235,6 +237,11 @@ func queryLatestHeight(ctx context.Context, rpcEndpoint string) (int64, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(body))
+	}
+
 	var rpcResp struct {
 		Result struct {
 			SyncInfo struct {
@@ -246,7 +253,14 @@ func queryLatestHeight(ctx context.Context, rpcEndpoint string) (int64, error) {
 		return 0, fmt.Errorf("decoding /status response: %w", err)
 	}
 
-	return strconv.ParseInt(rpcResp.Result.SyncInfo.LatestBlockHeight, 10, 64)
+	h, err := strconv.ParseInt(rpcResp.Result.SyncInfo.LatestBlockHeight, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing latest_block_height %q: %w", rpcResp.Result.SyncInfo.LatestBlockHeight, err)
+	}
+	if h <= 0 {
+		return 0, fmt.Errorf("latest_block_height is %d, node may still be syncing", h)
+	}
+	return h, nil
 }
 
 func queryBlockResults(ctx context.Context, rpcEndpoint string, height int64) (json.RawMessage, error) {

--- a/sidecar/tasks/result_export_test.go
+++ b/sidecar/tasks/result_export_test.go
@@ -96,7 +96,7 @@ func TestExportRPCUnavailable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
-	srv.Close() // close immediately so connections fail
+	srv.Close()
 
 	tmpDir := t.TempDir()
 	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
@@ -108,6 +108,38 @@ func TestExportRPCUnavailable(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Export() returned error %v, want nil (fail-safe)", err)
+	}
+}
+
+func TestExportRPCNon200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, "node is syncing")
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+
+	err := e.Export(context.Background(), ResultExportConfig{
+		Bucket:      "test-bucket",
+		Region:      "us-east-1",
+		RPCEndpoint: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Export() returned error %v, want nil (fail-safe on HTTP error)", err)
+	}
+}
+
+func TestQueryLatestHeight_ZeroHeight(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"result":{"sync_info":{"latest_block_height":"0"}}}`)
+	}))
+	defer srv.Close()
+
+	_, err := queryLatestHeight(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error for zero height, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `queryLatestHeight` now validates HTTP status codes and rejects height <= 0, preventing silent misinterpretation when the node is syncing or returning errors
- `EvalSchedules` now tracks in-flight scheduled tasks via `runningTasks` map and skips re-firing a task that is still running from a previous cron tick
- Replaced hardcoded RPC port with `seiconfig.PortRPC`

## Test plan
- [x] `TestExportRPCNon200Status` — verifies 503 response is handled fail-safe
- [x] `TestQueryLatestHeight_ZeroHeight` — verifies height 0 is rejected
- [x] `TestEvalSchedulesSkipsAlreadyRunning` — verifies concurrent execution of same scheduled task is prevented
- [x] CI lint and test pass

Made with [Cursor](https://cursor.com)