### PR TITLE
feat: genesis ceremony client types and /v0/node-id endpoint

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -63,7 +63,7 @@ var serveCmd = cli.Command{
 
 		go runSchedulerTicker(ctx, eng)
 
-		srv := server.NewServer(":"+port, eng)
+		srv := server.NewServer(":"+port, eng, homeDir)
 		if err := srv.ListenAndServe(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			return fmt.Errorf("server error: %w", err)
 		}

--- a/sidecar/client/client.go
+++ b/sidecar/client/client.go
@@ -3,8 +3,10 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -19,7 +21,9 @@ var ErrNotFound = errors.New("sidecar: task not found")
 // SidecarClient wraps the generated ClientWithResponses with a simpler,
 // error-oriented API.
 type SidecarClient struct {
-	inner *ClientWithResponses
+	inner   *ClientWithResponses
+	baseURL string
+	doer    HttpRequestDoer
 }
 
 // Option configures optional SidecarClient parameters.
@@ -47,18 +51,16 @@ func NewSidecarClient(baseURL string, opts ...Option) (*SidecarClient, error) {
 		fn(&o)
 	}
 
-	var clientOpts []ClientOption
-	if o.httpClient != nil {
-		clientOpts = append(clientOpts, WithHTTPClient(o.httpClient))
-	} else {
-		clientOpts = append(clientOpts, WithHTTPClient(&http.Client{Timeout: o.timeout}))
+	httpClient := o.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: o.timeout}
 	}
 
-	inner, err := NewClientWithResponses(baseURL, clientOpts...)
+	inner, err := NewClientWithResponses(baseURL, WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, err
 	}
-	return &SidecarClient{inner: inner}, nil
+	return &SidecarClient{inner: inner, baseURL: baseURL, doer: httpClient}, nil
 }
 
 // NewSidecarClientFromPodDNS builds a client targeting the sidecar via
@@ -196,6 +198,41 @@ func (c *SidecarClient) Healthz(ctx context.Context) (bool, error) {
 	default:
 		return false, fmt.Errorf("sidecar healthz returned %d: %s", resp.StatusCode(), bytes.TrimSpace(resp.Body))
 	}
