### PR TITLE
feat: set-genesis-peers task and assembler peers.json upload

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -61,6 +61,7 @@ var serveCmd = cli.Command{
 			engine.TaskGenerateGentx:            tasks.NewGentxGenerator(homeDir, nil).Handler(),
 			engine.TaskUploadGenesisArtifacts:   tasks.NewGenesisArtifactUploader(homeDir, nil).Handler(),
 			engine.TaskAssembleAndUploadGenesis: tasks.NewGenesisAssembler(homeDir, nil, nil, nil).Handler(),
+			engine.TaskSetGenesisPeers:          tasks.NewGenesisPeersSetter(homeDir, nil).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers)

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -52,6 +52,7 @@ const (
 	TaskTypeGenerateGentx          = "generate-gentx"
 	TaskTypeUploadGenesisArtifacts = "upload-genesis-artifacts"
 	TaskTypeAssembleGenesis        = "assemble-and-upload-genesis"
+	TaskTypeSetGenesisPeers        = "set-genesis-peers"
 )
 
 // Known condition and action values for AwaitConditionTask.

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -25,6 +25,7 @@ const (
 	TaskGenerateGentx            TaskType = "generate-gentx"
 	TaskUploadGenesisArtifacts   TaskType = "upload-genesis-artifacts"
 	TaskAssembleAndUploadGenesis TaskType = "assemble-and-upload-genesis"
+	TaskSetGenesisPeers          TaskType = "set-genesis-peers"
 )
 
 // Task is a unit of work submitted by the controller. When ID is set, the

--- a/sidecar/tasks/assemble_genesis.go
+++ b/sidecar/tasks/assemble_genesis.go
@@ -41,6 +41,15 @@ type GenesisAssembler struct {
 	s3UploaderFactory seis3.UploaderFactory
 }
 
