### PR TITLE
fix: harden sidecar client -- 202 support, UUID validation, typed AwaitCondition

### DIFF
--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -53,6 +53,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TaskSubmitResponse"
+        "202":
+          description: Task accepted (completed synchronously or deduplicated).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskSubmitResponse"
         "400":
           description: Invalid request.
           content:

--- a/sidecar/client/client.go
+++ b/sidecar/client/client.go
@@ -95,21 +95,38 @@ func (c *SidecarClient) Status(ctx context.Context) (*StatusResponse, error) {
 func (c *SidecarClient) SubmitTask(ctx context.Context, task TaskRequest) (uuid.UUID, error) {
 	resp, err := c.inner.SubmitTaskWithResponse(ctx, task)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("submitting task to sidecar: %w", err)
+		return uuid.Nil, fmt.Errorf("submitting %s task to sidecar: %w", task.Type, err)
 	}
+
 	switch resp.StatusCode() {
 	case http.StatusCreated:
 		if resp.JSON201 == nil {
 			return uuid.Nil, fmt.Errorf("sidecar returned 201 but no task ID in response body")
 		}
-		return resp.JSON201.Id, nil
+		id := resp.JSON201.Id
+		if id == uuid.Nil {
+			return uuid.Nil, fmt.Errorf("sidecar returned 201 with nil task ID")
+		}
+		return id, nil
+
+	case http.StatusAccepted:
+		if resp.JSON202 == nil {
+			return uuid.Nil, fmt.Errorf("sidecar returned 202 but no task ID in response body")
+		}
+		id := resp.JSON202.Id
+		if id == uuid.Nil {
+			return uuid.Nil, fmt.Errorf("sidecar returned 202 with nil task ID")
+		}
+		return id, nil
+
 	case http.StatusBadRequest:
 		if resp.JSON400 != nil {
-			return uuid.Nil, fmt.Errorf("sidecar rejected task: %s", resp.JSON400.Error)
+			return uuid.Nil, fmt.Errorf("sidecar rejected %s task: %s", task.Type, resp.JSON400.Error)
 		}
-		return uuid.Nil, fmt.Errorf("sidecar rejected task: %s", bytes.TrimSpace(resp.Body))
+		return uuid.Nil, fmt.Errorf("sidecar rejected %s task: %s", task.Type, bytes.TrimSpace(resp.Body))
+
 	default:
-		return uuid.Nil, fmt.Errorf("sidecar task submission returned %d: %s", resp.StatusCode(), bytes.TrimSpace(resp.Body))
+		return uuid.Nil, fmt.Errorf("sidecar %s task submission returned %d: %s", task.Type, resp.StatusCode(), bytes.TrimSpace(resp.Body))
 	}
 }
 
@@ -123,7 +140,7 @@ func (c *SidecarClient) ListTasks(ctx context.Context) ([]TaskResult, error) {
 		return nil, fmt.Errorf("sidecar list tasks returned %d: %s", resp.StatusCode(), bytes.TrimSpace(resp.Body))
 	}
 	if resp.JSON200 == nil {
-		return nil, nil
+		return []TaskResult{}, nil
 	}
 	return *resp.JSON200, nil
 }
@@ -257,6 +274,13 @@ func (c *SidecarClient) SubmitConfigureStateSyncTask(ctx context.Context, task C
 }
 
 func (c *SidecarClient) SubmitResultExportTask(ctx context.Context, task ResultExportTask) (uuid.UUID, error) {
+	if err := task.Validate(); err != nil {
+		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
+	}
+	return c.SubmitTask(ctx, task.ToTaskRequest())
+}
+
+func (c *SidecarClient) SubmitAwaitConditionTask(ctx context.Context, task AwaitConditionTask) (uuid.UUID, error) {
 	if err := task.Validate(); err != nil {
 		return uuid.Nil, fmt.Errorf("task validation failed: %w", err)
 	}

--- a/sidecar/client/client_test.go
+++ b/sidecar/client/client_test.go
@@ -52,7 +52,7 @@ func TestStatus_ServerError(t *testing.T) {
 	}
 }
 
