### PR TITLE
feat: add await-condition task with height polling and SIGTERM action

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/sei-protocol/seictl/sidecar/engine"
@@ -27,6 +29,9 @@ var serveCmd = cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		defer func() { _ = seilog.Close() }()
+
+		ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+		defer stop()
 
 		homeDir := destinations.home
 		if homeDir == "" {
@@ -51,6 +56,7 @@ var serveCmd = cli.Command{
 			engine.TaskConfigureStateSync: tasks.NewStateSyncConfigurer(homeDir, nil).Handler(),
 			engine.TaskSnapshotUpload:     tasks.NewSnapshotUploader(homeDir, nil).Handler(),
 			engine.TaskResultExport:       tasks.NewResultExporter(homeDir, nil).Handler(),
+			engine.TaskAwaitCondition:     tasks.NewConditionWaiter(nil).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers)

--- a/sidecar/actions/process.go
+++ b/sidecar/actions/process.go
@@ -1,0 +1,146 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sei-protocol/seilog"
+)
+
+var logger = seilog.NewLogger("seictl", "actions")
+
+const (
+	DefaultGracePeriod = 30 * time.Second
+	exitPollInterval   = 100 * time.Millisecond
+)
+
+// ProcessSignaler abstracts process discovery and signaling for testability.
+type ProcessSignaler interface {
+	FindPID(processName string) (int, error)
+	Signal(pid int, sig syscall.Signal) error
+	Alive(pid int) bool
+}
+
+// FindPID scans /proc for a process whose argv[0] matches processName.
+// Requires shareProcessNamespace: true in the Kubernetes pod spec.
+func FindPID(processName string) (int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, fmt.Errorf("reading /proc: %w", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+		if err != nil || len(cmdline) == 0 {
+			continue
+		}
+		exe := firstArg(cmdline)
+		if exe == processName || strings.HasSuffix(exe, "/"+processName) {
+			return pid, nil
+		}
+	}
+	return 0, fmt.Errorf("process %q not found in /proc", processName)
+}
+
+// SignalPID sends a signal to the given process.
+func SignalPID(pid int, sig syscall.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(sig)
+}
+
+// PIDAlive returns true if the process is still running.
+func PIDAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// isProcessGone returns true if the error indicates the process no longer exists.
+func isProcessGone(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
+}
+
+// GracefulStop sends SIGTERM to the named process, waits up to
+// gracePeriod for it to exit, then escalates to SIGKILL.
+// When signaler is nil the package-level functions are used directly.
+func GracefulStop(ctx context.Context, signaler ProcessSignaler, processName string, gracePeriod time.Duration) error {
+	findPID := FindPID
+	signal := SignalPID
+	alive := PIDAlive
+	if signaler != nil {
+		findPID = signaler.FindPID
+		signal = signaler.Signal
+		alive = signaler.Alive
+	}
+
+	pid, err := findPID(processName)
+	if err != nil {
+		if isProcessGone(err) {
+			logger.Info("process already exited", "process", processName)
+			return nil
+		}
+		return fmt.Errorf("finding %s process: %w", processName, err)
+	}
+	logger.Info("sending SIGTERM", "process", processName, "pid", pid)
+
+	if err := signal(pid, syscall.SIGTERM); err != nil {
+		if isProcessGone(err) {
+			logger.Info("process exited before SIGTERM delivered", "process", processName, "pid", pid)
+			return nil
+		}
+		return fmt.Errorf("sending SIGTERM to pid %d: %w", pid, err)
+	}
+
+	ticker := time.NewTicker(exitPollInterval)
+	defer ticker.Stop()
+	deadline := time.After(gracePeriod)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			logger.Warn("process did not exit after SIGTERM, sending SIGKILL", "process", processName, "pid", pid)
+			if err := signal(pid, syscall.SIGKILL); err != nil {
+				if isProcessGone(err) {
+					logger.Info("process exited before SIGKILL delivered", "process", processName, "pid", pid)
+					return nil
+				}
+				return fmt.Errorf("sending SIGKILL to pid %d: %w", pid, err)
+			}
+			logger.Info("SIGKILL sent", "process", processName, "pid", pid)
+			return nil
+		case <-ticker.C:
+			if !alive(pid) {
+				logger.Info("process exited after SIGTERM", "process", processName, "pid", pid)
+				return nil
+			}
+		}
+	}
+}
+
+func firstArg(cmdline []byte) string {
+	for i, c := range cmdline {
+		if c == 0 {
+			return string(cmdline[:i])
+		}
+	}
+	return string(cmdline)
+}