+type assembleConfig struct {
+	bucket         string
+	prefix         string
+	region         string
+	accountBalance string
+	namespace      string
+	nodes          []string
+}
+
 // NewGenesisAssembler creates an assembler targeting the given home directory.
 // The CommandRunner parameter is ignored (kept for call-site compatibility).
 func NewGenesisAssembler(homeDir string, _ CommandRunner, s3Factory S3ClientFactory, uploaderFactory seis3.UploaderFactory) *GenesisAssembler {
@@ -62,11 +71,13 @@ func NewGenesisAssembler(homeDir string, _ CommandRunner, s3Factory S3ClientFact
 // Expected params:
 //
 //	{
-//	  "s3Bucket": "...",
-//	  "s3Prefix": "...",
-//	  "s3Region": "...",
-//	  "chainId":  "...",
-//	  "nodes":    [{"name": "node-0"}, {"name": "node-1"}, ...]
+//	  "s3Bucket":   "...",
+//	  "s3Prefix":   "...",
+//	  "s3Region":   "...",
+//	  "chainId":    "...",
+//	  "namespace":  "...",
+//	  "accountBalance": "...",
+//	  "nodes":      [{"name": "node-0"}, {"name": "node-1"}, ...]
 //	}
 func (a *GenesisAssembler) Handler() engine.TaskHandler {
 	return func(ctx context.Context, params map[string]any) error {
@@ -93,6 +104,10 @@ func (a *GenesisAssembler) Handler() engine.TaskHandler {
 		}
 
 		if err := a.uploadGenesis(ctx, cfg); err != nil {
+			return err
+		}
+
+		if err := a.uploadPeers(ctx, cfg); err != nil {
 			return err
 		}
 
@@ -323,12 +338,77 @@ func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg assembleConfig
 	return nil
 }
 
-type assembleConfig struct {
-	bucket         string
-	prefix         string
-	region         string
-	accountBalance string
-	nodes          []string
+// uploadPeers builds a peers.json from each node's identity.json and uploads
+// it to S3 alongside genesis.json. Each entry is a full Tendermint peer address
+// using in-cluster DNS: <nodeID>@<name>-0.<name>.<namespace>.svc.cluster.local:26656
+func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig) error {
+	s3Client, err := a.s3ClientFactory(ctx, cfg.region)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: building S3 client for peers: %w", err)
+	}
+
+	prefix := normalizePrefix(cfg.prefix)
+	var peers []string
+
+	for _, nodeName := range cfg.nodes {
+		key := fmt.Sprintf("%s%s/identity.json", prefix, nodeName)
+		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(cfg.bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			return fmt.Errorf("assemble-genesis: downloading identity for %s: %w", nodeName, err)
+		}
+		data, err := io.ReadAll(output.Body)
+		_ = output.Body.Close()
+		if err != nil {
+			return fmt.Errorf("assemble-genesis: reading identity for %s: %w", nodeName, err)
+		}
+
+		var identity struct {
+			NodeKey json.RawMessage `json:"node_key"`
+		}
+		if err := json.Unmarshal(data, &identity); err != nil {
+			return fmt.Errorf("assemble-genesis: parsing identity for %s: %w", nodeName, err)
+		}
+
+		var nodeKey struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(identity.NodeKey, &nodeKey); err != nil {
+			return fmt.Errorf("assemble-genesis: parsing node_key for %s: %w", nodeName, err)
+		}
+		if nodeKey.ID == "" {
+			return fmt.Errorf("assemble-genesis: empty node ID for %s", nodeName)
+		}
+
+		dns := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local", nodeName, nodeName, cfg.namespace)
+		peers = append(peers, fmt.Sprintf("%s@%s:26656", nodeKey.ID, dns))
+	}
+
+	peersJSON, err := json.Marshal(peers)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: marshaling peers.json: %w", err)
+	}
+
+	uploader, err := a.s3UploaderFactory(ctx, cfg.region)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: building S3 uploader for peers: %w", err)
+	}
+
+	peersKey := prefix + "peers.json"
+	assembleLog.Info("uploading peers.json", "key", peersKey, "count", len(peers))
+
+	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
+		Bucket:      aws.String(cfg.bucket),
+		Key:         aws.String(peersKey),
+		Body:        bytes.NewReader(peersJSON),
+		ContentType: aws.String("application/json"),
+	})
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: uploading peers.json: %w", err)
+	}
+	return nil
 }
 
 func parseAssembleConfig(params map[string]any) (assembleConfig, error) {
@@ -336,6 +416,7 @@ func parseAssembleConfig(params map[string]any) (assembleConfig, error) {
 	prefix, _ := params["s3Prefix"].(string)
 	region, _ := params["s3Region"].(string)
 	accountBalance, _ := params["accountBalance"].(string)
+	namespace, _ := params["namespace"].(string)
 
 	if bucket == "" {
 		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 's3Bucket'")
@@ -345,6 +426,9 @@ func parseAssembleConfig(params map[string]any) (assembleConfig, error) {
 	}
 	if accountBalance == "" {
 		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 'accountBalance'")
+	}
+	if namespace == "" {
+		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 'namespace'")
 	}
 
 	rawNodes, ok := params["nodes"]
@@ -360,7 +444,7 @@ func parseAssembleConfig(params map[string]any) (assembleConfig, error) {
 		return assembleConfig{}, fmt.Errorf("assemble-genesis: 'nodes' list is empty")
 	}
 
-	return assembleConfig{bucket: bucket, prefix: prefix, region: region, accountBalance: accountBalance, nodes: nodes}, nil
+	return assembleConfig{bucket: bucket, prefix: prefix, region: region, accountBalance: accountBalance, namespace: namespace, nodes: nodes}, nil
 }
 
 func parseNodeNames(raw any) ([]string, error) {

--- a/sidecar/tasks/assemble_genesis_test.go
+++ b/sidecar/tasks/assemble_genesis_test.go
@@ -47,6 +47,7 @@ func TestAssembler_DownloadsGentxFiles(t *testing.T) {
 		prefix:         "genesis/",
 		region:         "us-west-2",
 		accountBalance: "10000000usei",
+		namespace:      "default",
 		nodes:          []string{"val-0", "val-1"},
 	}
 
@@ -70,11 +71,12 @@ func TestAssembler_MissingParams(t *testing.T) {
 		name   string
 		params map[string]any
 	}{
-		{"missing bucket", map[string]any{"s3Region": "r", "accountBalance": "10usei", "nodes": []any{map[string]any{"name": "n"}}}},
-		{"missing region", map[string]any{"s3Bucket": "b", "accountBalance": "10usei", "nodes": []any{map[string]any{"name": "n"}}}},
-		{"missing accountBalance", map[string]any{"s3Bucket": "b", "s3Region": "r", "nodes": []any{map[string]any{"name": "n"}}}},
-		{"missing nodes", map[string]any{"s3Bucket": "b", "s3Region": "r", "accountBalance": "10usei"}},
-		{"empty nodes", map[string]any{"s3Bucket": "b", "s3Region": "r", "accountBalance": "10usei", "nodes": []any{}}},
+		{"missing bucket", map[string]any{"s3Region": "r", "accountBalance": "10usei", "namespace": "ns", "nodes": []any{map[string]any{"name": "n"}}}},
+		{"missing region", map[string]any{"s3Bucket": "b", "accountBalance": "10usei", "namespace": "ns", "nodes": []any{map[string]any{"name": "n"}}}},
+		{"missing accountBalance", map[string]any{"s3Bucket": "b", "s3Region": "r", "namespace": "ns", "nodes": []any{map[string]any{"name": "n"}}}},
+		{"missing namespace", map[string]any{"s3Bucket": "b", "s3Region": "r", "accountBalance": "10usei", "nodes": []any{map[string]any{"name": "n"}}}},
+		{"missing nodes", map[string]any{"s3Bucket": "b", "s3Region": "r", "accountBalance": "10usei", "namespace": "ns"}},
+		{"empty nodes", map[string]any{"s3Bucket": "b", "s3Region": "r", "accountBalance": "10usei", "namespace": "ns", "nodes": []any{}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -94,8 +96,8 @@ func TestAssembler_S3DownloadFailure(t *testing.T) {
 	handler := NewGenesisAssembler(homeDir, nil, s3Factory, nil).Handler()
 	err := handler(context.Background(), map[string]any{
 		"s3Bucket": "b", "s3Prefix": "p/", "s3Region": "r", "chainId": "c",
-		"accountBalance": "10000000usei",
-		"nodes":          []any{map[string]any{"name": "missing-node"}},
+		"accountBalance": "10000000usei", "namespace": "default",
+		"nodes": []any{map[string]any{"name": "missing-node"}},
 	})
 	if err == nil {
 		t.Fatal("expected error when S3 download fails")

--- a/sidecar/tasks/genesis_peers.go
+++ b/sidecar/tasks/genesis_peers.go
@@ -1,0 +1,131 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
+)
+
+var genesisPeersLog = seilog.NewLogger("seictl", "task", "set-genesis-peers")
+
+// GenesisPeersSetter downloads a peers.json file produced by the genesis
+// assembler and writes the entries into config.toml as persistent_peers,
+// filtering out the current node's own entry.
+type GenesisPeersSetter struct {
+	homeDir         string
+	s3ClientFactory S3ClientFactory
+}
+
+// NewGenesisPeersSetter creates a setter targeting the given home directory.
+func NewGenesisPeersSetter(homeDir string, s3Factory S3ClientFactory) *GenesisPeersSetter {
+	if s3Factory == nil {
+		s3Factory = DefaultS3ClientFactory
+	}
+	return &GenesisPeersSetter{homeDir: homeDir, s3ClientFactory: s3Factory}
+}
+
+// Handler returns an engine.TaskHandler for the set-genesis-peers task.
+//
+// Expected params:
+//
+//	{"s3Bucket": "...", "s3Key": "...", "s3Region": "..."}
+func (g *GenesisPeersSetter) Handler() engine.TaskHandler {
+	return func(ctx context.Context, params map[string]any) error {
+		cfg, err := parseGenesisPeersConfig(params)
+		if err != nil {
+			return err
+		}
+
+		s3Client, err := g.s3ClientFactory(ctx, cfg.region)
+		if err != nil {
+			return fmt.Errorf("set-genesis-peers: building S3 client: %w", err)
+		}
+
+		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(cfg.bucket),
+			Key:    aws.String(cfg.key),
+		})
+		if err != nil {
+			return fmt.Errorf("set-genesis-peers: downloading peers.json: %w", err)
+		}
+		data, err := io.ReadAll(output.Body)
+		_ = output.Body.Close()
+		if err != nil {
+			return fmt.Errorf("set-genesis-peers: reading peers.json: %w", err)
+		}
+
+		var allPeers []string
+		if err := json.Unmarshal(data, &allPeers); err != nil {
+			return fmt.Errorf("set-genesis-peers: parsing peers.json: %w", err)
+		}
+
+		selfID, err := readLocalNodeID(g.homeDir)
+		if err != nil {
+			return err
+		}
+
+		var filtered []string
+		for _, peer := range allPeers {
+			if !strings.HasPrefix(peer, selfID+"@") {
+				filtered = append(filtered, peer)
+			}
+		}
+
+		genesisPeersLog.Info("applying genesis peers",
+			"total", len(allPeers), "self", selfID, "peers", len(filtered))
+
+		return writePeersToConfig(g.homeDir, filtered)
+	}
+}
+
+// readLocalNodeID reads the Tendermint node ID from the local node_key.json.
+func readLocalNodeID(homeDir string) (string, error) {
+	path := filepath.Join(homeDir, "config", "node_key.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("set-genesis-peers: reading node_key.json: %w", err)
+	}
+
+	var nodeKey struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &nodeKey); err != nil {
+		return "", fmt.Errorf("set-genesis-peers: parsing node_key.json: %w", err)
+	}
+	if nodeKey.ID == "" {
+		return "", fmt.Errorf("set-genesis-peers: node_key.json has empty id")
+	}
+	return nodeKey.ID, nil
+}
+
+type genesisPeersConfig struct {
+	bucket string
+	key    string
+	region string
+}
+
+func parseGenesisPeersConfig(params map[string]any) (genesisPeersConfig, error) {
+	bucket, _ := params["s3Bucket"].(string)
+	key, _ := params["s3Key"].(string)
+	region, _ := params["s3Region"].(string)
+
+	if bucket == "" {
+		return genesisPeersConfig{}, fmt.Errorf("set-genesis-peers: missing required param 's3Bucket'")
+	}
+	if key == "" {
+		return genesisPeersConfig{}, fmt.Errorf("set-genesis-peers: missing required param 's3Key'")
+	}
+	if region == "" {
+		return genesisPeersConfig{}, fmt.Errorf("set-genesis-peers: missing required param 's3Region'")
+	}
+	return genesisPeersConfig{bucket: bucket, key: key, region: region}, nil
+}


### PR DESCRIPTION
## Summary

- Assembler now downloads each node's identity.json from S3 after assembling genesis, builds full Tendermint peer addresses using in-cluster DNS, and uploads peers.json alongside genesis.json
- New `set-genesis-peers` sidecar task downloads peers.json, filters out the current node using its local node_key.json, and writes persistent_peers to config.toml
- Adds `namespace` as a required parameter to the assembler for constructing DNS addresses

## Context

Genesis ceremony nodes were failing at the `discover-peers` step because there are no external peer sources (EC2 tags, static) configured — all nodes start simultaneously in the same cluster. This produces the peer list as a ceremony artifact instead, matching the pattern from the legacy SeiNodePool approach.

Companion controller PR needed to wire `namespace` into assembler params and replace `discover-peers` with `set-genesis-peers` in the genesis plan.

## Test plan

- [x] Existing assembler tests updated and passing
- [x] Verify peers.json upload in integration test
- [x] Verify set-genesis-peers self-filtering with mock S3 + node_key.json