-func TestSubmitTask_Accepted(t *testing.T) {
+func TestSubmitTask_HTTP201(t *testing.T) {
 	taskID := uuid.New()
 	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v0/tasks" || r.Method != http.MethodPost {
@@ -89,6 +89,96 @@ func TestSubmitTask_Accepted(t *testing.T) {
 	}
 	if id != taskID {
 		t.Errorf("returned id = %s, want %s", id, taskID)
+	}
+}
+
+func TestSubmitTask_HTTP202(t *testing.T) {
+	taskID := uuid.New()
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(TaskSubmitResponse{Id: taskID})
+	}))
+
+	id, err := c.SubmitTask(context.Background(), TaskRequest{Type: TaskTypeMarkReady})
+	if err != nil {
+		t.Fatalf("SubmitTask() error = %v", err)
+	}
+	if id != taskID {
+		t.Errorf("returned id = %s, want %s", id, taskID)
+	}
+}
+
+func TestSubmitTask_HTTP202_MalformedBody(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+
+	_, err := c.SubmitTask(context.Background(), TaskRequest{Type: TaskTypeMarkReady})
+	if err == nil {
+		t.Fatal("expected error for malformed 202 body")
+	}
+}
+
+func TestSubmitTask_HTTP202_NilUUID(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(TaskSubmitResponse{Id: uuid.Nil})
+	}))
+
+	_, err := c.SubmitTask(context.Background(), TaskRequest{Type: TaskTypeMarkReady})
+	if err == nil {
+		t.Fatal("expected error for nil UUID in 202 response")
+	}
+	if !strings.Contains(err.Error(), "nil task ID") {
+		t.Errorf("error = %v, expected to contain 'nil task ID'", err)
+	}
+}
+
+func TestSubmitTask_HTTP201_NilUUID(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(TaskSubmitResponse{Id: uuid.Nil})
+	}))
+
+	_, err := c.SubmitTask(context.Background(), TaskRequest{Type: TaskTypeMarkReady})
+	if err == nil {
+		t.Fatal("expected error for nil UUID in 201 response")
+	}
+	if !strings.Contains(err.Error(), "nil task ID") {
+		t.Errorf("error = %v, expected to contain 'nil task ID'", err)
+	}
+}
+
+func TestSubmitTask_ServerError(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+
+	_, err := c.SubmitTask(context.Background(), TaskRequest{Type: TaskTypeMarkReady})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %v, expected to contain '500'", err)
+	}
+}
+
+func TestSubmitTask_Conflict(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "conflict", http.StatusConflict)
+	}))
+
+	_, err := c.SubmitTask(context.Background(), TaskRequest{Type: TaskTypeMarkReady})
+	if err == nil {
+		t.Fatal("expected error for 409 response")
+	}
+	if !strings.Contains(err.Error(), "409") {
+		t.Errorf("error = %v, expected to contain '409'", err)
 	}
 }
 
@@ -136,6 +226,9 @@ func TestSubmitTask_BadRequest(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown task type") {
 		t.Errorf("error = %v, expected to contain 'unknown task type'", err)
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error = %v, expected to contain the task type 'invalid'", err)
 	}
 }
 
@@ -297,5 +390,86 @@ func TestNewSidecarClientFromPodDNS_DefaultPort(t *testing.T) {
 	want := "http://mynode-0.mynode.prod.svc.cluster.local:7777/"
 	if inner.Server != want {
 		t.Errorf("Server = %q, want %q", inner.Server, want)
+	}
+}
+
+func TestSubmitAwaitConditionTask(t *testing.T) {
+	taskID := uuid.New()
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req TaskRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if req.Type != TaskTypeAwaitCondition {
+			t.Errorf("Type = %q, want %q", req.Type, TaskTypeAwaitCondition)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(TaskSubmitResponse{Id: taskID})
+	}))
+
+	id, err := c.SubmitAwaitConditionTask(context.Background(), AwaitConditionTask{
+		Condition:    ConditionHeight,
+		TargetHeight: 1000,
+		Action:       ActionSIGTERM,
+	})
+	if err != nil {
+		t.Fatalf("SubmitAwaitConditionTask() error = %v", err)
+	}
+	if id != taskID {
+		t.Errorf("returned id = %s, want %s", id, taskID)
+	}
+}
+
+func TestSubmitAwaitConditionTask_ValidationError(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("server should not be called when validation fails")
+	}))
+
+	_, err := c.SubmitAwaitConditionTask(context.Background(), AwaitConditionTask{
+		Condition:    ConditionHeight,
+		TargetHeight: -1,
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "validation failed") {
+		t.Errorf("error = %v, expected to contain 'validation failed'", err)
+	}
+}
+
+func TestListTasks_EmptyArray(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	results, err := c.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks() error = %v", err)
+	}
+	if results == nil {
+		t.Fatal("ListTasks() returned nil, want empty slice")
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results, want 0", len(results))
+	}
+}
+
+func TestConfigPatchTask_Validate_Empty(t *testing.T) {
+	task := ConfigPatchTask{}
+	if err := task.Validate(); err == nil {
+		t.Fatal("expected validation error for empty ConfigPatchTask")
+	}
+}
+
+func TestConfigPatchTask_Validate_OK(t *testing.T) {
+	task := ConfigPatchTask{
+		Files: map[string]map[string]any{
+			"config.toml": {"p2p": map[string]any{"seeds": "foo"}},
+		},
+	}
+	if err := task.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
 	}
 }