--- a/sidecar/actions/process_test.go
+++ b/sidecar/actions/process_test.go
@@ -1,0 +1,174 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type mockSignaler struct {
+	findPID   int
+	findErr   error
+	signalFn  func(pid int, sig syscall.Signal) error
+	signalErr error
+	alive     atomic.Bool
+	signals   []syscall.Signal
+}
+
+func (m *mockSignaler) FindPID(string) (int, error) { return m.findPID, m.findErr }
+
+func (m *mockSignaler) Signal(pid int, sig syscall.Signal) error {
+	m.signals = append(m.signals, sig)
+	if m.signalFn != nil {
+		return m.signalFn(pid, sig)
+	}
+	return m.signalErr
+}
+
+func (m *mockSignaler) Alive(int) bool { return m.alive.Load() }
+
+func TestGracefulStop_ImmediateExit(t *testing.T) {
+	sig := &mockSignaler{findPID: 42}
+	sig.alive.Store(false)
+
+	if err := GracefulStop(context.Background(), sig, "seid", time.Second); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(sig.signals) != 1 || sig.signals[0] != syscall.SIGTERM {
+		t.Errorf("expected single SIGTERM, got %v", sig.signals)
+	}
+}
+
+func TestGracefulStop_EscalatesToSIGKILL(t *testing.T) {
+	sig := &mockSignaler{findPID: 42}
+	sig.alive.Store(true)
+
+	if err := GracefulStop(context.Background(), sig, "seid", 200*time.Millisecond); err != nil {
+		t.Fatalf("expected success after SIGKILL, got %v", err)
+	}
+	if len(sig.signals) < 2 {
+		t.Fatalf("expected >= 2 signals, got %d", len(sig.signals))
+	}
+	if sig.signals[0] != syscall.SIGTERM {
+		t.Errorf("first signal: expected SIGTERM, got %v", sig.signals[0])
+	}
+	if sig.signals[len(sig.signals)-1] != syscall.SIGKILL {
+		t.Errorf("last signal: expected SIGKILL, got %v", sig.signals[len(sig.signals)-1])
+	}
+}
+
+func TestGracefulStop_FindPIDError(t *testing.T) {
+	sig := &mockSignaler{findErr: fmt.Errorf("not found")}
+	if err := GracefulStop(context.Background(), sig, "seid", time.Second); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGracefulStop_FindPIDProcessGone(t *testing.T) {
+	sig := &mockSignaler{findErr: syscall.ESRCH}
+	err := GracefulStop(context.Background(), sig, "seid", time.Second)
+	if err != nil {
+		t.Fatalf("expected success when process already gone, got %v", err)
+	}
+	if len(sig.signals) != 0 {
+		t.Errorf("expected no signals sent, got %v", sig.signals)
+	}
+}
+
+func TestGracefulStop_SIGTERMProcessGone(t *testing.T) {
+	sig := &mockSignaler{
+		findPID: 42,
+		signalFn: func(_ int, s syscall.Signal) error {
+			if s == syscall.SIGTERM {
+				return os.ErrProcessDone
+			}
+			return nil
+		},
+	}
+	err := GracefulStop(context.Background(), sig, "seid", time.Second)
+	if err != nil {
+		t.Fatalf("expected success when process exited before SIGTERM, got %v", err)
+	}
+}
+
+func TestGracefulStop_SIGKILLProcessGone(t *testing.T) {
+	sig := &mockSignaler{
+		findPID: 42,
+		signalFn: func(_ int, s syscall.Signal) error {
+			if s == syscall.SIGKILL {
+				return syscall.ESRCH
+			}
+			return nil
+		},
+	}
+	sig.alive.Store(true)
+
+	err := GracefulStop(context.Background(), sig, "seid", 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected success when process exited before SIGKILL, got %v", err)
+	}
+}
+
+func TestGracefulStop_SignalError(t *testing.T) {
+	sig := &mockSignaler{findPID: 42, signalErr: fmt.Errorf("permission denied")}
+	if err := GracefulStop(context.Background(), sig, "seid", time.Second); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGracefulStop_ContextCancellation(t *testing.T) {
+	sig := &mockSignaler{findPID: 42}
+	sig.alive.Store(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := GracefulStop(ctx, sig, "seid", 10*time.Second)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestFirstArg(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  []byte
+		expected string
+	}{
+		{"null delimited", []byte("seid\x00start\x00--home\x00/sei"), "seid"},
+		{"no null byte", []byte("seid"), "seid"},
+		{"full path", []byte("/usr/bin/seid\x00start"), "/usr/bin/seid"},
+		{"null at start", []byte("\x00rest"), ""},
+		{"empty", []byte{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstArg(tt.cmdline)
+			if got != tt.expected {
+				t.Errorf("firstArg(%q) = %q, want %q", tt.cmdline, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsProcessGone(t *testing.T) {
+	if !isProcessGone(os.ErrProcessDone) {
+		t.Error("expected ErrProcessDone to be recognized")
+	}
+	if !isProcessGone(syscall.ESRCH) {
+		t.Error("expected ESRCH to be recognized")
+	}
+	if isProcessGone(fmt.Errorf("something else")) {
+		t.Error("expected generic error to not be recognized")
+	}
+	if isProcessGone(nil) {
+		t.Error("expected nil to not be recognized")
+	}
+}

--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: sei-sidecar API
   description: HTTP API for the sei-sidecar task executor.
-  version: 0.5.0
+  version: 0.6.0
   license:
     name: Apache-2.0
 

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -30,6 +30,13 @@ const (
 	TaskTypeConfigureStateSync = string(engine.TaskConfigureStateSync)
 	TaskTypeSnapshotUpload     = string(engine.TaskSnapshotUpload)
 	TaskTypeResultExport       = string(engine.TaskResultExport)
+	TaskTypeAwaitCondition     = string(engine.TaskAwaitCondition)
+)
+
+// Known condition and action values for AwaitConditionTask.
+const (
+	ConditionHeight = "height"
+	ActionSIGTERM   = "SIGTERM_SEID"
 )
 
 // SnapshotRestoreTask downloads and extracts a snapshot archive from S3.
@@ -511,4 +518,41 @@ func ResultExportTaskFromParams(params map[string]interface{}) ResultExportTask 
 		Prefix: s("prefix"),
 		Region: s("region"),
 	}
+}
+
+// AwaitConditionTask blocks until a condition is met, then optionally
+// executes a post-condition action. Currently supports the "height"
+// condition and the "SIGTERM_SEID" action.
+type AwaitConditionTask struct {
+	Condition    string
+	TargetHeight int64
+	Action       string
+}
+
+func (t AwaitConditionTask) TaskType() string { return TaskTypeAwaitCondition }
+
+func (t AwaitConditionTask) Validate() error {
+	switch t.Condition {
+	case ConditionHeight:
+		if t.TargetHeight <= 0 {
+			return fmt.Errorf("await-condition: height condition requires TargetHeight > 0")
+		}
+	default:
+		return fmt.Errorf("await-condition: unknown condition %q", t.Condition)
+	}
+	if t.Action != "" && t.Action != ActionSIGTERM {
+		return fmt.Errorf("await-condition: unknown action %q", t.Action)
+	}
+	return nil
+}
+
+func (t AwaitConditionTask) ToTaskRequest() TaskRequest {
+	p := map[string]interface{}{
+		"condition":    t.Condition,
+		"targetHeight": t.TargetHeight,
+	}
+	if t.Action != "" {
+		p["action"] = t.Action
+	}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
 }

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -644,3 +644,96 @@ func TestResultExportTask_WithSchedule(t *testing.T) {
 		t.Errorf("schedule.cron = %q, want %q", *req.Schedule.Cron, cron)
 	}
 }
+
+func TestAwaitConditionValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		task AwaitConditionTask
+		ok   bool
+	}{
+		{"valid height", AwaitConditionTask{Condition: ConditionHeight, TargetHeight: 1000}, true},
+		{"valid height with action", AwaitConditionTask{Condition: ConditionHeight, TargetHeight: 1000, Action: ActionSIGTERM}, true},
+		{"zero height", AwaitConditionTask{Condition: ConditionHeight, TargetHeight: 0}, false},
+		{"negative height", AwaitConditionTask{Condition: ConditionHeight, TargetHeight: -1}, false},
+		{"unknown condition", AwaitConditionTask{Condition: "foo", TargetHeight: 1000}, false},
+		{"empty condition", AwaitConditionTask{TargetHeight: 1000}, false},
+		{"unknown action", AwaitConditionTask{Condition: ConditionHeight, TargetHeight: 1000, Action: "BAD"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.task.Validate()
+			if tc.ok && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Error("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+func TestAwaitConditionToTaskRequest(t *testing.T) {
+	task := AwaitConditionTask{
+		Condition:    ConditionHeight,
+		TargetHeight: 5000,
+		Action:       ActionSIGTERM,
+	}
+	req := task.ToTaskRequest()
+	if req.Type != TaskTypeAwaitCondition {
+		t.Errorf("Type = %q, want %q", req.Type, TaskTypeAwaitCondition)
+	}
+	if req.Params == nil {
+		t.Fatal("expected non-nil Params")
+	}
+	p := *req.Params
+	if p["condition"] != ConditionHeight {
+		t.Errorf("condition = %v, want %q", p["condition"], ConditionHeight)
+	}
+	if p["targetHeight"] != int64(5000) {
+		t.Errorf("targetHeight = %v, want 5000", p["targetHeight"])
+	}
+	if p["action"] != ActionSIGTERM {
+		t.Errorf("action = %v, want %q", p["action"], ActionSIGTERM)
+	}
+}
+
+func TestAwaitConditionToTaskRequest_NoAction(t *testing.T) {
+	task := AwaitConditionTask{
+		Condition:    ConditionHeight,
+		TargetHeight: 100,
+	}
+	req := task.ToTaskRequest()
+	p := *req.Params
+	if _, ok := p["action"]; ok {
+		t.Errorf("expected action to be absent, got %v", p["action"])
+	}
+}
+
+func TestAwaitConditionJSONRoundTrip(t *testing.T) {
+	task := AwaitConditionTask{
+		Condition:    ConditionHeight,
+		TargetHeight: 8000,
+		Action:       ActionSIGTERM,
+	}
+	req := task.ToTaskRequest()
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded TaskRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.Type != TaskTypeAwaitCondition {
+		t.Errorf("decoded Type = %q, want %q", decoded.Type, TaskTypeAwaitCondition)
+	}
+	p := *decoded.Params
+	if p["condition"] != ConditionHeight {
+		t.Errorf("condition = %v, want %q", p["condition"], ConditionHeight)
+	}
+	// JSON numbers decode as float64.
+	if p["targetHeight"] != float64(8000) {
+		t.Errorf("targetHeight = %v (type %T), want 8000", p["targetHeight"], p["targetHeight"])
+	}
+}

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -20,6 +20,7 @@ const (
 	TaskConfigureStateSync TaskType = "configure-state-sync"
 	TaskSnapshotUpload     TaskType = "snapshot-upload"
 	TaskResultExport       TaskType = "result-export"
+	TaskAwaitCondition     TaskType = "await-condition"
 )
 
 // Task is a unit of work submitted by the controller.

--- a/sidecar/rpc/status.go
+++ b/sidecar/rpc/status.go
@@ -1,0 +1,100 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	seiconfig "github.com/sei-protocol/sei-config"
+)
+
+// DefaultEndpoint is the local CometBFT RPC address.
+var DefaultEndpoint = fmt.Sprintf("http://localhost:%d", seiconfig.PortRPC)
+
+const defaultRequestTimeout = 500 * time.Millisecond
+
+// StatusClient queries a CometBFT node's /status endpoint.
+type StatusClient struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// NodeStatus holds the fields we care about from CometBFT /status.
+type NodeStatus struct {
+	LatestBlockHeight int64
+	CatchingUp        bool
+}
+
+// Endpoint returns the configured RPC endpoint.
+func (c *StatusClient) Endpoint() string { return c.endpoint }
+
+type statusResponse struct {
+	Result struct {
+		SyncInfo struct {
+			LatestBlockHeight string `json:"latest_block_height"`
+			CatchingUp        bool   `json:"catching_up"`
+		} `json:"sync_info"`
+	} `json:"result"`
+}
+
+// NewStatusClient creates a client targeting the given RPC endpoint.
+// Pass "" for the default localhost endpoint.
+func NewStatusClient(endpoint string, httpClient *http.Client) *StatusClient {
+	if endpoint == "" {
+		endpoint = DefaultEndpoint
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	return &StatusClient{endpoint: endpoint, httpClient: httpClient}
+}
+
+// Status queries the node and returns the parsed status.
+func (c *StatusClient) Status(ctx context.Context) (*NodeStatus, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/status", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var rpcResp statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return nil, fmt.Errorf("decoding /status: %w", err)
+	}
+
+	h, err := strconv.ParseInt(rpcResp.Result.SyncInfo.LatestBlockHeight, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parsing latest_block_height %q: %w", rpcResp.Result.SyncInfo.LatestBlockHeight, err)
+	}
+
+	return &NodeStatus{
+		LatestBlockHeight: h,
+		CatchingUp:        rpcResp.Result.SyncInfo.CatchingUp,
+	}, nil
+}
+
+// LatestHeight is a convenience wrapper returning just the height.
+func (c *StatusClient) LatestHeight(ctx context.Context) (int64, error) {
+	s, err := c.Status(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return s.LatestBlockHeight, nil
+}

--- a/sidecar/rpc/status_test.go
+++ b/sidecar/rpc/status_test.go
@@ -1,0 +1,106 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStatusClient_LatestHeight(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":{"sync_info":{"latest_block_height":"12345","catching_up":false}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewStatusClient(srv.URL, nil)
+	h, err := c.LatestHeight(context.Background())
+	if err != nil {
+		t.Fatalf("LatestHeight: %v", err)
+	}
+	if h != 12345 {
+		t.Errorf("height = %d, want 12345", h)
+	}
+}
+
+func TestStatusClient_CatchingUp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":{"sync_info":{"latest_block_height":"100","catching_up":true}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewStatusClient(srv.URL, nil)
+	s, err := c.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !s.CatchingUp {
+		t.Error("expected CatchingUp=true")
+	}
+}
+
+func TestStatusClient_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	c := NewStatusClient(srv.URL, nil)
+	_, err := c.LatestHeight(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestStatusClient_ConnectionRefused(t *testing.T) {
+	c := NewStatusClient("http://127.0.0.1:1", nil)
+	_, err := c.LatestHeight(context.Background())
+	if err == nil {
+		t.Fatal("expected error for refused connection")
+	}
+}
+
+func TestStatusClient_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	c := NewStatusClient(srv.URL, nil)
+	_, err := c.LatestHeight(context.Background())
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestStatusClient_InvalidBlockHeight(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"empty height", `{"result":{"sync_info":{"latest_block_height":"","catching_up":false}}}`},
+		{"non-numeric height", `{"result":{"sync_info":{"latest_block_height":"abc","catching_up":false}}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.payload))
+			}))
+			defer srv.Close()
+
+			c := NewStatusClient(srv.URL, nil)
+			_, err := c.LatestHeight(context.Background())
+			if err == nil {
+				t.Fatal("expected error for invalid block height")
+			}
+		})
+	}
+}
+
+func TestStatusClient_DefaultEndpoint(t *testing.T) {
+	c := NewStatusClient("", nil)
+	if c.Endpoint() != DefaultEndpoint {
+		t.Errorf("endpoint = %q, want %q", c.Endpoint(), DefaultEndpoint)
+	}
+}

--- a/sidecar/tasks/await_condition.go
+++ b/sidecar/tasks/await_condition.go
@@ -1,0 +1,140 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/sei-protocol/seictl/sidecar/actions"
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seictl/sidecar/rpc"
+	"github.com/sei-protocol/seilog"
+)
+
+var awaitLog = seilog.NewLogger("seictl", "task", "await-condition")
+
+const (
+	conditionHeight = "height"
+	actionSIGTERM   = "SIGTERM_SEID"
+
+	heightPollInterval = 100 * time.Millisecond
+)
+
+// ConditionWaiter polls a local node until a condition is met, then
+// optionally executes a post-condition action.
+type ConditionWaiter struct {
+	rpc *rpc.StatusClient
+}
+
+// NewConditionWaiter creates a ConditionWaiter. Pass nil for the default RPC client.
+func NewConditionWaiter(rpcClient *rpc.StatusClient) *ConditionWaiter {
+	if rpcClient == nil {
+		rpcClient = rpc.NewStatusClient("", nil)
+	}
+	return &ConditionWaiter{rpc: rpcClient}
+}
+
+// Handler returns an engine.TaskHandler for the await-condition task type.
+func (w *ConditionWaiter) Handler() engine.TaskHandler {
+	return func(ctx context.Context, params map[string]any) error {
+		condition, ok := params["condition"].(string)
+		if !ok || condition == "" {
+			return fmt.Errorf("condition is required (got %T)", params["condition"])
+		}
+		action, _ := params["action"].(string)
+
+		switch condition {
+		case conditionHeight:
+			if err := w.awaitHeight(ctx, params); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown condition %q", condition)
+		}
+
+		if action == "" {
+			return nil
+		}
+		return w.executeAction(ctx, action)
+	}
+}
+
+func (w *ConditionWaiter) awaitHeight(ctx context.Context, params map[string]any) error {
+	targetHeight, err := parseTargetHeight(params)
+	if err != nil {
+		return err
+	}
+
+	awaitLog.Info("awaiting height", "target", targetHeight, "rpc", w.rpc.Endpoint())
+
+	var rpcHealthy bool
+	var loggedInitialWait bool
+	ticker := time.NewTicker(heightPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+
+		height, err := w.rpc.LatestHeight(ctx)
+		if err != nil {
+			if rpcHealthy {
+				awaitLog.Warn("rpc became unavailable", "err", err)
+				rpcHealthy = false
+			} else if !loggedInitialWait {
+				awaitLog.Info("waiting for rpc to become available", "err", err)
+				loggedInitialWait = true
+			}
+			continue
+		}
+		if !rpcHealthy {
+			awaitLog.Info("rpc available", "height", height)
+			rpcHealthy = true
+		}
+
+		if height >= targetHeight {
+			awaitLog.Info("target height reached", "current", height, "target", targetHeight)
+			return nil
+		}
+	}
+}
+
+func parseTargetHeight(params map[string]any) (int64, error) {
+	switch v := params["targetHeight"].(type) {
+	case float64:
+		h := int64(v)
+		if h <= 0 {
+			return 0, fmt.Errorf("targetHeight must be > 0, got %d", h)
+		}
+		return h, nil
+	case int64:
+		if v <= 0 {
+			return 0, fmt.Errorf("targetHeight must be > 0, got %d", v)
+		}
+		return v, nil
+	case json.Number:
+		h, err := v.Int64()
+		if err != nil {
+			return 0, fmt.Errorf("parsing targetHeight: %w", err)
+		}
+		if h <= 0 {
+			return 0, fmt.Errorf("targetHeight must be > 0, got %d", h)
+		}
+		return h, nil
+	default:
+		return 0, fmt.Errorf("targetHeight is required (got %T)", params["targetHeight"])
+	}
+}
+
+func (w *ConditionWaiter) executeAction(ctx context.Context, action string) error {
+	switch action {
+	case actionSIGTERM:
+		return actions.GracefulStop(ctx, nil, "seid", actions.DefaultGracePeriod)
+	default:
+		return fmt.Errorf("unknown action %q", action)
+	}
+}

--- a/sidecar/tasks/await_condition_test.go
+++ b/sidecar/tasks/await_condition_test.go
@@ -1,0 +1,251 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/seictl/sidecar/rpc"
+)
+
+// heightServer returns an httptest.Server that serves a height sequence.
+// After the sequence is exhausted it keeps returning the last value.
+func heightServer(heights ...int64) *httptest.Server {
+	var mu sync.Mutex
+	idx := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		i := idx
+		if i < len(heights)-1 {
+			idx++
+		}
+		mu.Unlock()
+		fmt.Fprintf(w, `{"result":{"sync_info":{"latest_block_height":"%d","catching_up":false}}}`, heights[i])
+	}))
+}
+
+func rpcClient(url string) *rpc.StatusClient {
+	return rpc.NewStatusClient(url, nil)
+}
+
+func TestAwaitHeight_ReachesTarget(t *testing.T) {
+	srv := heightServer(100, 200, 500)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(500),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := handler(ctx, params); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestAwaitHeight_AlreadyPastTarget(t *testing.T) {
+	srv := heightServer(1000)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(500),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := handler(ctx, params); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestAwaitHeight_MissingTargetHeight(t *testing.T) {
+	srv := heightServer(100)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{"condition": "height"}
+	if err := handler(context.Background(), params); err == nil {
+		t.Fatal("expected error for missing targetHeight")
+	}
+}
+
+func TestAwaitHeight_ZeroTargetHeight(t *testing.T) {
+	srv := heightServer(100)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(0),
+	}
+	if err := handler(context.Background(), params); err == nil {
+		t.Fatal("expected error for zero targetHeight")
+	}
+}
+
+func TestAwaitHeight_NegativeTargetHeight(t *testing.T) {
+	srv := heightServer(100)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(-5),
+	}
+	if err := handler(context.Background(), params); err == nil {
+		t.Fatal("expected error for negative targetHeight")
+	}
+}
+
+func TestAwaitHeight_TransientRPCErrors(t *testing.T) {
+	errSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer errSrv.Close()
+
+	goodSrv := heightServer(500)
+	defer goodSrv.Close()
+
+	var mu sync.Mutex
+	calls := 0
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		var target string
+		if n <= 2 {
+			target = errSrv.URL
+		} else {
+			target = goodSrv.URL
+		}
+		resp, err := http.Get(target + r.URL.Path)
+		if err != nil {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		w.WriteHeader(resp.StatusCode)
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				_, _ = w.Write(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+	}))
+	defer proxy.Close()
+
+	handler := NewConditionWaiter(rpcClient(proxy.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(500),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := handler(ctx, params); err != nil {
+		t.Fatalf("expected success after transient errors, got %v", err)
+	}
+}
+
+func TestAwaitHeight_ContextCancellation(t *testing.T) {
+	srv := heightServer(100)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(99999),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := handler(ctx, params)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestAwaitHeight_MissingCondition(t *testing.T) {
+	handler := NewConditionWaiter(rpcClient("http://unused")).Handler()
+	params := map[string]any{}
+	if err := handler(context.Background(), params); err == nil {
+		t.Fatal("expected error for missing condition")
+	}
+}
+
+func TestAwaitHeight_UnknownCondition(t *testing.T) {
+	handler := NewConditionWaiter(rpcClient("http://unused")).Handler()
+	params := map[string]any{"condition": "unknown"}
+	if err := handler(context.Background(), params); err == nil {
+		t.Fatal("expected error for unknown condition")
+	}
+}
+
+func TestAwaitHeight_UnknownAction(t *testing.T) {
+	srv := heightServer(500)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(500),
+		"action":       "UNKNOWN",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := handler(ctx, params); err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+}
+
+func TestAwaitHeight_Int64TargetHeight(t *testing.T) {
+	srv := heightServer(1000)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": int64(500),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := handler(ctx, params); err != nil {
+		t.Fatalf("expected success with int64 targetHeight, got %v", err)
+	}
+}
+
+func TestAwaitHeight_JSONNumberTargetHeight(t *testing.T) {
+	srv := heightServer(5000)
+	defer srv.Close()
+
+	handler := NewConditionWaiter(rpcClient(srv.URL)).Handler()
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": json.Number("5000"),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := handler(ctx, params); err != nil {
+		t.Fatalf("expected success with json.Number targetHeight, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `await-condition` task type for the PreInitPlan bootstrap flow. The sidecar polls the local CometBFT `/status` RPC at 100ms intervals until `latest_block_height >= targetHeight`, then optionally sends SIGTERM to `seid` with SIGKILL escalation after 30s.
- Introduces `sidecar/rpc` package (`StatusClient` for CometBFT status queries) and `sidecar/actions` package (process discovery via `/proc` and `GracefulStop` with context cancellation and `isProcessGone` handling).
- Adds `signal.NotifyContext` to the serve command for graceful sidecar shutdown on pod termination.

## New packages

| Package | Purpose |
|---------|---------|
| `sidecar/rpc` | CometBFT `/status` RPC client (500ms context timeout, no competing `http.Client` timeout) |
| `sidecar/actions` | Process discovery (`/proc` scanning, requires `shareProcessNamespace: true`) and graceful stop orchestration |

## Kubernetes notes

- Pod spec must set `shareProcessNamespace: true` and `restartPolicy: Never`
- `terminationGracePeriodSeconds` should exceed `DefaultGracePeriod` (30s) to allow the sidecar to serve the final task status
- Containers must share the same UID or seictl needs `CAP_KILL`
- `seid` must be launched directly (not via shell wrapper) for `/proc/*/cmdline` matching

## Test plan

- [x] Height polling: reaches target, already past target, transient RPC errors, context cancellation
- [x] Input validation: missing/unknown condition, zero/negative/missing targetHeight, unknown action
- [x] Target height parsing: float64, int64, json.Number
- [x] GracefulStop: immediate exit, SIGKILL escalation, context cancellation
- [x] Process-gone handling: ESRCH on FindPID, ErrProcessDone on SIGTERM, ESRCH on SIGKILL
- [x] firstArg /proc cmdline parsing edge cases
- [x] StatusClient: happy path, catching up, HTTP errors, connection refused, malformed JSON, invalid block height
- [x] AwaitConditionTask client: validation, ToTaskRequest, JSON round-trip