+}
+
+// GetNodeID queries the sidecar's /v0/node-id endpoint and returns the
+// Tendermint node ID (hex-encoded). This is a direct HTTP call rather than
+// using the generated client, since /v0/node-id is outside the OpenAPI spec.
+func (c *SidecarClient) GetNodeID(ctx context.Context) (string, error) {
+	url := c.baseURL + "/v0/node-id"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("building node-id request: %w", err)
+	}
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("querying node-id: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading node-id response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("node-id returned %d: %s", resp.StatusCode, bytes.TrimSpace(body))
+	}
+
+	var result struct {
+		NodeID string `json:"nodeId"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing node-id response: %w", err)
+	}
+	if result.NodeID == "" {
+		return "", fmt.Errorf("node-id response missing nodeId field")
+	}
+	return result.NodeID, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/sidecar/client/client_test.go
+++ b/sidecar/client/client_test.go
@@ -473,3 +473,51 @@ func TestConfigPatchTask_Validate_OK(t *testing.T) {
 		t.Fatalf("Validate() error = %v", err)
 	}
 }
+
+func TestGetNodeID_OK(t *testing.T) {
+	want := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/node-id" || r.Method != http.MethodGet {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"nodeId": want})
+	}))
+
+	got, err := c.GetNodeID(context.Background())
+	if err != nil {
+		t.Fatalf("GetNodeID() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("GetNodeID() = %q, want %q", got, want)
+	}
+}
+
+func TestGetNodeID_ServerError(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not ready", http.StatusInternalServerError)
+	}))
+
+	_, err := c.GetNodeID(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %v, expected to contain '500'", err)
+	}
+}
+
+func TestGetNodeID_EmptyNodeID(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"nodeId": ""})
+	}))
+
+	_, err := c.GetNodeID(context.Background())
+	if err == nil {
+		t.Fatal("expected error for empty nodeId")
+	}
+	if !strings.Contains(err.Error(), "missing nodeId") {
+		t.Errorf("error = %v, expected to contain 'missing nodeId'", err)
+	}
+}

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -31,6 +31,11 @@ const (
 	TaskTypeSnapshotUpload     = string(engine.TaskSnapshotUpload)
 	TaskTypeResultExport       = string(engine.TaskResultExport)
 	TaskTypeAwaitCondition     = string(engine.TaskAwaitCondition)
+
+	TaskTypeGenerateIdentity       = "generate-identity"
+	TaskTypeGenerateGentx          = "generate-gentx"
+	TaskTypeUploadGenesisArtifacts = "upload-genesis-artifacts"
+	TaskTypeAssembleGenesis        = "assemble-and-upload-genesis"
 )
 
 // Known condition and action values for AwaitConditionTask.
@@ -523,15 +528,13 @@ func ResultExportTaskFromParams(params map[string]interface{}) ResultExportTask 
 	}
 }
 
-// --- Genesis ceremony task types ---
-
 // GenerateIdentityTask creates validator identity (keys, node ID).
 type GenerateIdentityTask struct {
 	ChainID string
 	Moniker string
 }
 
-func (t GenerateIdentityTask) TaskType() string { return "generate-identity" }
+func (t GenerateIdentityTask) TaskType() string { return TaskTypeGenerateIdentity }
 
 func (t GenerateIdentityTask) Validate() error {
 	if t.ChainID == "" {
@@ -561,7 +564,7 @@ type GenerateGentxTask struct {
 	GenesisParams  string
 }
 
-func (t GenerateGentxTask) TaskType() string { return "generate-gentx" }
+func (t GenerateGentxTask) TaskType() string { return TaskTypeGenerateGentx }
 
 func (t GenerateGentxTask) Validate() error {
 	if t.ChainID == "" {
@@ -596,7 +599,7 @@ type UploadGenesisArtifactsTask struct {
 	NodeName string
 }
 
-func (t UploadGenesisArtifactsTask) TaskType() string { return "upload-genesis-artifacts" }
+func (t UploadGenesisArtifactsTask) TaskType() string { return TaskTypeUploadGenesisArtifacts }
 
 func (t UploadGenesisArtifactsTask) Validate() error {
 	if t.S3Bucket == "" {
@@ -635,7 +638,7 @@ type AssembleAndUploadGenesisTask struct {
 	Nodes    []GenesisNodeParam
 }
 
-func (t AssembleAndUploadGenesisTask) TaskType() string { return "assemble-and-upload-genesis" }
+func (t AssembleAndUploadGenesisTask) TaskType() string { return TaskTypeAssembleGenesis }
 
 func (t AssembleAndUploadGenesisTask) Validate() error {
 	if t.S3Bucket == "" {

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -523,6 +523,151 @@ func ResultExportTaskFromParams(params map[string]interface{}) ResultExportTask 
 	}
 }
 
+// --- Genesis ceremony task types ---
+
+// GenerateIdentityTask creates validator identity (keys, node ID).
+type GenerateIdentityTask struct {
+	ChainID string
+	Moniker string
+}
+
+func (t GenerateIdentityTask) TaskType() string { return "generate-identity" }
+
+func (t GenerateIdentityTask) Validate() error {
+	if t.ChainID == "" {
+		return fmt.Errorf("generate-identity: missing required field ChainID")
+	}
+	if t.Moniker == "" {
+		return fmt.Errorf("generate-identity: missing required field Moniker")
+	}
+	return nil
+}
+
+func (t GenerateIdentityTask) ToTaskRequest() TaskRequest {
+	p := map[string]interface{}{
+		"chainId": t.ChainID,
+		"moniker": t.Moniker,
+	}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
+}
+
+// GenerateGentxTask creates a gentx for the validator. The handler discovers
+// the node's own account address from the keys generated during identity
+// creation and funds it with AccountBalance before generating the gentx.
+type GenerateGentxTask struct {
+	ChainID        string
+	StakingAmount  string
+	AccountBalance string
+	GenesisParams  string
+}
+
+func (t GenerateGentxTask) TaskType() string { return "generate-gentx" }
+
+func (t GenerateGentxTask) Validate() error {
+	if t.ChainID == "" {
+		return fmt.Errorf("generate-gentx: missing required field ChainID")
+	}
+	if t.StakingAmount == "" {
+		return fmt.Errorf("generate-gentx: missing required field StakingAmount")
+	}
+	if t.AccountBalance == "" {
+		return fmt.Errorf("generate-gentx: missing required field AccountBalance")
+	}
+	return nil
+}
+
+func (t GenerateGentxTask) ToTaskRequest() TaskRequest {
+	p := map[string]interface{}{
+		"chainId":        t.ChainID,
+		"stakingAmount":  t.StakingAmount,
+		"accountBalance": t.AccountBalance,
+	}
+	if t.GenesisParams != "" {
+		p["genesisParams"] = t.GenesisParams
+	}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
+}
+
+// UploadGenesisArtifactsTask uploads identity.json and gentx.json to S3.
+type UploadGenesisArtifactsTask struct {
+	S3Bucket string
+	S3Prefix string
+	S3Region string
+	NodeName string
+}
+
+func (t UploadGenesisArtifactsTask) TaskType() string { return "upload-genesis-artifacts" }
+
+func (t UploadGenesisArtifactsTask) Validate() error {
+	if t.S3Bucket == "" {
+		return fmt.Errorf("upload-genesis-artifacts: missing required field S3Bucket")
+	}
+	if t.S3Region == "" {
+		return fmt.Errorf("upload-genesis-artifacts: missing required field S3Region")
+	}
+	if t.NodeName == "" {
+		return fmt.Errorf("upload-genesis-artifacts: missing required field NodeName")
+	}
+	return nil
+}
+
+func (t UploadGenesisArtifactsTask) ToTaskRequest() TaskRequest {
+	p := map[string]interface{}{
+		"s3Bucket": t.S3Bucket,
+		"s3Prefix": t.S3Prefix,
+		"s3Region": t.S3Region,
+		"nodeName": t.NodeName,
+	}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
+}
+
+// GenesisNodeParam is the wire format for nodes[] in assemble-and-upload-genesis.
+type GenesisNodeParam struct {
+	Name string `json:"name"`
+}
+
+// AssembleAndUploadGenesisTask collects per-node artifacts and produces final genesis.json.
+type AssembleAndUploadGenesisTask struct {
+	S3Bucket string
+	S3Prefix string
+	S3Region string
+	ChainID  string
+	Nodes    []GenesisNodeParam
+}
+
+func (t AssembleAndUploadGenesisTask) TaskType() string { return "assemble-and-upload-genesis" }
+
+func (t AssembleAndUploadGenesisTask) Validate() error {
+	if t.S3Bucket == "" {
+		return fmt.Errorf("assemble-and-upload-genesis: missing required field S3Bucket")
+	}
+	if t.S3Region == "" {
+		return fmt.Errorf("assemble-and-upload-genesis: missing required field S3Region")
+	}
+	if t.ChainID == "" {
+		return fmt.Errorf("assemble-and-upload-genesis: missing required field ChainID")
+	}
+	if len(t.Nodes) == 0 {
+		return fmt.Errorf("assemble-and-upload-genesis: at least one node is required")
+	}
+	return nil
+}
+
+func (t AssembleAndUploadGenesisTask) ToTaskRequest() TaskRequest {
+	nodes := make([]interface{}, len(t.Nodes))
+	for i, n := range t.Nodes {
+		nodes[i] = map[string]interface{}{"name": n.Name}
+	}
+	p := map[string]interface{}{
+		"s3Bucket": t.S3Bucket,
+		"s3Prefix": t.S3Prefix,
+		"s3Region": t.S3Region,
+		"chainId":  t.ChainID,
+		"nodes":    nodes,
+	}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
+}
+
 // AwaitConditionTask blocks until a condition is met, then optionally
 // executes a post-condition action. Currently supports the "height"
 // condition and the "SIGTERM_SEID" action.

--- a/sidecar/server/server.go
+++ b/sidecar/server/server.go
@@ -15,6 +15,12 @@ import (
 	"github.com/sei-protocol/seictl/sidecar/engine"
 )
 
+const (
+	ed25519PrivKeyLen   = 64 // seed (32) + public key (32)
+	ed25519PubKeyOffset = 32
+	cometbftAddressLen  = 20 // hex(SHA256(pubkey)[:20])
+)
+
 // Server is the HTTP API for the sidecar.
 type Server struct {
 	addr    string
@@ -172,14 +178,14 @@ func (s *Server) handleNodeID(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	keyBytes, err := base64.StdEncoding.DecodeString(keyFile.PrivKey.Value)
-	if err != nil || len(keyBytes) != 64 {
+	if err != nil || len(keyBytes) != ed25519PrivKeyLen {
 		writeError(w, http.StatusInternalServerError, "invalid Ed25519 key in node_key.json")
 		return
 	}
 
-	pubKey := keyBytes[32:]
+	pubKey := keyBytes[ed25519PubKeyOffset:]
 	hash := sha256.Sum256(pubKey)
-	nodeID := hex.EncodeToString(hash[:20])
+	nodeID := hex.EncodeToString(hash[:cometbftAddressLen])
 
 	writeJSON(w, http.StatusOK, map[string]string{"nodeId": nodeID})
 }

--- a/sidecar/server/server.go
+++ b/sidecar/server/server.go
@@ -2,9 +2,14 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/sei-protocol/seictl/sidecar/engine"
@@ -12,9 +17,10 @@ import (
 
 // Server is the HTTP API for the sidecar.
 type Server struct {
-	addr   string
-	engine *engine.Engine
-	mux    *http.ServeMux
+	addr    string
+	homeDir string
+	engine  *engine.Engine
+	mux     *http.ServeMux
 }
 
 // TaskRequest is the JSON body for POST /v0/tasks. When Schedule is set
@@ -31,14 +37,17 @@ type ErrorResponse struct {
 }
 
 // NewServer creates a Server wired to the given engine.
-func NewServer(addr string, eng *engine.Engine) *Server {
+// homeDir is the seid home directory (e.g. /sei) used by the node-id endpoint.
+func NewServer(addr string, eng *engine.Engine, homeDir string) *Server {
 	s := &Server{
-		addr:   addr,
-		engine: eng,
-		mux:    http.NewServeMux(),
+		addr:    addr,
+		homeDir: homeDir,
+		engine:  eng,
+		mux:     http.NewServeMux(),
 	}
 	s.mux.HandleFunc("GET /v0/healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /v0/status", s.handleStatus)
+	s.mux.HandleFunc("GET /v0/node-id", s.handleNodeID)
 	s.mux.HandleFunc("POST /v0/tasks", s.handlePostTask)
 	s.mux.HandleFunc("GET /v0/tasks", s.handleListTasks)
 	s.mux.HandleFunc("GET /v0/tasks/{id}", s.handleGetTask)
@@ -138,6 +147,41 @@ func (s *Server) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleNodeID reads node_key.json from the home directory and returns the
+// Tendermint node ID. The node ID is hex(SHA256(ed25519_pubkey)[:20]), matching
+// CometBFT's p2p.PubKeyToID derivation.
+func (s *Server) handleNodeID(w http.ResponseWriter, _ *http.Request) {
+	keyPath := filepath.Join(s.homeDir, "config", "node_key.json")
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError,
+			"node_key.json not found — generate-identity may not have run yet")
+		return
+	}
+
+	var keyFile struct {
+		PrivKey struct {
+			Value string `json:"value"`
+		} `json:"priv_key"`
+	}
+	if err := json.Unmarshal(data, &keyFile); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to parse node_key.json")
+		return
+	}
+
+	keyBytes, err := base64.StdEncoding.DecodeString(keyFile.PrivKey.Value)
+	if err != nil || len(keyBytes) != 64 {
+		writeError(w, http.StatusInternalServerError, "invalid Ed25519 key in node_key.json")
+		return
+	}
+
+	pubKey := keyBytes[32:]
+	hash := sha256.Sum256(pubKey)
+	nodeID := hex.EncodeToString(hash[:20])
+
+	writeJSON(w, http.StatusOK, map[string]string{"nodeId": nodeID})
 }
 
 // ListenAndServe starts the HTTP server and blocks until ctx is cancelled.

--- a/sidecar/server/server_test.go
+++ b/sidecar/server/server_test.go
@@ -54,7 +54,7 @@ func waitForTaskResult(eng *engine.Engine, id string) *engine.TaskResult {
 
 func TestHealthzReturns503BeforeReady(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 	rec := serveHTTP(srv, http.MethodGet, "/v0/healthz", "")
 
 	if rec.Code != http.StatusServiceUnavailable {
@@ -66,7 +66,7 @@ func TestHealthzReturns200AfterMarkReady(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskMarkReady: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	_, _ = eng.Submit(engine.Task{Type: engine.TaskMarkReady})
 	waitForReady(eng)
@@ -81,7 +81,7 @@ func TestStatusResponse(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskMarkReady: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	rec := serveHTTP(srv, http.MethodGet, "/v0/status", "")
 	if rec.Code != http.StatusOK {
@@ -112,7 +112,7 @@ func TestPostTaskReturnsID(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	body := `{"type":"config-patch","params":{"peers":["a@1.2.3.4:26656"]}}`
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", body)
@@ -133,7 +133,7 @@ func TestPostTaskScheduled(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	body := `{"type":"config-patch","schedule":{"cron":"*/5 * * * *"}}`
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", body)
@@ -152,7 +152,7 @@ func TestPostTaskScheduled(t *testing.T) {
 
 func TestPostTaskInvalidJSON(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{not json}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -161,7 +161,7 @@ func TestPostTaskInvalidJSON(t *testing.T) {
 
 func TestPostTaskMissingType(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"params":{}}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -170,7 +170,7 @@ func TestPostTaskMissingType(t *testing.T) {
 
 func TestPostTaskUnknownType(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"nonexistent"}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -181,7 +181,7 @@ func TestPostTaskInvalidSchedule(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch","schedule":{"cron":"not a cron"}}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -190,7 +190,7 @@ func TestPostTaskInvalidSchedule(t *testing.T) {
 
 func TestListTasksEmpty(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 	rec := serveHTTP(srv, http.MethodGet, "/v0/tasks", "")
 
 	var results []engine.TaskResult
@@ -206,7 +206,7 @@ func TestListTasksAfterSubmit(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
@@ -227,7 +227,7 @@ func TestGetTask(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
@@ -259,7 +259,7 @@ func TestGetTaskInProgress(t *testing.T) {
 			return nil
 		},
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	if rec.Code != http.StatusCreated {
@@ -304,7 +304,7 @@ func TestGetTaskInProgress(t *testing.T) {
 
 func TestGetTaskNotFound(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 	rec := serveHTTP(srv, http.MethodGet, "/v0/tasks/nonexistent", "")
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
@@ -315,7 +315,7 @@ func TestDeleteTask(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
@@ -338,7 +338,7 @@ func TestDeleteScheduledTask(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng)
+	srv := NewServer(":0", eng, t.TempDir())
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch","schedule":{"cron":"*/5 * * * *"}}`)
 	var resp map[string]string

