### PR TITLE
refactor: typed submit methods and async task model

### DIFF
--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: sei-sidecar API
   description: HTTP API for the sei-sidecar task executor.
-  version: 0.3.0
+  version: 0.5.0
   license:
     name: Apache-2.0
 
@@ -38,9 +38,11 @@ paths:
       operationId: submitTask
       summary: Submit a task
       description: |
-        If `schedule` is provided, a recurring scheduled task is created and
-        201 is returned. Otherwise the task is submitted for immediate execution
-        and 202 is returned. Returns 409 if a one-shot task is already running.
+        The `async` field selects the execution mode:
+        - Omitted: immediate one-shot (202).
+        - `async.schedule`: recurring cron-triggered task (201).
+        - `async.daemon`: long-running daemon task (201).
+        Returns 409 if an immediate task is already running.
       requestBody:
         required: true
         content:
@@ -49,7 +51,7 @@ paths:
               $ref: "#/components/schemas/TaskRequest"
       responses:
         "201":
-          description: Scheduled task created.
+          description: Scheduled or daemon task created.
           content:
             application/json:
               schema:
@@ -75,7 +77,7 @@ paths:
     get:
       operationId: listTasks
       summary: List recent task results
-      description: Returns the most recent completed task results and active scheduled tasks.
+      description: Returns the most recent completed task results, active scheduled tasks, and daemon tasks.
       responses:
         "200":
           description: Task results.
@@ -113,7 +115,9 @@ paths:
     delete:
       operationId: deleteTask
       summary: Remove a task
-      description: Removes a completed task result or stops and removes a scheduled task.
+      description: |
+        Removes a completed task result, stops and removes a scheduled task,
+        or cancels and removes a daemon task.
       parameters:
         - name: id
           in: path
@@ -143,12 +147,23 @@ components:
         params:
           type: object
           additionalProperties: true
-        schedule:
-          $ref: "#/components/schemas/Schedule"
+        async:
+          $ref: "#/components/schemas/AsyncConfig"
 
-    Schedule:
+    AsyncConfig:
       type: object
-      description: Defines when a task should recur. Currently only cron is supported; blockHeight is reserved for future use.
+      description: >
+        Describes asynchronous task execution. Omit for immediate one-shot.
+        Set exactly one field.
+      properties:
+        schedule:
+          $ref: "#/components/schemas/ScheduleConfig"
+        daemon:
+          $ref: "#/components/schemas/DaemonConfig"
+
+    ScheduleConfig:
+      type: object
+      description: Triggers a task on a recurring basis.
       properties:
         cron:
           type: string
@@ -157,6 +172,12 @@ components:
           type: integer
           format: int64
           description: Reserved for future block-height-based scheduling.
+
+    DaemonConfig:
+      type: object
+      description: >
+        Marks a task as long-running. The handler runs indefinitely; only an
+        unrecoverable error produces a terminal status.
 
     StatusResponse:
       type: object
@@ -192,8 +213,8 @@ components:
         params:
           type: object
           additionalProperties: true
-        schedule:
-          $ref: "#/components/schemas/Schedule"
+        async:
+          $ref: "#/components/schemas/AsyncConfig"
         error:
           type: string
           description: Error message if the task failed.

--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: sei-sidecar API
   description: HTTP API for the sei-sidecar task executor.
-  version: 0.5.0
+  version: 0.4.0
   license:
     name: Apache-2.0
 
@@ -178,6 +178,7 @@ components:
       description: >
         Marks a task as long-running. The handler runs indefinitely; only an
         unrecoverable error produces a terminal status.
+      additionalProperties: false
 
     StatusResponse:
       type: object

--- a/sidecar/client/client.go
+++ b/sidecar/client/client.go
@@ -92,19 +92,11 @@ func (c *SidecarClient) Status(ctx context.Context) (*StatusResponse, error) {
 	return resp.JSON200, nil
 }
 