--- a/sidecar/client/sidecar.gen.go
+++ b/sidecar/client/sidecar.gen.go
@@ -597,6 +597,7 @@ type SubmitTaskResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *TaskSubmitResponse
+	JSON202      *TaskSubmitResponse
 	JSON400      *ErrorResponse
 }
 
@@ -811,6 +812,13 @@ func ParseSubmitTaskResponse(rsp *http.Response) (*SubmitTaskResponse, error) {
 			return nil, err
 		}
 		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest TaskSubmitResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest ErrorResponse

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -315,6 +315,9 @@ type ConfigPatchTask struct {
 func (t ConfigPatchTask) TaskType() string { return TaskTypeConfigPatch }
 
 func (t ConfigPatchTask) Validate() error {
+	if len(t.Files) == 0 {
+		return fmt.Errorf("config-patch: at least one file is required")
+	}
 	return nil
 }
 

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -479,10 +479,10 @@ func TestConfigPatchToTaskRequest_NestedValuesPreserved(t *testing.T) {
 	}
 }
 
-func TestConfigPatchValidationAcceptsEmpty(t *testing.T) {
+func TestConfigPatchValidationRejectsEmpty(t *testing.T) {
 	task := ConfigPatchTask{}
-	if err := task.Validate(); err != nil {
-		t.Errorf("expected nil error for empty ConfigPatchTask, got %v", err)
+	if err := task.Validate(); err == nil {
+		t.Error("expected error for empty ConfigPatchTask")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **OpenAPI spec**: Add `202 Accepted` response to `POST /v0/tasks` and regenerate client, giving the generated code a proper `JSON202` field
- **client.go**: Replace manual `json.Unmarshal` workaround for 202 with the generated `JSON202` path; validate non-nil UUID on both 201 and 202; include task type in all error messages; add `SubmitAwaitConditionTask` typed method; return empty slice from `ListTasks` instead of nil
- **tasks.go**: `ConfigPatchTask.Validate()` now requires at least one file (was a no-op)
- **Test coverage**: 10 new test cases covering 202, 201/202 nil UUID, 5xx, 409, bad request with task type in error, AwaitCondition typed method happy + validation, ListTasks empty array, ConfigPatchTask validation

## Audit findings addressed

| Finding | Severity | Status |
|---------|----------|--------|
| 202 fix has zero test coverage | P0 | Fixed -- `TestSubmitTask_HTTP202`, `_MalformedBody`, `_NilUUID` |
| OpenAPI spec missing 202 response | P1 | Fixed -- spec updated, client regenerated |
| 202 path does not validate nil UUID | P2 | Fixed -- both 201 and 202 paths check |
| ConfigPatchTask.Validate() always returns nil | P2 | Fixed -- requires `len(Files) > 0` |
| ListTasks returns nil for empty body | P2 | Fixed -- returns `[]TaskResult{}` |
| Missing SubmitAwaitConditionTask typed method | P3 | Fixed -- added with validation |
| Test coverage gaps (no 5xx, 409, etc.) | P2 | Fixed -- new tests added |

## Test plan

- [x] `go test ./...` passes (all 54 client tests + full suite)
- [x] `go build ./...` clean
- [x] CI passes on PR