--- a/sidecar/server/server_test.go
+++ b/sidecar/server/server_test.go
@@ -2,9 +2,15 @@ package server
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -353,5 +359,80 @@ func TestDeleteScheduledTask(t *testing.T) {
 	rec = serveHTTP(srv, http.MethodGet, "/v0/tasks/"+id, "")
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 after delete, got %d", rec.Code)
+	}
+}
+
+// writeTestNodeKey generates a real Ed25519 keypair, writes it as a CometBFT
+// node_key.json, and returns the expected node ID (hex(SHA256(pubkey)[:20])).
+func writeTestNodeKey(t *testing.T, homeDir string) string {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// CometBFT stores the full 64-byte key (seed || pubkey) base64-encoded.
+	keyFile := struct {
+		PrivKey struct {
+			Type  string `json:"type"`
+			Value string `json:"value"`
+		} `json:"priv_key"`
+	}{
+		PrivKey: struct {
+			Type  string `json:"type"`
+			Value string `json:"value"`
+		}{
+			Type:  "tendermint/PrivKeyEd25519",
+			Value: base64.StdEncoding.EncodeToString(priv),
+		},
+	}
+	data, err := json.Marshal(keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configDir := filepath.Join(homeDir, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "node_key.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := sha256.Sum256(pub)
+	return hex.EncodeToString(hash[:20])
+}
+
+func TestNodeID_ReturnsCorrectID(t *testing.T) {
+	homeDir := t.TempDir()
+	want := writeTestNodeKey(t, homeDir)
+
+	eng := newTestEngine(t, nil)
+	srv := NewServer(":0", eng, homeDir)
+
+	rec := serveHTTP(srv, http.MethodGet, "/v0/node-id", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result struct {
+		NodeID string `json:"nodeId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if result.NodeID != want {
+		t.Errorf("nodeId = %q, want %q", result.NodeID, want)
+	}
+}
+
+func TestNodeID_MissingKeyFile(t *testing.T) {
+	eng := newTestEngine(t, nil)
+	srv := NewServer(":0", eng, t.TempDir())
+
+	rec := serveHTTP(srv, http.MethodGet, "/v0/node-id", "")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
 	}
 }


### PR DESCRIPTION
## Summary

- Add four genesis ceremony task builder types (`GenerateIdentityTask`, `GenerateGentxTask`, `UploadGenesisArtifactsTask`, `AssembleAndUploadGenesisTask`) implementing the `TaskBuilder` interface for controller-side plan construction
- Add `GET /v0/node-id` server endpoint that derives the Tendermint node ID from `node_key.json` using CometBFT-compatible `SHA256(ed25519_pubkey)[:20]`
- Add `GetNodeID()` client method for the controller to collect node IDs during peer assembly
- Refactor `SidecarClient` to store `baseURL` and `doer` for direct HTTP calls outside the OpenAPI-generated client

These are the seictl-side prerequisites for the network deployment genesis ceremony feature in sei-k8s-controller. Task handlers (the actual `generate-identity`, `generate-gentx`, etc. implementations) will follow in a subsequent PR.

## Design decisions

- **`AccountBalance` is a single string** (e.g. `"1000000usei,1000000uusdc"`), not a list of address+amount pairs. Each node discovers its own address during identity generation -- no cross-node coordination needed between the identity and gentx steps.
- **`/v0/node-id` is outside the OpenAPI spec** since it is a simple read from disk, not a task. The client uses a direct HTTP call rather than the generated client.
- **Node ID derivation** matches CometBFT exactly: `hex(SHA256(ed25519_pubkey)[:20])`, reading the 32-byte public key from the last half of the 64-byte Ed25519 private key in `node_key.json`.

## Test plan

- [x] All existing server tests pass (updated `NewServer` calls to include `homeDir`)
- [x] All existing client tests pass
- [x] `go build ./...` clean
- [ ] Validate task builder `ToTaskRequest()` output matches expected wire format