-// SubmitTask validates and sends a typed task to the sidecar. Returns the
-// assigned task UUID on success, ErrBusy on 409, and a descriptive error
-// otherwise.
-func (c *SidecarClient) SubmitTask(ctx context.Context, task TaskBuilder) (uuid.UUID, error) {
-	if err := task.Validate(); err != nil {
-		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
-	}
-	return c.SubmitRawTask(ctx, task.ToTaskRequest())
-}
-
-// SubmitRawTask sends a pre-built TaskRequest without validation. Use
-// SubmitTask for the typed, validated path.
-func (c *SidecarClient) SubmitRawTask(ctx context.Context, task TaskRequest) (uuid.UUID, error) {
+// SubmitTask sends a TaskRequest to the sidecar. This is the generic
+// submission path used internally by the typed Submit*Task methods and
+// by the controller for dynamic dispatch. Prefer the typed methods for
+// compile-time validation of task parameters.
+func (c *SidecarClient) SubmitTask(ctx context.Context, task TaskRequest) (uuid.UUID, error) {
 	resp, err := c.inner.SubmitTaskWithResponse(ctx, task)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("submitting task to sidecar: %w", err)
@@ -198,4 +190,86 @@ func (c *SidecarClient) Healthz(ctx context.Context) (bool, error) {
 	default:
 		return false, fmt.Errorf("sidecar healthz returned %d: %s", resp.StatusCode(), bytes.TrimSpace(resp.Body))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Typed submit methods -- primary public API for task submission.
+// Each validates the typed struct and delegates to SubmitTask.
+// ---------------------------------------------------------------------------
+
+func (c *SidecarClient) SubmitSnapshotRestoreTask(ctx context.Context, task SnapshotRestoreTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitSnapshotUploadTask(ctx context.Context, task SnapshotUploadTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitConfigureGenesisTask(ctx context.Context, task ConfigureGenesisTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitDiscoverPeersTask(ctx context.Context, task DiscoverPeersTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitConfigPatchTask(ctx context.Context, task ConfigPatchTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitConfigApplyTask(ctx context.Context, task ConfigApplyTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitConfigValidateTask(ctx context.Context, task ConfigValidateTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitConfigReloadTask(ctx context.Context, task ConfigReloadTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitMarkReadyTask(ctx context.Context, task MarkReadyTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitConfigureStateSyncTask(ctx context.Context, task ConfigureStateSyncTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitResultExportTask(ctx context.Context, task ResultExportTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
 }

--- a/sidecar/client/client_test.go
+++ b/sidecar/client/client_test.go
@@ -83,9 +83,9 @@ func TestSubmitTask_Accepted(t *testing.T) {
 		Region:  "us-east-1",
 		ChainID: "sei-chain",
 	}
-	id, err := c.SubmitTask(context.Background(), task)
+	id, err := c.SubmitSnapshotRestoreTask(context.Background(), task)
 	if err != nil {
-		t.Fatalf("SubmitTask() error = %v", err)
+		t.Fatalf("SubmitSnapshotRestoreTask() error = %v", err)
 	}
 	if id != taskID {
 		t.Errorf("returned id = %s, want %s", id, taskID)
@@ -100,23 +100,23 @@ func TestSubmitTask_Scheduled(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
-		if req.Schedule == nil || req.Schedule.Cron == nil {
-			t.Fatal("expected schedule.cron to be set")
+		if req.Async == nil || req.Async.Schedule == nil || req.Async.Schedule.Cron == nil {
+			t.Fatal("expected async.schedule.cron to be set")
 		}
-		if *req.Schedule.Cron != cron {
-			t.Errorf("schedule.cron = %q, want %q", *req.Schedule.Cron, cron)
+		if *req.Async.Schedule.Cron != cron {
+			t.Errorf("async.schedule.cron = %q, want %q", *req.Async.Schedule.Cron, cron)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(TaskSubmitResponse{Id: taskID})
 	}))
 
-	id, err := c.SubmitRawTask(context.Background(), TaskRequest{
-		Type:     TaskTypeDiscoverPeers,
-		Schedule: &Schedule{Cron: &cron},
+	id, err := c.SubmitTask(context.Background(), TaskRequest{
+		Type:  TaskTypeDiscoverPeers,
+		Async: &AsyncConfig{Schedule: &ScheduleConfig{Cron: &cron}},
 	})
 	if err != nil {
-		t.Fatalf("SubmitRawTask() error = %v", err)
+		t.Fatalf("SubmitTask() error = %v", err)
 	}
 	if id != taskID {
 		t.Errorf("returned id = %s, want %s", id, taskID)
@@ -130,7 +130,7 @@ func TestSubmitTask_Busy(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "task already running"})
 	}))
 
-	_, err := c.SubmitTask(context.Background(), MarkReadyTask{})
+	_, err := c.SubmitMarkReadyTask(context.Background(), MarkReadyTask{})
 	if !errors.Is(err, ErrBusy) {
 		t.Errorf("error = %v, want ErrBusy", err)
 	}
@@ -143,7 +143,7 @@ func TestSubmitTask_BadRequest(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "unknown task type"})
 	}))
 
-	_, err := c.SubmitRawTask(context.Background(), TaskRequest{Type: "invalid"})
+	_, err := c.SubmitTask(context.Background(), TaskRequest{Type: "invalid"})
 	if err == nil {
 		t.Fatal("expected error for 400 response")
 	}
@@ -157,7 +157,7 @@ func TestSubmitTask_ValidationFailure(t *testing.T) {
 		t.Fatal("server should not be called when validation fails")
 	}))
 
-	_, err := c.SubmitTask(context.Background(), SnapshotRestoreTask{})
+	_, err := c.SubmitSnapshotRestoreTask(context.Background(), SnapshotRestoreTask{})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}

--- a/sidecar/client/sidecar.gen.go
+++ b/sidecar/client/sidecar.gen.go
@@ -37,8 +37,20 @@ type ErrorResponse struct {
 	Error string `json:"error"`
 }
 
-// Schedule Defines when a task should recur. Currently only cron is supported; blockHeight is reserved for future use.
-type Schedule struct {
+// AsyncConfig Describes asynchronous task execution. Omit for immediate one-shot. Set exactly one field.
+type AsyncConfig struct {
+	// Daemon Marks a task as long-running.
+	Daemon *DaemonConfig `json:"daemon,omitempty"`
+
+	// Schedule Triggers a task on a recurring basis.
+	Schedule *ScheduleConfig `json:"schedule,omitempty"`
+}
+
+// DaemonConfig Marks a task as long-running. The handler runs indefinitely; only an unrecoverable error produces a terminal status.
+type DaemonConfig struct{}
+
+// ScheduleConfig Triggers a task on a recurring basis.
+type ScheduleConfig struct {
 	// BlockHeight Reserved for future block-height-based scheduling.
 	BlockHeight *int64 `json:"blockHeight,omitempty"`
 
@@ -56,10 +68,10 @@ type StatusResponseStatus string
 
 // TaskRequest defines model for TaskRequest.
 type TaskRequest struct {
-	Params *map[string]interface{} `json:"params,omitempty"`
+	// Async Describes asynchronous task execution. Omit for immediate one-shot.
+	Async *AsyncConfig `json:"async,omitempty"`
 
-	// Schedule Defines when a task should recur. Currently only cron is supported; blockHeight is reserved for future use.
-	Schedule *Schedule `json:"schedule,omitempty"`
+	Params *map[string]interface{} `json:"params,omitempty"`
 
 	// Type Task type identifier.
 	Type string `json:"type"`
@@ -75,8 +87,8 @@ type TaskResult struct {
 	NextRunAt *time.Time              `json:"nextRunAt,omitempty"`
 	Params    *map[string]interface{} `json:"params,omitempty"`
 
-	// Schedule Defines when a task should recur. Currently only cron is supported; blockHeight is reserved for future use.
-	Schedule *Schedule `json:"schedule,omitempty"`
+	// Async Describes asynchronous task execution.
+	Async *AsyncConfig `json:"async,omitempty"`
 
 	// Status Current task lifecycle state.
 	Status      TaskResultStatus `json:"status"`

--- a/sidecar/client/sidecar.gen.go
+++ b/sidecar/client/sidecar.gen.go
@@ -32,14 +32,9 @@ const (
 	TaskResultStatusRunning   TaskResultStatus = "running"
 )
 
-// ErrorResponse defines model for ErrorResponse.
-type ErrorResponse struct {
-	Error string `json:"error"`
-}
-
 // AsyncConfig Describes asynchronous task execution. Omit for immediate one-shot. Set exactly one field.
 type AsyncConfig struct {
-	// Daemon Marks a task as long-running.
+	// Daemon Marks a task as long-running. The handler runs indefinitely; only an unrecoverable error produces a terminal status.
 	Daemon *DaemonConfig `json:"daemon,omitempty"`
 
 	// Schedule Triggers a task on a recurring basis.
@@ -47,7 +42,12 @@ type AsyncConfig struct {
 }
 
 // DaemonConfig Marks a task as long-running. The handler runs indefinitely; only an unrecoverable error produces a terminal status.
-type DaemonConfig struct{}
+type DaemonConfig = map[string]interface{}
+
+// ErrorResponse defines model for ErrorResponse.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
 
 // ScheduleConfig Triggers a task on a recurring basis.
 type ScheduleConfig struct {
@@ -68,9 +68,8 @@ type StatusResponseStatus string
 
 // TaskRequest defines model for TaskRequest.
 type TaskRequest struct {
-	// Async Describes asynchronous task execution. Omit for immediate one-shot.
-	Async *AsyncConfig `json:"async,omitempty"`
-
+	// Async Describes asynchronous task execution. Omit for immediate one-shot. Set exactly one field.
+	Async  *AsyncConfig            `json:"async,omitempty"`
 	Params *map[string]interface{} `json:"params,omitempty"`
 
 	// Type Task type identifier.
@@ -79,16 +78,15 @@ type TaskRequest struct {
 
 // TaskResult defines model for TaskResult.
 type TaskResult struct {
-	CompletedAt *time.Time `json:"completedAt,omitempty"`
+	// Async Describes asynchronous task execution. Omit for immediate one-shot. Set exactly one field.
+	Async       *AsyncConfig `json:"async,omitempty"`
+	CompletedAt *time.Time   `json:"completedAt,omitempty"`
 
 	// Error Error message if the task failed.
 	Error     *string                 `json:"error,omitempty"`
 	Id        openapi_types.UUID      `json:"id"`
 	NextRunAt *time.Time              `json:"nextRunAt,omitempty"`
 	Params    *map[string]interface{} `json:"params,omitempty"`
-
-	// Async Describes asynchronous task execution.
-	Async *AsyncConfig `json:"async,omitempty"`
 
 	// Status Current task lifecycle state.
 	Status      TaskResultStatus `json:"status"`

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -3,9 +3,7 @@ package client
 import (
 	"fmt"
 	"net/url"
-	"time"
 
-	"github.com/robfig/cron/v3"
 	seiconfig "github.com/sei-protocol/sei-config"
 	"github.com/sei-protocol/seictl/sidecar/engine"
 )
@@ -32,8 +30,6 @@ const (
 	TaskTypeConfigureStateSync = string(engine.TaskConfigureStateSync)
 	TaskTypeSnapshotUpload     = string(engine.TaskSnapshotUpload)
 	TaskTypeResultExport       = string(engine.TaskResultExport)
-
-	defaultResultExportCron = "*/10 * * * *"
 )
 
 // SnapshotRestoreTask downloads and extracts a snapshot archive from S3.
@@ -85,11 +81,12 @@ func SnapshotRestoreTaskFromParams(params map[string]interface{}) SnapshotRestor
 }
 
 // SnapshotUploadTask archives and streams a local snapshot to S3.
+// Async may be set to run this task on a cron schedule or as a daemon.
 type SnapshotUploadTask struct {
 	Bucket string
 	Prefix string
 	Region string
-	Cron   string
+	Async  *AsyncConfig
 }
 
 func (t SnapshotUploadTask) TaskType() string { return TaskTypeSnapshotUpload }
@@ -100,27 +97,6 @@ func (t SnapshotUploadTask) Validate() error {
 	}
 	if t.Region == "" {
 		return fmt.Errorf("snapshot-upload: missing required field Region")
-	}
-	if t.Cron != "" {
-		if err := validateMinCronInterval(t.Cron, 24*time.Hour); err != nil {
-			return fmt.Errorf("snapshot-upload: %w", err)
-		}
-	}
-	return nil
-}
-
-// validateMinCronInterval parses a standard 5-field cron expression and
-// checks that the gap between the first two scheduled firings is at least min.
-func validateMinCronInterval(expr string, min time.Duration) error {
-	sched, err := cron.ParseStandard(expr)
-	if err != nil {
-		return fmt.Errorf("invalid cron expression %q: %w", expr, err)
-	}
-	t0 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	first := sched.Next(t0)
-	second := sched.Next(first)
-	if gap := second.Sub(first); gap < min {
-		return fmt.Errorf("cron %q fires every %v, minimum allowed interval is %v", expr, gap, min)
 	}
 	return nil
 }
@@ -134,8 +110,8 @@ func (t SnapshotUploadTask) ToTaskRequest() TaskRequest {
 		p["prefix"] = t.Prefix
 	}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
-	if t.Cron != "" {
-		req.Schedule = &Schedule{Cron: &t.Cron}
+	if t.Async != nil {
+		req.Async = t.Async
 	}
 	return req
 }
@@ -491,10 +467,12 @@ func ConfigReloadTaskFromParams(params map[string]interface{}) ConfigReloadTask 
 
 // ResultExportTask queries the local seid RPC for block results and uploads
 // them in paginated NDJSON files to S3.
+// Async may be set to run this task on a cron schedule or as a daemon.
 type ResultExportTask struct {
 	Bucket string
 	Prefix string
 	Region string
+	Async  *AsyncConfig
 }
 
 func (t ResultExportTask) TaskType() string { return TaskTypeResultExport }
@@ -517,12 +495,11 @@ func (t ResultExportTask) ToTaskRequest() TaskRequest {
 	if t.Prefix != "" {
 		p["prefix"] = t.Prefix
 	}
-	cron := defaultResultExportCron
-	return TaskRequest{
-		Type:     t.TaskType(),
-		Params:   &p,
-		Schedule: &Schedule{Cron: &cron},
+	req := TaskRequest{Type: t.TaskType(), Params: &p}
+	if t.Async != nil {
+		req.Async = t.Async
 	}
+	return req
 }
 
 // ResultExportTaskFromParams reconstructs a ResultExportTask from

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -152,22 +152,27 @@ func TestSnapshotUploadRoundTrip(t *testing.T) {
 	properties.TestingRun(t)
 }
 
-func TestSnapshotUploadTask_CronSchedule(t *testing.T) {
-	task := SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 0 * * *"}
+func TestSnapshotUploadTask_NoAsync(t *testing.T) {
+	task := SnapshotUploadTask{Bucket: "b", Region: "r"}
 	req := task.ToTaskRequest()
-	if req.Schedule == nil {
-		t.Fatal("expected Schedule to be set")
-	}
-	if req.Schedule.Cron == nil || *req.Schedule.Cron != "0 0 * * *" {
-		t.Errorf("Schedule.Cron = %v, want %q", req.Schedule.Cron, "0 0 * * *")
+	if req.Async != nil {
+		t.Errorf("expected nil Async, got %v", req.Async)
 	}
 }
 
-func TestSnapshotUploadTask_NoCron(t *testing.T) {
-	task := SnapshotUploadTask{Bucket: "b", Region: "r"}
+func TestSnapshotUploadTask_WithAsync(t *testing.T) {
+	cron := "0 0 * * *"
+	task := SnapshotUploadTask{
+		Bucket: "b",
+		Region: "r",
+		Async:  &AsyncConfig{Schedule: &ScheduleConfig{Cron: &cron}},
+	}
 	req := task.ToTaskRequest()
-	if req.Schedule != nil {
-		t.Errorf("expected nil Schedule when Cron is empty, got %v", req.Schedule)
+	if req.Async == nil || req.Async.Schedule == nil || req.Async.Schedule.Cron == nil {
+		t.Fatal("expected async.schedule.cron to be set")
+	}
+	if *req.Async.Schedule.Cron != cron {
+		t.Errorf("async.schedule.cron = %q, want %q", *req.Async.Schedule.Cron, cron)
 	}
 }
 
@@ -341,12 +346,8 @@ func TestSnapshotUploadValidation(t *testing.T) {
 		task SnapshotUploadTask
 		ok   bool
 	}{
-		{"valid no cron", SnapshotUploadTask{Bucket: "b", Region: "r"}, true},
-		{"valid daily cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 0 * * *"}, true},
-		{"valid weekly cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 0 * * 0"}, true},
-		{"rejects hourly cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "0 * * * *"}, false},
-		{"rejects every-minute cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "* * * * *"}, false},
-		{"rejects invalid cron", SnapshotUploadTask{Bucket: "b", Region: "r", Cron: "not-a-cron"}, false},
+		{"valid", SnapshotUploadTask{Bucket: "b", Region: "r"}, true},
+		{"valid with prefix", SnapshotUploadTask{Bucket: "b", Prefix: "p", Region: "r"}, true},
 		{"missing bucket", SnapshotUploadTask{Region: "r"}, false},
 		{"missing region", SnapshotUploadTask{Bucket: "b"}, false},
 		{"all empty", SnapshotUploadTask{}, false},
@@ -533,17 +534,17 @@ func TestTaskRequestJSONRoundTrip(t *testing.T) {
 	properties.TestingRun(t)
 }
 
-func TestScheduleJSONRoundTrip(t *testing.T) {
+func TestScheduleConfigJSONRoundTrip(t *testing.T) {
 	cron := "*/5 * * * *"
 	height := int64(12345)
 	cases := []struct {
 		name  string
-		sched Schedule
+		sched ScheduleConfig
 	}{
-		{"cron only", Schedule{Cron: &cron}},
-		{"block height only", Schedule{BlockHeight: &height}},
-		{"both", Schedule{Cron: &cron, BlockHeight: &height}},
-		{"empty", Schedule{}},
+		{"cron only", ScheduleConfig{Cron: &cron}},
+		{"block height only", ScheduleConfig{BlockHeight: &height}},
+		{"both", ScheduleConfig{Cron: &cron, BlockHeight: &height}},
+		{"empty", ScheduleConfig{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -551,7 +552,7 @@ func TestScheduleJSONRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Marshal: %v", err)
 			}
-			var decoded Schedule
+			var decoded ScheduleConfig
 			if err := json.Unmarshal(data, &decoded); err != nil {
 				t.Fatalf("Unmarshal: %v", err)
 			}
@@ -571,6 +572,36 @@ func TestScheduleJSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAsyncConfigJSONRoundTrip(t *testing.T) {
+	cron := "*/5 * * * *"
+	cases := []struct {
+		name string
+		cfg  AsyncConfig
+	}{
+		{"schedule", AsyncConfig{Schedule: &ScheduleConfig{Cron: &cron}}},
+		{"daemon", AsyncConfig{Daemon: &DaemonConfig{}}},
+		{"empty", AsyncConfig{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.cfg)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var decoded AsyncConfig
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if (tc.cfg.Schedule == nil) != (decoded.Schedule == nil) {
+				t.Errorf("Schedule nil mismatch")
+			}
+			if (tc.cfg.Daemon == nil) != (decoded.Daemon == nil) {
+				t.Errorf("Daemon nil mismatch")
+			}
+		})
+	}
+}
+
 func TestResultExportRoundTrip(t *testing.T) {
 	properties := gopter.NewProperties(gopter.DefaultTestParameters())
 	properties.Property("ResultExportTask round-trips through TaskRequest", prop.ForAll(
@@ -583,7 +614,7 @@ func TestResultExportRoundTrip(t *testing.T) {
 			if req.Type != TaskTypeResultExport {
 				return false
 			}
-			if req.Schedule == nil {
+			if req.Async != nil {
 				return false
 			}
 			rebuilt := ResultExportTaskFromParams(*req.Params)
@@ -620,13 +651,26 @@ func TestResultExportValidation(t *testing.T) {
 	}
 }
 
-func TestResultExportTask_HasCronSchedule(t *testing.T) {
+func TestResultExportTask_NoAsync(t *testing.T) {
 	task := ResultExportTask{Bucket: "b", Region: "r"}
 	req := task.ToTaskRequest()
-	if req.Schedule == nil {
-		t.Fatal("expected Schedule to be set")
+	if req.Async != nil {
+		t.Errorf("expected nil Async, got %v", req.Async)
 	}
-	if req.Schedule.Cron == nil {
-		t.Fatal("expected Schedule.Cron to be set")
+}
+
+func TestResultExportTask_WithAsync(t *testing.T) {
+	cron := "*/10 * * * *"
+	task := ResultExportTask{
+		Bucket: "b",
+		Region: "r",
+		Async:  &AsyncConfig{Schedule: &ScheduleConfig{Cron: &cron}},
+	}
+	req := task.ToTaskRequest()
+	if req.Async == nil || req.Async.Schedule == nil || req.Async.Schedule.Cron == nil {
+		t.Fatal("expected async.schedule.cron to be set")
+	}
+	if *req.Async.Schedule.Cron != cron {
+		t.Errorf("async.schedule.cron = %q, want %q", *req.Async.Schedule.Cron, cron)
 	}
 }

--- a/sidecar/engine/engine.go
+++ b/sidecar/engine/engine.go
@@ -27,21 +27,35 @@ type taskEnvelope struct {
 	submittedAt time.Time
 }
 
-// Engine is the task executor. One-shot tasks are serialized through a channel
-// with a TryLock gate. Scheduled tasks run in their own goroutines when their
-// cron fires. Both share the unified TaskResult model.
+// daemonEntry tracks a running daemon task and its cancel func.
+type daemonEntry struct {
+	result *TaskResult
+	cancel context.CancelFunc
+}
+
+// Engine is the task executor. Immediate tasks are serialized through a
+// channel with a TryLock gate. Scheduled tasks run in their own goroutines
+// when their cron fires. Daemon tasks run indefinitely in dedicated
+// goroutines. All three share the unified TaskResult model.
 type Engine struct {
-	handlers     map[TaskType]TaskHandler
-	ctx          context.Context
-	taskCh       chan taskEnvelope
-	taskMu       sync.Mutex
-	running      atomic.Bool
-	mu           sync.RWMutex
-	ready        bool
-	inflight     *TaskResult
-	results      []*TaskResult
+	handlers map[TaskType]TaskHandler
+	ctx      context.Context
+	taskCh   chan taskEnvelope
+	taskMu   sync.Mutex
+	running  atomic.Bool
+	mu       sync.RWMutex
+	ready    bool
+
+	// Immediate one-shot tasks.
+	inflight *TaskResult
+	results  []*TaskResult
+
+	// Scheduled (cron) tasks.
 	scheduled    map[string]*TaskResult
 	runningTasks map[string]struct{}
+
+	// Long-running daemon tasks.
+	daemons map[string]*daemonEntry
 }
 
 // NewEngine creates a new Engine and starts its worker loop. The engine
@@ -53,6 +67,7 @@ func NewEngine(ctx context.Context, handlers map[TaskType]TaskHandler) *Engine {
 		taskCh:       make(chan taskEnvelope, 1),
 		scheduled:    make(map[string]*TaskResult),
 		runningTasks: make(map[string]struct{}),
+		daemons:      make(map[string]*daemonEntry),
 	}
 	go e.loop()
 	return e
@@ -123,7 +138,7 @@ func (e *Engine) Submit(task Task) (string, error) {
 // SubmitScheduled creates a scheduled task. Returns the task ID. Currently
 // only cron schedules are supported; block-height scheduling is reserved for
 // future use. The schedule is evaluated by EvalSchedules.
-func (e *Engine) SubmitScheduled(task Task, sched Schedule) (string, error) {
+func (e *Engine) SubmitScheduled(task Task, sched ScheduleConfig) (string, error) {
 	if _, ok := e.handlers[task.Type]; !ok {
 		return "", fmt.Errorf("unknown task type: %s", task.Type)
 	}
@@ -140,7 +155,7 @@ func (e *Engine) SubmitScheduled(task Task, sched Schedule) (string, error) {
 		Type:        string(task.Type),
 		Status:      TaskStatusRunning,
 		Params:      task.Params,
-		Schedule:    &sched,
+		Async:       &AsyncConfig{Schedule: &sched},
 		SubmittedAt: now,
 		NextRunAt:   &next,
 	}
@@ -150,6 +165,59 @@ func (e *Engine) SubmitScheduled(task Task, sched Schedule) (string, error) {
 	e.mu.Unlock()
 
 	log.Info("scheduled task registered", "type", task.Type, "id", id, "cron", sched.Cron, "next-run", next.Format(time.RFC3339))
+	return id, nil
+}
+
+// SubmitDaemon starts a long-running daemon task in its own goroutine.
+// The handler is expected to run indefinitely; a nil return is treated as
+// unexpected completion and a non-nil return as a terminal failure. Daemon
+// tasks bypass the one-shot lock.
+func (e *Engine) SubmitDaemon(task Task, cfg DaemonConfig) (string, error) {
+	handler, ok := e.handlers[task.Type]
+	if !ok {
+		return "", fmt.Errorf("unknown task type: %s", task.Type)
+	}
+
+	id := uuid.New().String()
+	now := time.Now()
+	daemonCtx, cancel := context.WithCancel(e.ctx)
+
+	tr := &TaskResult{
+		ID:          id,
+		Type:        string(task.Type),
+		Status:      TaskStatusRunning,
+		Params:      task.Params,
+		Async:       &AsyncConfig{Daemon: &cfg},
+		SubmittedAt: now,
+	}
+
+	e.mu.Lock()
+	e.daemons[id] = &daemonEntry{result: tr, cancel: cancel}
+	e.mu.Unlock()
+
+	log.Info("daemon task started", "type", task.Type, "id", id)
+
+	go func() {
+		err := handler(daemonCtx, task.Params)
+
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		entry, ok := e.daemons[id]
+		if !ok {
+			return
+		}
+		t := time.Now()
+		entry.result.CompletedAt = &t
+		if err != nil {
+			entry.result.Error = err.Error()
+			entry.result.Status = TaskStatusFailed
+			log.Error("daemon task failed", "type", task.Type, "id", id, "err", err)
+		} else {
+			entry.result.Status = TaskStatusCompleted
+			log.Warn("daemon task returned unexpectedly", "type", task.Type, "id", id)
+		}
+	}()
+
 	return id, nil
 }
 
@@ -185,8 +253,8 @@ func (e *Engine) EvalSchedules() {
 		}
 		e.runningTasks[tr.ID] = struct{}{}
 
-		if tr.Schedule != nil && tr.Schedule.Cron != "" {
-			if next, cronErr := nextCronTime(tr.Schedule.Cron, now); cronErr == nil {
+		if tr.Async != nil && tr.Async.Schedule != nil && tr.Async.Schedule.Cron != "" {
+			if next, cronErr := nextCronTime(tr.Async.Schedule.Cron, now); cronErr == nil {
 				tr.NextRunAt = &next
 				log.Debug("scheduled task advancing", "type", tr.Type, "id", tr.ID, "next-run", next.Format(time.RFC3339))
 			}
@@ -255,12 +323,13 @@ func (e *Engine) Status() StatusResponse {
 }
 
 // RecentResults returns the most recent task results (newest first),
-// combining in-flight, completed one-shot results, and active scheduled tasks.
+// combining in-flight, completed one-shot results, scheduled tasks, and
+// daemon tasks.
 func (e *Engine) RecentResults() []TaskResult {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	cap := len(e.results) + len(e.scheduled) + 1
+	cap := len(e.results) + len(e.scheduled) + len(e.daemons) + 1
 	all := make([]TaskResult, 0, cap)
 	if e.inflight != nil {
 		all = append(all, *e.inflight)
@@ -271,6 +340,9 @@ func (e *Engine) RecentResults() []TaskResult {
 	for _, s := range e.scheduled {
 		all = append(all, *s)
 	}
+	for _, d := range e.daemons {
+		all = append(all, *d.result)
+	}
 
 	if len(all) > maxResults {
 		all = all[:maxResults]
@@ -278,7 +350,8 @@ func (e *Engine) RecentResults() []TaskResult {
 	return all
 }
 
-// GetResult returns a task by ID (in-flight, completed, or scheduled), or nil.
+// GetResult returns a task by ID (in-flight, completed, scheduled, or
+// daemon), or nil.
 func (e *Engine) GetResult(id string) *TaskResult {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -291,6 +364,10 @@ func (e *Engine) GetResult(id string) *TaskResult {
 		cp := *s
 		return &cp
 	}
+	if d, ok := e.daemons[id]; ok {
+		cp := *d.result
+		return &cp
+	}
 	for _, r := range e.results {
 		if r.ID == id {
 			cp := *r
@@ -301,13 +378,19 @@ func (e *Engine) GetResult(id string) *TaskResult {
 }
 
 // RemoveResult removes a task by ID. For scheduled tasks this stops the
-// schedule. Returns true if found.
+// schedule. For daemon tasks this cancels the goroutine's context.
+// Returns true if found.
 func (e *Engine) RemoveResult(id string) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if _, ok := e.scheduled[id]; ok {
 		delete(e.scheduled, id)
+		return true
+	}
+	if d, ok := e.daemons[id]; ok {
+		d.cancel()
+		delete(e.daemons, id)
 		return true
 	}
 	for i, r := range e.results {

--- a/sidecar/engine/engine_test.go
+++ b/sidecar/engine/engine_test.go
@@ -264,7 +264,7 @@ func TestSubmitScheduled(t *testing.T) {
 		TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
 
-	id, err := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, Schedule{Cron: "*/5 * * * *"})
+	id, err := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, ScheduleConfig{Cron: "*/5 * * * *"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -276,8 +276,8 @@ func TestSubmitScheduled(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected result for scheduled task")
 	}
-	if result.Schedule == nil || result.Schedule.Cron != "*/5 * * * *" {
-		t.Fatalf("expected cron expression in schedule, got %+v", result.Schedule)
+	if result.Async == nil || result.Async.Schedule == nil || result.Async.Schedule.Cron != "*/5 * * * *" {
+		t.Fatalf("expected cron expression in async.schedule, got %+v", result.Async)
 	}
 	if result.NextRunAt == nil {
 		t.Fatal("expected NextRunAt to be set")
@@ -289,7 +289,7 @@ func TestSubmitScheduledEmptyCron(t *testing.T) {
 		TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
 
-	_, err := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, Schedule{})
+	_, err := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, ScheduleConfig{})
 	if err == nil {
 		t.Fatal("expected error for empty schedule")
 	}
@@ -300,7 +300,7 @@ func TestRemoveScheduledTask(t *testing.T) {
 		TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
 
-	id, _ := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, Schedule{Cron: "*/5 * * * *"})
+	id, _ := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, ScheduleConfig{Cron: "*/5 * * * *"})
 
 	if !eng.RemoveResult(id) {
 		t.Fatal("expected remove to return true")
@@ -321,7 +321,7 @@ func TestEvalSchedulesFiresDueTasks(t *testing.T) {
 		},
 	})
 
-	id, _ := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, Schedule{Cron: "* * * * *"})
+	id, _ := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, ScheduleConfig{Cron: "* * * * *"})
 
 	eng.mu.Lock()
 	past := time.Now().Add(-1 * time.Minute)
@@ -352,7 +352,7 @@ func TestEvalSchedulesSkipsAlreadyRunning(t *testing.T) {
 		},
 	})
 
-	id, _ := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, Schedule{Cron: "* * * * *"})
+	id, _ := eng.SubmitScheduled(Task{Type: TaskConfigPatch}, ScheduleConfig{Cron: "* * * * *"})
 
 	eng.mu.Lock()
 	past := time.Now().Add(-1 * time.Minute)
@@ -379,6 +379,179 @@ func TestEvalSchedulesSkipsAlreadyRunning(t *testing.T) {
 	}
 
 	close(blocked)
+}
+
+// --- Daemon task tests ---
+
+func TestSubmitDaemon(t *testing.T) {
+	started := make(chan struct{})
+	blocked := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := NewEngine(ctx, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(ctx context.Context, _ map[string]any) error {
+			close(started)
+			<-blocked
+			return nil
+		},
+	})
+
+	id, err := eng.SubmitDaemon(Task{Type: TaskConfigPatch}, DaemonConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty ID")
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for daemon task to start")
+	}
+
+	result := eng.GetResult(id)
+	if result == nil {
+		t.Fatal("expected result for daemon task")
+	}
+	if result.Status != TaskStatusRunning {
+		t.Fatalf("expected status %q, got %q", TaskStatusRunning, result.Status)
+	}
+	if result.Async == nil || result.Async.Daemon == nil {
+		t.Fatal("expected async.daemon to be set")
+	}
+
+	close(blocked)
+}
+
+func TestSubmitDaemonRejectsUnknownType(t *testing.T) {
+	eng := newTestEngine(t, map[TaskType]TaskHandler{})
+
+	_, err := eng.SubmitDaemon(Task{Type: "nonexistent"}, DaemonConfig{})
+	if err == nil {
+		t.Fatal("expected error for unknown task type")
+	}
+}
+
+func TestDaemonTaskFailure(t *testing.T) {
+	handlerErr := errors.New("fatal crash")
+	eng := newTestEngine(t, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return handlerErr },
+	})
+
+	id, _ := eng.SubmitDaemon(Task{Type: TaskConfigPatch}, DaemonConfig{})
+	result := waitForResult(t, eng, id)
+
+	if result.Status != TaskStatusFailed {
+		t.Fatalf("expected status %q, got %q", TaskStatusFailed, result.Status)
+	}
+	if result.Error != handlerErr.Error() {
+		t.Fatalf("expected error %q, got %q", handlerErr.Error(), result.Error)
+	}
+}
+
+func TestDaemonTaskUnexpectedReturn(t *testing.T) {
+	eng := newTestEngine(t, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
+	})
+
+	id, _ := eng.SubmitDaemon(Task{Type: TaskConfigPatch}, DaemonConfig{})
+	result := waitForResult(t, eng, id)
+
+	if result.Status != TaskStatusCompleted {
+		t.Fatalf("expected status %q, got %q", TaskStatusCompleted, result.Status)
+	}
+}
+
+func TestRemoveDaemonTaskCancels(t *testing.T) {
+	started := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := NewEngine(ctx, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(ctx context.Context, _ map[string]any) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+
+	id, _ := eng.SubmitDaemon(Task{Type: TaskConfigPatch}, DaemonConfig{})
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for daemon task to start")
+	}
+
+	if !eng.RemoveResult(id) {
+		t.Fatal("expected remove to return true")
+	}
+	if eng.GetResult(id) != nil {
+		t.Fatal("expected nil after removal")
+	}
+}
+
+func TestDaemonDoesNotBlockOneShot(t *testing.T) {
+	bgStarted := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := NewEngine(ctx, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(ctx context.Context, _ map[string]any) error {
+			close(bgStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		TaskMarkReady: func(_ context.Context, _ map[string]any) error { return nil },
+	})
+
+	_, _ = eng.SubmitDaemon(Task{Type: TaskConfigPatch}, DaemonConfig{})
+
+	select {
+	case <-bgStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for daemon task to start")
+	}
+
+	id, err := eng.Submit(Task{Type: TaskMarkReady})
+	if err != nil {
+		t.Fatalf("one-shot should not be blocked by daemon task: %v", err)
+	}
+	waitForResult(t, eng, id)
+}
+
+func TestRecentResultsIncludesDaemon(t *testing.T) {
+	started := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	eng := NewEngine(ctx, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(ctx context.Context, _ map[string]any) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+
+	id, _ := eng.SubmitDaemon(Task{Type: TaskConfigPatch}, DaemonConfig{})
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for daemon task to start")
+	}
+
+	results := eng.RecentResults()
+	found := false
+	for _, r := range results {
+		if r.ID == id {
+			found = true
+			if r.Async == nil || r.Async.Daemon == nil {
+				t.Fatal("expected async.daemon in recent results")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected daemon task in recent results")
+	}
 }
 
 func TestContextCancellationStopsEngine(t *testing.T) {

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -40,22 +40,37 @@ const (
 	TaskStatusFailed    TaskStatus = "failed"
 )
 
-// Schedule defines when a task should recur. Exactly one field should be set.
-// Cron is supported today; BlockHeight is reserved for future use.
-type Schedule struct {
+// AsyncConfig describes asynchronous task execution. When set on a
+// TaskResult the caller did not poll for completion — the engine owns
+// the lifecycle. Exactly one field should be set.
+type AsyncConfig struct {
+	Schedule *ScheduleConfig `json:"schedule,omitempty"`
+	Daemon   *DaemonConfig   `json:"daemon,omitempty"`
+}
+
+// ScheduleConfig triggers a task on a recurring basis. Exactly one field
+// should be set. Cron is supported today; BlockHeight is reserved for
+// future use.
+type ScheduleConfig struct {
 	Cron        string `json:"cron,omitempty"`
 	BlockHeight *int64 `json:"blockHeight,omitempty"`
 }
 
-// TaskResult records a task and its outcome. Both one-shot and scheduled tasks
-// share this model. Scheduled tasks persist until deleted; one-shot results
-// are kept in a bounded history.
+// DaemonConfig marks a task as long-running. The handler runs
+// indefinitely; only an unrecoverable error produces a terminal status.
+// The struct is intentionally minimal — future fields could include
+// restart policy, health-check interval, etc.
+type DaemonConfig struct{}
+
+// TaskResult records a task and its outcome. Immediate, scheduled, and
+// daemon tasks share this model. The Async field indicates which async
+// execution mode was used (nil = immediate one-shot).
 type TaskResult struct {
 	ID          string         `json:"id"`
 	Type        string         `json:"type"`
 	Status      TaskStatus     `json:"status"`
 	Params      map[string]any `json:"params,omitempty"`
-	Schedule    *Schedule      `json:"schedule,omitempty"`
+	Async       *AsyncConfig   `json:"async,omitempty"`
 	Error       string         `json:"error,omitempty"`
 	SubmittedAt time.Time      `json:"submittedAt"`
 	CompletedAt *time.Time     `json:"completedAt,omitempty"`

--- a/sidecar/server/server.go
+++ b/sidecar/server/server.go
@@ -17,12 +17,13 @@ type Server struct {
 	mux    *http.ServeMux
 }
 
-// TaskRequest is the JSON body for POST /v0/tasks. If Schedule is set the
-// task becomes a recurring cron-triggered task; otherwise it runs immediately.
+// TaskRequest is the JSON body for POST /v0/tasks. The Async field
+// selects the execution mode: nil = immediate one-shot,
+// async.schedule = cron-triggered, async.daemon = long-running.
 type TaskRequest struct {
-	Type     string           `json:"type"`
-	Params   map[string]any   `json:"params,omitempty"`
-	Schedule *engine.Schedule `json:"schedule,omitempty"`
+	Type   string              `json:"type"`
+	Params map[string]any      `json:"params,omitempty"`
+	Async  *engine.AsyncConfig `json:"async,omitempty"`
 }
 
 // ErrorResponse is a standard JSON error envelope.
@@ -81,32 +82,41 @@ func (s *Server) handlePostTask(w http.ResponseWriter, r *http.Request) {
 
 	task := engine.Task{Type: engine.TaskType(req.Type), Params: req.Params}
 
-	if req.Schedule != nil {
-		if req.Schedule.Cron != "" {
-			if err := engine.ValidateCron(req.Schedule.Cron); err != nil {
+	switch {
+	case req.Async != nil && req.Async.Schedule != nil:
+		if req.Async.Schedule.Cron != "" {
+			if err := engine.ValidateCron(req.Async.Schedule.Cron); err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
 		}
-		id, err := s.engine.SubmitScheduled(task, *req.Schedule)
+		id, err := s.engine.SubmitScheduled(task, *req.Async.Schedule)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		writeJSON(w, http.StatusCreated, map[string]string{"id": id})
-		return
-	}
 
-	id, err := s.engine.Submit(task)
-	if err != nil {
-		if errors.Is(err, engine.ErrBusy) {
-			writeError(w, http.StatusConflict, err.Error())
+	case req.Async != nil && req.Async.Daemon != nil:
+		id, err := s.engine.SubmitDaemon(task, *req.Async.Daemon)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		writeJSON(w, http.StatusCreated, map[string]string{"id": id})
+
+	default:
+		id, err := s.engine.Submit(task)
+		if err != nil {
+			if errors.Is(err, engine.ErrBusy) {
+				writeError(w, http.StatusConflict, err.Error())
+				return
+			}
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]string{"id": id})
 	}
-	writeJSON(w, http.StatusAccepted, map[string]string{"id": id})
 }
 
 func (s *Server) handleListTasks(w http.ResponseWriter, _ *http.Request) {

--- a/sidecar/server/server_test.go
+++ b/sidecar/server/server_test.go
@@ -161,7 +161,7 @@ func TestPostTaskScheduled(t *testing.T) {
 	})
 	srv := NewServer(":0", eng)
 
-	body := `{"type":"config-patch","schedule":{"cron":"*/5 * * * *"}}`
+	body := `{"type":"config-patch","async":{"schedule":{"cron":"*/5 * * * *"}}}`
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", body)
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
@@ -208,7 +208,7 @@ func TestPostTaskInvalidSchedule(t *testing.T) {
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
 	srv := NewServer(":0", eng)
-	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch","schedule":{"cron":"not a cron"}}`)
+	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch","async":{"schedule":{"cron":"not a cron"}}}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
 	}
@@ -366,7 +366,7 @@ func TestDeleteScheduledTask(t *testing.T) {
 	})
 	srv := NewServer(":0", eng)
 
-	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch","schedule":{"cron":"*/5 * * * *"}}`)
+	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch","async":{"schedule":{"cron":"*/5 * * * *"}}}`)
 	var resp map[string]string
 	_ = json.NewDecoder(rec.Body).Decode(&resp)
 	id := resp["id"]


### PR DESCRIPTION
## Summary

- Introduces AsyncConfig (ScheduleConfig + DaemonConfig) to support cron-triggered and long-running daemon task execution alongside immediate one-shot tasks.
- Replaces the generic SubmitTask(TaskBuilder) client API with typed per-task submit methods (SubmitSnapshotRestoreTask, SubmitSnapshotUploadTask, etc.) that validate inputs and hide the map[string]any wire format from callers.
- Moves Async onto only the task structs that support it (SnapshotUploadTask, ResultExportTask), so the type system prevents invalid combinations.
- Removes the AsyncTaskBuilder wrapper in favor of setting Async directly on the task struct.
- Extends the engine with SubmitScheduled and SubmitDaemon execution paths, and updates the server to dispatch on async.schedule / async.daemon.

## Changes by layer

**Engine** (sidecar/engine/)
- types.go: AsyncConfig, ScheduleConfig, DaemonConfig; TaskResult.Async field
- engine.go: SubmitScheduled (cron goroutine), SubmitDaemon (long-running goroutine)
- engine_test.go: lifecycle, cancellation, and failure tests for all three execution modes

**Server** (sidecar/server/)
- server.go: dispatch on req.Async.Schedule and req.Async.Daemon
- server_test.go: updated JSON payloads

**Client** (sidecar/client/)
- tasks.go: Async field on SnapshotUploadTask and ResultExportTask; removed AsyncTaskBuilder
- client.go: 11 typed submit methods; SubmitRawTask renamed to SubmitTask
- sidecar.gen.go: regenerated with AsyncConfig/DaemonConfig schemas

**OpenAPI** (sidecar/api/openapi.yaml)
- Added AsyncConfig, ScheduleConfig, DaemonConfig schemas; version bumped to 0.5.0

## Test plan

- [x] go build ./... passes
- [x] go test ./sidecar/... passes (engine, server, client packages)
- [x] Typed submit methods validate and delegate correctly
- [x] Async field round-trips through ToTaskRequest() for supported task types
- [x] Async field is nil for task types that don't support it
