### PR TITLE
fix: use flat JSON format for seid /status response parsing

### DIFF
--- a/sidecar/rpc/status.go
+++ b/sidecar/rpc/status.go
@@ -33,12 +33,10 @@ type NodeStatus struct {
 func (c *StatusClient) Endpoint() string { return c.endpoint }
 
 type statusResponse struct {
-	Result struct {
-		SyncInfo struct {
-			LatestBlockHeight string `json:"latest_block_height"`
-			CatchingUp        bool   `json:"catching_up"`
-		} `json:"sync_info"`
-	} `json:"result"`
+	SyncInfo struct {
+		LatestBlockHeight string `json:"latest_block_height"`
+		CatchingUp        bool   `json:"catching_up"`
+	} `json:"sync_info"`
 }
 
 // NewStatusClient creates a client targeting the given RPC endpoint.
@@ -79,14 +77,14 @@ func (c *StatusClient) Status(ctx context.Context) (*NodeStatus, error) {
 		return nil, fmt.Errorf("decoding /status: %w", err)
 	}
 
-	h, err := strconv.ParseInt(rpcResp.Result.SyncInfo.LatestBlockHeight, 10, 64)
+	h, err := strconv.ParseInt(rpcResp.SyncInfo.LatestBlockHeight, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("parsing latest_block_height %q: %w", rpcResp.Result.SyncInfo.LatestBlockHeight, err)
+		return nil, fmt.Errorf("parsing latest_block_height %q: %w", rpcResp.SyncInfo.LatestBlockHeight, err)
 	}
 
 	return &NodeStatus{
 		LatestBlockHeight: h,
-		CatchingUp:        rpcResp.Result.SyncInfo.CatchingUp,
+		CatchingUp:        rpcResp.SyncInfo.CatchingUp,
 	}, nil
 }
 

--- a/sidecar/rpc/status_test.go
+++ b/sidecar/rpc/status_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStatusClient_LatestHeight(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"result":{"sync_info":{"latest_block_height":"12345","catching_up":false}}}`))
+		_, _ = w.Write([]byte(`{"sync_info":{"latest_block_height":"12345","catching_up":false}}`))
 	}))
 	defer srv.Close()
 
@@ -25,7 +25,7 @@ func TestStatusClient_LatestHeight(t *testing.T) {
 
 func TestStatusClient_CatchingUp(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"result":{"sync_info":{"latest_block_height":"100","catching_up":true}}}`))
+		_, _ = w.Write([]byte(`{"sync_info":{"latest_block_height":"100","catching_up":true}}`))
 	}))
 	defer srv.Close()
 
@@ -79,8 +79,8 @@ func TestStatusClient_InvalidBlockHeight(t *testing.T) {
 		name    string
 		payload string
 	}{
-		{"empty height", `{"result":{"sync_info":{"latest_block_height":"","catching_up":false}}}`},
-		{"non-numeric height", `{"result":{"sync_info":{"latest_block_height":"abc","catching_up":false}}}`},
+		{"empty height", `{"sync_info":{"latest_block_height":"","catching_up":false}}`},
+		{"non-numeric height", `{"sync_info":{"latest_block_height":"abc","catching_up":false}}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sidecar/tasks/await_condition_test.go
+++ b/sidecar/tasks/await_condition_test.go
@@ -25,7 +25,7 @@ func heightServer(heights ...int64) *httptest.Server {
 			idx++
 		}
 		mu.Unlock()
-		fmt.Fprintf(w, `{"result":{"sync_info":{"latest_block_height":"%d","catching_up":false}}}`, heights[i])
+		fmt.Fprintf(w, `{"sync_info":{"latest_block_height":"%d","catching_up":false}}`, heights[i])
 	}))
 }
 

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -244,19 +244,17 @@ func queryLatestHeight(ctx context.Context, rpcEndpoint string) (int64, error) {
 	}
 
 	var rpcResp struct {
-		Result struct {
-			SyncInfo struct {
-				LatestBlockHeight string `json:"latest_block_height"`
-			} `json:"sync_info"`
-		} `json:"result"`
+		SyncInfo struct {
+			LatestBlockHeight string `json:"latest_block_height"`
+		} `json:"sync_info"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
 		return 0, fmt.Errorf("decoding /status response: %w", err)
 	}
 
-	h, err := strconv.ParseInt(rpcResp.Result.SyncInfo.LatestBlockHeight, 10, 64)
+	h, err := strconv.ParseInt(rpcResp.SyncInfo.LatestBlockHeight, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("parsing latest_block_height %q: %w", rpcResp.Result.SyncInfo.LatestBlockHeight, err)
+		return 0, fmt.Errorf("parsing latest_block_height %q: %w", rpcResp.SyncInfo.LatestBlockHeight, err)
 	}
 	if h <= 0 {
 		return 0, fmt.Errorf("latest_block_height is %d, node may still be syncing", h)
@@ -285,14 +283,12 @@ func queryBlockResults(ctx context.Context, rpcEndpoint string, height int64) (j
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(body))
 	}
 
-	var rpcResp struct {
-		Result json.RawMessage `json:"result"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
-		return nil, fmt.Errorf("decoding response: %w", err)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
 	}
 
-	return rpcResp.Result, nil
+	return json.RawMessage(body), nil
 }
 
 func parseExportConfig(params map[string]any) (ResultExportConfig, error) {

--- a/sidecar/tasks/result_export_test.go
+++ b/sidecar/tasks/result_export_test.go
@@ -41,9 +41,9 @@ func fakeRPCServer(latestHeight int64) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/status":
-			fmt.Fprintf(w, `{"result":{"sync_info":{"latest_block_height":"%d"}}}`, latestHeight)
+			fmt.Fprintf(w, `{"sync_info":{"latest_block_height":"%d"}}`, latestHeight)
 		case r.URL.Path == "/block_results":
-			fmt.Fprint(w, `{"result":{}}`)
+			fmt.Fprint(w, `{}`)
 		default:
 			http.NotFound(w, r)
 		}
@@ -134,7 +134,7 @@ func TestExportRPCNon200Status(t *testing.T) {
 
 func TestQueryLatestHeight_ZeroHeight(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, `{"result":{"sync_info":{"latest_block_height":"0"}}}`)
+		fmt.Fprint(w, `{"sync_info":{"latest_block_height":"0"}}`)
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary

- The `statusResponse` struct expected a JSONRPC `result` wrapper (`{"result":{"sync_info":{...}}}`) but seid returns a flat format (`{"sync_info":{...}}`). This caused `LatestHeight` to silently fail on every poll — `strconv.ParseInt("")` returned an error each time — leaving the `await-condition` task stuck indefinitely even after the target height was reached.
- Same wrapper assumption existed in `result_export.go` for both `/status` and `/block_results` endpoints; fixed both.

## Root cause

Discovered while debugging a `pacific-1-shadow-replayer` pre-init Job where `seid` had synced past the target height (198.8M vs 198.7M target) but the sidecar task never detected it. The TCP connection was established and HTTP 200s were flowing, but the JSON parse always produced an empty string for `latest_block_height`.

## Test plan

- [x] All existing tests updated to use the flat format and pass
- [x] `go test ./sidecar/... -count=1` — all 7 packages pass