### PR TITLE
feat: add result-export comparison mode with canonical RPC

### DIFF
--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -529,14 +529,15 @@ func ConfigReloadTaskFromParams(params map[string]interface{}) ConfigReloadTask 
 }
 
 // ResultExportTask queries the local seid RPC for block results and uploads
-// them in paginated NDJSON files to S3.
-// Schedule may be set to run this task on a recurring cron.
+// them in paginated NDJSON files to S3. CanonicalRPC enables comparison mode:
+// the sidecar compares local block results against the canonical chain and
+// the task completes when app-hash divergence is detected.
 type ResultExportTask struct {
 	TaskMeta
-	Bucket   string
-	Prefix   string
-	Region   string
-	Schedule *ScheduleConfig
+	Bucket       string
+	Prefix       string
+	Region       string
+	CanonicalRPC string
 }
 
 func (t ResultExportTask) TaskType() string { return TaskTypeResultExport }
@@ -559,10 +560,10 @@ func (t ResultExportTask) ToTaskRequest() TaskRequest {
 	if t.Prefix != "" {
 		p["prefix"] = t.Prefix
 	}
-	req := TaskRequest{Type: t.TaskType(), Params: &p}
-	if t.Schedule != nil {
-		req.Schedule = t.Schedule
+	if t.CanonicalRPC != "" {
+		p["canonicalRpc"] = t.CanonicalRPC
 	}
+	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	t.applyMeta(&req)
 	return req
 }
@@ -572,9 +573,10 @@ func (t ResultExportTask) ToTaskRequest() TaskRequest {
 func ResultExportTaskFromParams(params map[string]interface{}) ResultExportTask {
 	s := func(k string) string { v, _ := params[k].(string); return v }
 	return ResultExportTask{
-		Bucket: s("bucket"),
-		Prefix: s("prefix"),
-		Region: s("region"),
+		Bucket:       s("bucket"),
+		Prefix:       s("prefix"),
+		Region:       s("region"),
+		CanonicalRPC: s("canonicalRpc"),
 	}
 }
 

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -584,9 +584,6 @@ func TestResultExportRoundTrip(t *testing.T) {
 			if req.Type != TaskTypeResultExport {
 				return false
 			}
-			if req.Schedule != nil {
-				return false
-			}
 			rebuilt := ResultExportTaskFromParams(*req.Params)
 			return rebuilt.Bucket == task.Bucket &&
 				rebuilt.Region == task.Region
@@ -621,27 +618,34 @@ func TestResultExportValidation(t *testing.T) {
 	}
 }
 
-func TestResultExportTask_NoSchedule(t *testing.T) {
-	task := ResultExportTask{Bucket: "b", Region: "r"}
+func TestResultExportTask_WithCanonicalRPC(t *testing.T) {
+	task := ResultExportTask{
+		Bucket:       "b",
+		Prefix:       "shadow-results/pacific-1/",
+		Region:       "eu-central-1",
+		CanonicalRPC: "http://canonical-rpc:26657",
+	}
 	req := task.ToTaskRequest()
-	if req.Schedule != nil {
-		t.Errorf("expected nil Schedule, got %v", req.Schedule)
+	p := *req.Params
+	if p["canonicalRpc"] != "http://canonical-rpc:26657" {
+		t.Errorf("canonicalRpc = %v, want %q", p["canonicalRpc"], "http://canonical-rpc:26657")
+	}
+
+	rebuilt := ResultExportTaskFromParams(p)
+	if rebuilt.CanonicalRPC != task.CanonicalRPC {
+		t.Errorf("round-trip CanonicalRPC = %q, want %q", rebuilt.CanonicalRPC, task.CanonicalRPC)
+	}
+	if rebuilt.Bucket != task.Bucket {
+		t.Errorf("round-trip Bucket = %q, want %q", rebuilt.Bucket, task.Bucket)
 	}
 }
 
-func TestResultExportTask_WithSchedule(t *testing.T) {
-	cron := "*/10 * * * *"
-	task := ResultExportTask{
-		Bucket:   "b",
-		Region:   "r",
-		Schedule: &ScheduleConfig{Cron: &cron},
-	}
+func TestResultExportTask_WithoutCanonicalRPC_OmitsParam(t *testing.T) {
+	task := ResultExportTask{Bucket: "b", Region: "r"}
 	req := task.ToTaskRequest()
-	if req.Schedule == nil || req.Schedule.Cron == nil {
-		t.Fatal("expected schedule.cron to be set")
-	}
-	if *req.Schedule.Cron != cron {
-		t.Errorf("schedule.cron = %q, want %q", *req.Schedule.Cron, cron)
+	p := *req.Params
+	if _, ok := p["canonicalRpc"]; ok {
+		t.Errorf("expected canonicalRpc to be absent, got %v", p["canonicalRpc"])
 	}
 }
 

--- a/sidecar/shadow/comparator.go
+++ b/sidecar/shadow/comparator.go
@@ -1,0 +1,64 @@
+package shadow
+
+import (
+	"context"
+	"time"
+
+	"github.com/sei-protocol/seilog"
+)
+
+var log = seilog.NewLogger("seictl", "shadow")
+
+// Comparator performs block-by-block comparison between a shadow node and
+// a canonical chain node via their RPC endpoints.
+type Comparator struct {
+	shadowRPC    string
+	canonicalRPC string
+}
+
+// NewComparator creates a Comparator that queries shadowRPC for the local
+// shadow node and canonicalRPC for the reference chain.
+func NewComparator(shadowRPC, canonicalRPC string) *Comparator {
+	return &Comparator{
+		shadowRPC:    shadowRPC,
+		canonicalRPC: canonicalRPC,
+	}
+}
+
+// CompareBlock performs a layered comparison for the given block height.
+// Layer 0 (block headers) always runs. If Layer 0 detects a divergence,
+// Layer 1 (transaction receipts) is run to provide diagnostic detail.
+func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareResult, error) {
+	result := &CompareResult{
+		Height:    height,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Match:     true,
+	}
+
+	// --- Layer 0: block header comparison ---
+	l0, err := c.compareLayer0(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+	result.Layer0 = *l0
+
+	if !l0.Match() {
+		result.Match = false
+		layer := 0
+		result.DivergenceLayer = &layer
+
+		// --- Layer 1: transaction receipt comparison ---
+		l1, err := c.compareLayer1(ctx, height)
+		if err != nil {
+			log.Warn("layer 1 comparison failed, returning layer 0 result only",
+				"height", height, "err", err)
+		} else {
+			result.Layer1 = l1
+			if l1 != nil && len(l1.Divergences) > 0 {
+				layer = 1
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/sidecar/shadow/comparator_test.go
+++ b/sidecar/shadow/comparator_test.go
@@ -1,0 +1,208 @@
+package shadow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// blockJSON builds a minimal /block response with the given header fields.
+func blockJSON(appHash, lastResultsHash string) []byte {
+	resp := map[string]any{
+		"result": map[string]any{
+			"block": map[string]any{
+				"header": map[string]any{
+					"app_hash":          appHash,
+					"last_results_hash": lastResultsHash,
+				},
+			},
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+// blockResultsJSON builds a minimal /block_results response.
+func blockResultsJSON(txs []txResult) []byte {
+	resp := map[string]any{
+		"result": map[string]any{
+			"txs_results": txs,
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+// rpcServer creates an httptest server that responds to /block and /block_results.
+func rpcServer(appHash, lastResultsHash string, txs []txResult) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/block":
+			w.Write(blockJSON(appHash, lastResultsHash))
+		case r.URL.Path == "/block_results":
+			w.Write(blockResultsJSON(txs))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestCompareBlock_Match(t *testing.T) {
+	srv := rpcServer("AABB", "CCDD", nil)
+	defer srv.Close()
+
+	comp := NewComparator(srv.URL, srv.URL)
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if !result.Match {
+		t.Error("expected match when both endpoints return identical data")
+	}
+	if result.DivergenceLayer != nil {
+		t.Errorf("expected nil divergence layer, got %d", *result.DivergenceLayer)
+	}
+	if !result.Layer0.AppHashMatch {
+		t.Error("expected AppHash match")
+	}
+	if result.Layer1 != nil {
+		t.Error("expected nil Layer1 when Layer0 matches")
+	}
+}
+
+func TestCompareBlock_Layer0Divergence(t *testing.T) {
+	shadowSrv := rpcServer("SHADOW_HASH", "RESULTS_HASH", nil)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CANONICAL_HASH", "RESULTS_HASH", nil)
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL)
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Match {
+		t.Error("expected divergence")
+	}
+	if result.DivergenceLayer == nil || *result.DivergenceLayer != 0 {
+		t.Errorf("expected divergence layer 0, got %v", result.DivergenceLayer)
+	}
+	if result.Layer0.AppHashMatch {
+		t.Error("expected AppHash mismatch")
+	}
+	if result.Layer0.ShadowAppHash != "SHADOW_HASH" {
+		t.Errorf("shadow app hash = %q, want SHADOW_HASH", result.Layer0.ShadowAppHash)
+	}
+	if result.Layer0.CanonicalAppHash != "CANONICAL_HASH" {
+		t.Errorf("canonical app hash = %q, want CANONICAL_HASH", result.Layer0.CanonicalAppHash)
+	}
+}
+
+func TestCompareBlock_Layer1TxDivergence(t *testing.T) {
+	shadowTxs := []txResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200", Log: "ok", Events: json.RawMessage(`[]`)},
+	}
+	canonicalTxs := []txResult{
+		{Code: 1, GasUsed: "150", GasWanted: "200", Log: "reverted", Events: json.RawMessage(`[]`)},
+	}
+
+	shadowSrv := rpcServer("AAA", "BBB", shadowTxs)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CCC", "BBB", canonicalTxs)
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL)
+	result, err := comp.CompareBlock(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Match {
+		t.Error("expected divergence")
+	}
+	if result.Layer1 == nil {
+		t.Fatal("expected Layer1 to be populated")
+	}
+	if len(result.Layer1.Divergences) != 1 {
+		t.Fatalf("expected 1 tx divergence, got %d", len(result.Layer1.Divergences))
+	}
+
+	div := result.Layer1.Divergences[0]
+	if div.TxIndex != 0 {
+		t.Errorf("tx index = %d, want 0", div.TxIndex)
+	}
+
+	// Should have divergences for code, gasUsed, and log.
+	fieldNames := make(map[string]bool)
+	for _, f := range div.Fields {
+		fieldNames[f.Field] = true
+	}
+	for _, expected := range []string{"code", "gasUsed", "log"} {
+		if !fieldNames[expected] {
+			t.Errorf("expected field %q in divergences", expected)
+		}
+	}
+}
+
+func TestCompareBlock_Layer1TxCountMismatch(t *testing.T) {
+	shadowTxs := []txResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200"},
+		{Code: 0, GasUsed: "100", GasWanted: "200"},
+	}
+	canonicalTxs := []txResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200"},
+	}
+
+	shadowSrv := rpcServer("AAA", "BBB", shadowTxs)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CCC", "BBB", canonicalTxs)
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL)
+	result, err := comp.CompareBlock(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Layer1 == nil {
+		t.Fatal("expected Layer1 result")
+	}
+	if result.Layer1.TxCountMatch {
+		t.Error("expected tx count mismatch")
+	}
+
+	// Extra tx on shadow side should be reported as "presence" divergence.
+	found := false
+	for _, d := range result.Layer1.Divergences {
+		for _, f := range d.Fields {
+			if f.Field == "presence" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a presence divergence for the extra tx")
+	}
+}
+
+func TestCompareBlock_RPCError(t *testing.T) {
+	badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "internal error")
+	}))
+	defer badSrv.Close()
+
+	goodSrv := rpcServer("AA", "BB", nil)
+	defer goodSrv.Close()
+
+	comp := NewComparator(badSrv.URL, goodSrv.URL)
+	_, err := comp.CompareBlock(context.Background(), 1)
+	if err == nil {
+		t.Error("expected error when shadow RPC fails")
+	}
+}

--- a/sidecar/shadow/comparator_test.go
+++ b/sidecar/shadow/comparator_test.go
@@ -190,6 +190,87 @@ func TestCompareBlock_Layer1TxCountMismatch(t *testing.T) {
 	}
 }
 
+func TestCompareResult_Diverged(t *testing.T) {
+	match := CompareResult{Match: true}
+	if match.Diverged() {
+		t.Error("expected Diverged()=false for matching result")
+	}
+
+	mismatch := CompareResult{Match: false}
+	if !mismatch.Diverged() {
+		t.Error("expected Diverged()=true for mismatching result")
+	}
+}
+
+func TestLayer0Result_Match(t *testing.T) {
+	cases := []struct {
+		name string
+		r    Layer0Result
+		want bool
+	}{
+		{"all match", Layer0Result{AppHashMatch: true, LastResultsHashMatch: true, GasUsedMatch: true}, true},
+		{"app hash mismatch", Layer0Result{AppHashMatch: false, LastResultsHashMatch: true, GasUsedMatch: true}, false},
+		{"results hash mismatch", Layer0Result{AppHashMatch: true, LastResultsHashMatch: false, GasUsedMatch: true}, false},
+		{"gas mismatch", Layer0Result{AppHashMatch: true, LastResultsHashMatch: true, GasUsedMatch: false}, false},
+		{"all mismatch", Layer0Result{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.Match(); got != tc.want {
+				t.Errorf("Match() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareBlock_AllMatch_NoLayer1(t *testing.T) {
+	srv := rpcServer("SAME", "SAME", nil)
+	defer srv.Close()
+
+	comp := NewComparator(srv.URL, srv.URL)
+	result, err := comp.CompareBlock(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+	if !result.Match {
+		t.Error("expected match")
+	}
+	if result.Layer0.ShadowAppHash != "" {
+		t.Error("expected empty ShadowAppHash when matching")
+	}
+	if result.Layer0.CanonicalAppHash != "" {
+		t.Error("expected empty CanonicalAppHash when matching")
+	}
+	if result.Layer1 != nil {
+		t.Error("expected nil Layer1 when all hashes match")
+	}
+}
+
+func TestCompareBlock_LastResultsHashDivergence(t *testing.T) {
+	shadowSrv := rpcServer("SAME_APP", "SHADOW_RES", nil)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("SAME_APP", "CANONICAL_RES", nil)
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL)
+	result, err := comp.CompareBlock(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+	if result.Match {
+		t.Error("expected divergence on LastResultsHash mismatch")
+	}
+	if !result.Layer0.AppHashMatch {
+		t.Error("expected AppHash to match")
+	}
+	if result.Layer0.LastResultsHashMatch {
+		t.Error("expected LastResultsHash mismatch")
+	}
+	if result.Layer0.ShadowLastResultsHash != "SHADOW_RES" {
+		t.Errorf("ShadowLastResultsHash = %q, want SHADOW_RES", result.Layer0.ShadowLastResultsHash)
+	}
+}
+
 func TestCompareBlock_RPCError(t *testing.T) {
 	badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/sidecar/shadow/layer0.go
+++ b/sidecar/shadow/layer0.go
@@ -1,0 +1,86 @@
+package shadow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// compareLayer0 fetches the block header from both chains at the given
+// height and compares AppHash, LastResultsHash, and total gas used.
+func (c *Comparator) compareLayer0(ctx context.Context, height int64) (*Layer0Result, error) {
+	shadowBlock, err := queryBlock(ctx, c.shadowRPC, height)
+	if err != nil {
+		return nil, fmt.Errorf("querying shadow block at height %d: %w", height, err)
+	}
+	canonicalBlock, err := queryBlock(ctx, c.canonicalRPC, height)
+	if err != nil {
+		return nil, fmt.Errorf("querying canonical block at height %d: %w", height, err)
+	}
+
+	sHeader := shadowBlock.header()
+	cHeader := canonicalBlock.header()
+
+	sAppHash := sHeader.AppHash
+	cAppHash := cHeader.AppHash
+	sLastResults := sHeader.LastResultsHash
+	cLastResults := cHeader.LastResultsHash
+
+	// Gas is summed from block_results; the block header doesn't carry it
+	// directly. For L0 we compare what the header gives us. Gas comparison
+	// via block_results happens implicitly in L1.
+	// For now, mark gas as matching at L0; a future enhancement can pull
+	// gas from the block_results endpoint at this layer.
+	gasMatch := true
+
+	result := &Layer0Result{
+		AppHashMatch:         sAppHash == cAppHash,
+		LastResultsHashMatch: sLastResults == cLastResults,
+		GasUsedMatch:         gasMatch,
+	}
+
+	if !result.AppHashMatch {
+		result.ShadowAppHash = sAppHash
+		result.CanonicalAppHash = cAppHash
+	}
+	if !result.LastResultsHashMatch {
+		result.ShadowLastResultsHash = sLastResults
+		result.CanonicalLastResultsHash = cLastResults
+	}
+
+	return result, nil
+}
+
+// blockResponse is the subset of the Tendermint /block RPC response
+// that we need for header comparison.
+type blockResponse struct {
+	Result struct {
+		Block struct {
+			Header blockHeader `json:"header"`
+		} `json:"block"`
+	} `json:"result"`
+}
+
+type blockHeader struct {
+	AppHash         string `json:"app_hash"`
+	LastResultsHash string `json:"last_results_hash"`
+}
+
+func (b *blockResponse) header() blockHeader {
+	return b.Result.Block.Header
+}
+
+// queryBlock fetches the block at the given height from a Tendermint RPC endpoint.
+func queryBlock(ctx context.Context, rpcEndpoint string, height int64) (*blockResponse, error) {
+	url := fmt.Sprintf("%s/block?height=%d", rpcEndpoint, height)
+	body, err := rpcGet(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp blockResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decoding /block response: %w", err)
+	}
+	return &resp, nil
+}

--- a/sidecar/shadow/layer1.go
+++ b/sidecar/shadow/layer1.go
@@ -1,0 +1,138 @@
+package shadow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// compareLayer1 fetches block_results from both chains and compares
+// individual transaction receipts to identify which transactions diverged.
+func (c *Comparator) compareLayer1(ctx context.Context, height int64) (*Layer1Result, error) {
+	shadowResults, err := queryBlockResults(ctx, c.shadowRPC, height)
+	if err != nil {
+		return nil, fmt.Errorf("querying shadow block_results at height %d: %w", height, err)
+	}
+	canonicalResults, err := queryBlockResults(ctx, c.canonicalRPC, height)
+	if err != nil {
+		return nil, fmt.Errorf("querying canonical block_results at height %d: %w", height, err)
+	}
+
+	sTxs := shadowResults.txResults()
+	cTxs := canonicalResults.txResults()
+
+	result := &Layer1Result{
+		TotalTxs:     max(len(sTxs), len(cTxs)),
+		TxCountMatch: len(sTxs) == len(cTxs),
+	}
+
+	// Compare the overlapping transactions.
+	minLen := min(len(sTxs), len(cTxs))
+	for i := 0; i < minLen; i++ {
+		divergence := compareTxReceipts(i, sTxs[i], cTxs[i])
+		if divergence != nil {
+			result.Divergences = append(result.Divergences, *divergence)
+		}
+	}
+
+	// Any extra transactions on either side are divergences by definition.
+	if len(sTxs) > minLen {
+		for i := minLen; i < len(sTxs); i++ {
+			result.Divergences = append(result.Divergences, TxDivergence{
+				TxIndex: i,
+				Fields: []FieldDivergence{{
+					Field:     "presence",
+					Shadow:    "present",
+					Canonical: "missing",
+				}},
+			})
+		}
+	}
+	if len(cTxs) > minLen {
+		for i := minLen; i < len(cTxs); i++ {
+			result.Divergences = append(result.Divergences, TxDivergence{
+				TxIndex: i,
+				Fields: []FieldDivergence{{
+					Field:     "presence",
+					Shadow:    "missing",
+					Canonical: "present",
+				}},
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// compareTxReceipts compares critical fields from two transaction results.
+// Returns nil when the receipts match.
+func compareTxReceipts(idx int, shadow, canonical txResult) *TxDivergence {
+	var fields []FieldDivergence
+
+	if shadow.Code != canonical.Code {
+		fields = append(fields, FieldDivergence{
+			Field: "code", Shadow: shadow.Code, Canonical: canonical.Code,
+		})
+	}
+	if shadow.GasUsed != canonical.GasUsed {
+		fields = append(fields, FieldDivergence{
+			Field: "gasUsed", Shadow: shadow.GasUsed, Canonical: canonical.GasUsed,
+		})
+	}
+	if shadow.GasWanted != canonical.GasWanted {
+		fields = append(fields, FieldDivergence{
+			Field: "gasWanted", Shadow: shadow.GasWanted, Canonical: canonical.GasWanted,
+		})
+	}
+	if shadow.Log != canonical.Log {
+		fields = append(fields, FieldDivergence{
+			Field: "log", Shadow: shadow.Log, Canonical: canonical.Log,
+		})
+	}
+	if !reflect.DeepEqual(shadow.Events, canonical.Events) {
+		fields = append(fields, FieldDivergence{
+			Field: "events", Shadow: shadow.Events, Canonical: canonical.Events,
+		})
+	}
+
+	if len(fields) == 0 {
+		return nil
+	}
+	return &TxDivergence{TxIndex: idx, Fields: fields}
+}
+
+// blockResultsResponse is the subset of the Tendermint /block_results
+// RPC response needed for transaction receipt comparison.
+type blockResultsResponse struct {
+	Result struct {
+		TxsResults []txResult `json:"txs_results"`
+	} `json:"result"`
+}
+
+type txResult struct {
+	Code      int             `json:"code"`
+	Log       string          `json:"log"`
+	GasUsed   string          `json:"gas_used"`
+	GasWanted string          `json:"gas_wanted"`
+	Events    json.RawMessage `json:"events"`
+}
+
+func (b *blockResultsResponse) txResults() []txResult {
+	return b.Result.TxsResults
+}
+
+// queryBlockResults fetches /block_results at the given height.
+func queryBlockResults(ctx context.Context, rpcEndpoint string, height int64) (*blockResultsResponse, error) {
+	url := fmt.Sprintf("%s/block_results?height=%d", rpcEndpoint, height)
+	body, err := rpcGet(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp blockResultsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decoding /block_results response: %w", err)
+	}
+	return &resp, nil
+}

--- a/sidecar/shadow/rpc.go
+++ b/sidecar/shadow/rpc.go
@@ -1,0 +1,36 @@
+package shadow
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const rpcTimeout = 10 * time.Second
+
+// rpcGet performs an HTTP GET to the given URL and returns the response body.
+func rpcGet(ctx context.Context, url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(body))
+	}
+
+	return io.ReadAll(resp.Body)
+}

--- a/sidecar/shadow/types.go
+++ b/sidecar/shadow/types.go
@@ -1,0 +1,91 @@
+// Package shadow provides block-by-block comparison between a shadow
+// chain node and a canonical chain node. The comparison is layered:
+//
+//   - Layer 0: Block header hashes (AppHash, LastResultsHash, gas).
+//     If these match, the block is identical and deeper layers are skipped.
+//   - Layer 1: Transaction receipt comparison (status, gas, logs, etc.).
+//     Run only when Layer 0 fails, to isolate which transactions diverged.
+//   - Layer 2: State diff comparison (future).
+//   - Layer 3: Execution trace comparison (future).
+package shadow
+
+// CompareResult holds the comparison output for a single block.
+type CompareResult struct {
+	// Height is the block height that was compared.
+	Height int64 `json:"height"`
+
+	// Timestamp is the UTC time the comparison was performed.
+	Timestamp string `json:"timestamp"`
+
+	// Match is true when all checked layers agree between shadow and canonical.
+	Match bool `json:"match"`
+
+	// DivergenceLayer is the first layer that detected a mismatch.
+	// Nil when Match is true.
+	DivergenceLayer *int `json:"divergenceLayer,omitempty"`
+
+	// Layer0 holds the block-level hash comparison. Always populated.
+	Layer0 Layer0Result `json:"layer0"`
+
+	// Layer1 holds the transaction receipt comparison.
+	// Only populated when Layer 0 detected a divergence.
+	Layer1 *Layer1Result `json:"layer1,omitempty"`
+}
+
+// Diverged returns true when the comparison detected a mismatch at any layer.
+func (r *CompareResult) Diverged() bool {
+	return !r.Match
+}
+
+// Layer0Result compares block-level hashes. This is the cheapest check;
+// if all fields match, the block is identical and no further comparison
+// is needed.
+type Layer0Result struct {
+	AppHashMatch         bool `json:"appHashMatch"`
+	LastResultsHashMatch bool `json:"lastResultsHashMatch"`
+	GasUsedMatch         bool `json:"gasUsedMatch"`
+
+	// Raw values are included when there is a mismatch, for diagnostics.
+	ShadowAppHash    string `json:"shadowAppHash,omitempty"`
+	CanonicalAppHash string `json:"canonicalAppHash,omitempty"`
+
+	ShadowLastResultsHash    string `json:"shadowLastResultsHash,omitempty"`
+	CanonicalLastResultsHash string `json:"canonicalLastResultsHash,omitempty"`
+
+	ShadowGasUsed    int64 `json:"shadowGasUsed,omitempty"`
+	CanonicalGasUsed int64 `json:"canonicalGasUsed,omitempty"`
+}
+
+// Match returns true when all Layer 0 fields agree.
+func (r Layer0Result) Match() bool {
+	return r.AppHashMatch && r.LastResultsHashMatch && r.GasUsedMatch
+}
+
+// Layer1Result compares individual transaction receipts within a block.
+// Only populated when Layer 0 fails.
+type Layer1Result struct {
+	// TotalTxs is the number of transactions in the block.
+	TotalTxs int `json:"totalTxs"`
+
+	// TxCountMatch is true when both chains have the same number of txs.
+	TxCountMatch bool `json:"txCountMatch"`
+
+	// Divergences lists the per-transaction differences found.
+	Divergences []TxDivergence `json:"divergences,omitempty"`
+}
+
+// TxDivergence records a mismatch for a single transaction within a block.
+type TxDivergence struct {
+	// TxIndex is the position of the transaction within the block.
+	TxIndex int `json:"txIndex"`
+
+	// Fields lists which receipt fields diverged.
+	Fields []FieldDivergence `json:"fields"`
+}
+
+// FieldDivergence records a single field-level mismatch in a tx receipt.
+type FieldDivergence struct {
+	Field     string `json:"field"`
+	Shadow    any    `json:"shadow"`
+	Canonical any    `json:"canonical"`
+}

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -1,0 +1,199 @@
+package tasks
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+	"github.com/sei-protocol/seictl/sidecar/shadow"
+)
+
+const (
+	comparePollInterval = 5 * time.Second
+	comparePageSize     = 100
+)
+
+// ExportAndCompare runs a continuous comparison loop between the local
+// shadow node and a canonical chain. For each block it performs a layered
+// comparison via shadow.Comparator and streams the results as gzipped
+// NDJSON pages to S3. When app-hash divergence is detected, the final
+// page (including the divergent block) is flushed and the task completes
+// successfully — signaling the controller that divergence was found.
+func (e *ResultExporter) ExportAndCompare(ctx context.Context, cfg ResultExportConfig) error {
+	comp := shadow.NewComparator(cfg.RPCEndpoint, cfg.CanonicalRPC)
+	last := e.readExportState()
+	height := last.LastExportedHeight + 1
+	prefix := normalizePrefix(cfg.Prefix)
+
+	uploader, err := e.s3UploaderFactory(ctx, cfg.Region)
+	if err != nil {
+		return fmt.Errorf("building S3 uploader: %w", err)
+	}
+
+	exportLog.Info("starting block comparison",
+		"start-height", height,
+		"canonical-rpc", cfg.CanonicalRPC,
+		"bucket", cfg.Bucket)
+
+	var pageBuf []shadow.CompareResult
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// Wait for the shadow node to produce blocks at or beyond our target.
+		latestHeight, err := queryLatestHeight(ctx, cfg.RPCEndpoint)
+		if err != nil {
+			exportLog.Debug("shadow RPC unavailable, will retry", "err", err)
+			if err := sleep(ctx, comparePollInterval); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if height > latestHeight {
+			if err := sleep(ctx, comparePollInterval); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Compare all available blocks up to the latest height.
+		for height <= latestHeight {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			result, err := comp.CompareBlock(ctx, height)
+			if err != nil {
+				exportLog.Warn("comparison failed, will retry", "height", height, "err", err)
+				if err := sleep(ctx, comparePollInterval); err != nil {
+					return err
+				}
+				break
+			}
+
+			pageBuf = append(pageBuf, *result)
+
+			if result.Diverged() {
+				exportLog.Info("app-hash divergence detected",
+					"height", height,
+					"shadow-app-hash", result.Layer0.ShadowAppHash,
+					"canonical-app-hash", result.Layer0.CanonicalAppHash)
+
+				// Flush the final page including the divergent block.
+				if err := flushComparePage(ctx, uploader, cfg.Bucket, prefix, pageBuf); err != nil {
+					return fmt.Errorf("flushing final comparison page: %w", err)
+				}
+				if err := e.writeExportState(exportState{LastExportedHeight: height}); err != nil {
+					exportLog.Warn("failed to persist export state", "err", err)
+				}
+
+				// Task completes successfully — the controller sees "completed"
+				// and knows divergence was found.
+				return nil
+			}
+
+			// Flush page when buffer is full.
+			if len(pageBuf) >= comparePageSize {
+				if err := flushComparePage(ctx, uploader, cfg.Bucket, prefix, pageBuf); err != nil {
+					exportLog.Warn("page flush failed, will retry", "err", err)
+					break
+				}
+				if err := e.writeExportState(exportState{LastExportedHeight: height}); err != nil {
+					exportLog.Warn("failed to persist export state", "err", err)
+				}
+				pageBuf = pageBuf[:0]
+			}
+
+			height++
+		}
+	}
+}
+
+// flushComparePage streams a page of comparison results as gzipped NDJSON to S3.
+func flushComparePage(ctx context.Context, uploader seis3.Uploader, bucket, prefix string, results []shadow.CompareResult) error {
+	if len(results) == 0 {
+		return nil
+	}
+
+	start := results[0].Height
+	end := results[len(results)-1].Height
+	key := fmt.Sprintf("%s%d-%d.compare.ndjson.gz", prefix, start, end)
+
+	exportLog.Info("flushing comparison page", "key", key, "blocks", len(results))
+
+	pr, pw := io.Pipe()
+
+	writeErr := make(chan error, 1)
+	go func() {
+		writeErr <- writeCompareNDJSON(results, pw)
+	}()
+
+	_, uploadErr := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        pr,
+		ContentType: aws.String("application/gzip"),
+	})
+
+	if uploadErr != nil {
+		pr.CloseWithError(uploadErr)
+	}
+
+	wErr := <-writeErr
+	if uploadErr != nil {
+		return uploadErr
+	}
+	return wErr
+}
+
+// writeCompareNDJSON writes gzipped NDJSON comparison results to wc.
+func writeCompareNDJSON(results []shadow.CompareResult, wc io.WriteCloser) (retErr error) {
+	defer func() {
+		if retErr != nil {
+			wc.(*io.PipeWriter).CloseWithError(retErr)
+		} else {
+			_ = wc.Close()
+		}
+	}()
+
+	gw := gzip.NewWriter(wc)
+	defer func() {
+		if err := gw.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing gzip writer: %w", err)
+		}
+	}()
+
+	for _, r := range results {
+		line, err := json.Marshal(r)
+		if err != nil {
+			return fmt.Errorf("marshaling comparison at height %d: %w", r.Height, err)
+		}
+		line = append(line, '\n')
+		if _, err := gw.Write(line); err != nil {
+			return fmt.Errorf("writing comparison at height %d: %w", r.Height, err)
+		}
+	}
+
+	return nil
+}
+
+// sleep blocks until the duration elapses or ctx is cancelled.
+func sleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -38,6 +38,11 @@ type ResultExportConfig struct {
 	Prefix      string
 	Region      string
 	RPCEndpoint string
+
+	// CanonicalRPC enables comparison mode. When set, the exporter compares
+	// local block execution against this canonical RPC endpoint and completes
+	// when app-hash divergence is detected.
+	CanonicalRPC string
 }
 
 type exportState struct {
@@ -63,6 +68,9 @@ func (e *ResultExporter) Handler() engine.TaskHandler {
 		cfg, err := parseExportConfig(params)
 		if err != nil {
 			return err
+		}
+		if cfg.CanonicalRPC != "" {
+			return e.ExportAndCompare(ctx, cfg)
 		}
 		return e.Export(ctx, cfg)
 	}
@@ -296,6 +304,7 @@ func parseExportConfig(params map[string]any) (ResultExportConfig, error) {
 	prefix, _ := params["prefix"].(string)
 	region, _ := params["region"].(string)
 	rpcEndpoint, _ := params["rpcEndpoint"].(string)
+	canonicalRPC, _ := params["canonicalRpc"].(string)
 
 	if bucket == "" {
 		return ResultExportConfig{}, fmt.Errorf("result-export: missing required param 'bucket'")
@@ -308,10 +317,11 @@ func parseExportConfig(params map[string]any) (ResultExportConfig, error) {
 	}
 
 	return ResultExportConfig{
-		Bucket:      bucket,
-		Prefix:      prefix,
-		Region:      region,
-		RPCEndpoint: rpcEndpoint,
+		Bucket:       bucket,
+		Prefix:       prefix,
+		Region:       region,
+		RPCEndpoint:  rpcEndpoint,
+		CanonicalRPC: canonicalRPC,
 	}, nil
 }
 

--- a/sidecar/tasks/result_export_test.go
+++ b/sidecar/tasks/result_export_test.go
@@ -195,12 +195,13 @@ func TestExportWritesStateAfterPage(t *testing.T) {
 
 func TestParseExportConfig(t *testing.T) {
 	cases := []struct {
-		name            string
-		params          map[string]any
-		wantErr         bool
-		wantBucket      string
-		wantRegion      string
-		wantRPCEndpoint string
+		name             string
+		params           map[string]any
+		wantErr          bool
+		wantBucket       string
+		wantRegion       string
+		wantRPCEndpoint  string
+		wantCanonicalRPC string
 	}{
 		{
 			name:    "missing bucket",
@@ -226,6 +227,14 @@ func TestParseExportConfig(t *testing.T) {
 			wantRegion:      "r",
 			wantRPCEndpoint: "http://custom:26657",
 		},
+		{
+			name:             "valid with canonicalRpc",
+			params:           map[string]any{"bucket": "b", "region": "r", "canonicalRpc": "http://canonical:26657"},
+			wantBucket:       "b",
+			wantRegion:       "r",
+			wantRPCEndpoint:  defaultRPCEndpoint,
+			wantCanonicalRPC: "http://canonical:26657",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -248,6 +257,198 @@ func TestParseExportConfig(t *testing.T) {
 			if cfg.RPCEndpoint != tc.wantRPCEndpoint {
 				t.Errorf("RPCEndpoint = %q, want %q", cfg.RPCEndpoint, tc.wantRPCEndpoint)
 			}
+			if cfg.CanonicalRPC != tc.wantCanonicalRPC {
+				t.Errorf("CanonicalRPC = %q, want %q", cfg.CanonicalRPC, tc.wantCanonicalRPC)
+			}
 		})
 	}
+}
+
+// --- Handler routing tests ---
+
+func TestHandlerRouting_WithCanonicalRPC_CallsExportAndCompare(t *testing.T) {
+	// Set up matching shadow/canonical RPC servers so CompareBlock returns
+	// a match on every height. Then cancel the context to stop the loop.
+	srv := fakeRPCAndBlockServer(5, "AABB", "CCDD", nil)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so ExportAndCompare returns
+
+	err := e.Handler()(ctx, map[string]any{
+		"bucket":       "test-bucket",
+		"region":       "us-east-1",
+		"rpcEndpoint":  srv.URL,
+		"canonicalRpc": srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected context.Canceled error")
+	}
+}
+
+func TestHandlerRouting_WithoutCanonicalRPC_CallsExport(t *testing.T) {
+	srv := fakeRPCServer(0) // 0 blocks → nothing to export
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+
+	err := e.Handler()(context.Background(), map[string]any{
+		"bucket":      "test-bucket",
+		"region":      "us-east-1",
+		"rpcEndpoint": srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Handler() error = %v, want nil for empty export", err)
+	}
+}
+
+// --- ExportAndCompare tests ---
+
+func TestExportAndCompare_DivergenceDetected(t *testing.T) {
+	// Shadow returns different app hash than canonical → immediate divergence.
+	shadowSrv := fakeRPCAndBlockServer(5, "SHADOW_HASH", "RESULTS", nil)
+	defer shadowSrv.Close()
+	canonicalSrv := fakeRPCAndBlockServer(5, "CANONICAL_HASH", "RESULTS", nil)
+	defer canonicalSrv.Close()
+
+	tmpDir := t.TempDir()
+	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+
+	err := e.ExportAndCompare(context.Background(), ResultExportConfig{
+		Bucket:       "test-bucket",
+		Prefix:       "compare/",
+		Region:       "us-east-1",
+		RPCEndpoint:  shadowSrv.URL,
+		CanonicalRPC: canonicalSrv.URL,
+	})
+	// Divergence detected = task completes successfully (nil error).
+	if err != nil {
+		t.Fatalf("ExportAndCompare() error = %v, want nil (divergence = success)", err)
+	}
+
+	state := e.readExportState()
+	if state.LastExportedHeight != 1 {
+		t.Errorf("LastExportedHeight = %d, want 1 (diverged at first block)", state.LastExportedHeight)
+	}
+}
+
+func TestExportAndCompare_ContextCancelled(t *testing.T) {
+	// Both servers match → loop runs forever until context is cancelled.
+	srv := fakeRPCAndBlockServer(5, "SAME", "SAME", nil)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay to let the loop start.
+	go func() {
+		cancel()
+	}()
+
+	err := e.ExportAndCompare(ctx, ResultExportConfig{
+		Bucket:       "test-bucket",
+		Region:       "us-east-1",
+		RPCEndpoint:  srv.URL,
+		CanonicalRPC: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected context.Canceled error")
+	}
+}
+
+func TestExportAndCompare_S3UploaderError(t *testing.T) {
+	srv := fakeRPCAndBlockServer(5, "AA", "BB", nil)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	e := NewResultExporter(tmpDir, failingUploaderFactory("AWS creds expired"))
+
+	err := e.ExportAndCompare(context.Background(), ResultExportConfig{
+		Bucket:       "test-bucket",
+		Region:       "us-east-1",
+		RPCEndpoint:  srv.URL,
+		CanonicalRPC: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error from S3 uploader factory failure")
+	}
+}
+
+func TestExportAndCompare_ResumesFromExportState(t *testing.T) {
+	// Set export state to height 3, shadow serves up to 5.
+	// With matching hashes, it compares blocks 4 and 5 (no divergence).
+	// Set up divergence at block 4 by using different servers.
+	shadowSrv := fakeRPCAndBlockServer(5, "SHADOW", "RES", nil)
+	defer shadowSrv.Close()
+	canonicalSrv := fakeRPCAndBlockServer(5, "CANONICAL", "RES", nil)
+	defer canonicalSrv.Close()
+
+	tmpDir := t.TempDir()
+	stateData, _ := json.Marshal(exportState{LastExportedHeight: 3})
+	if err := os.WriteFile(filepath.Join(tmpDir, exportStateFile), stateData, 0o644); err != nil {
+		t.Fatalf("writing state: %v", err)
+	}
+
+	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	err := e.ExportAndCompare(context.Background(), ResultExportConfig{
+		Bucket:       "test-bucket",
+		Region:       "us-east-1",
+		RPCEndpoint:  shadowSrv.URL,
+		CanonicalRPC: canonicalSrv.URL,
+	})
+	if err != nil {
+		t.Fatalf("ExportAndCompare() error = %v", err)
+	}
+
+	state := e.readExportState()
+	if state.LastExportedHeight != 4 {
+		t.Errorf("LastExportedHeight = %d, want 4 (first block after resume)", state.LastExportedHeight)
+	}
+}
+
+// --- flushComparePage tests ---
+
+func TestFlushComparePage_EmptyResults(t *testing.T) {
+	err := flushComparePage(context.Background(), &mockResultUploader{}, "bucket", "prefix/", nil)
+	if err != nil {
+		t.Errorf("flushComparePage(nil) error = %v, want nil", err)
+	}
+}
+
+// --- Test helpers ---
+
+// fakeRPCAndBlockServer responds to /status, /block, and /block_results.
+func fakeRPCAndBlockServer(latestHeight int64, appHash, lastResultsHash string, txResults []json.RawMessage) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/status":
+			fmt.Fprintf(w, `{"sync_info":{"latest_block_height":"%d"}}`, latestHeight)
+		case r.URL.Path == "/block":
+			resp := map[string]any{
+				"result": map[string]any{
+					"block": map[string]any{
+						"header": map[string]any{
+							"app_hash":          appHash,
+							"last_results_hash": lastResultsHash,
+						},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/block_results":
+			resp := map[string]any{
+				"result": map[string]any{
+					"txs_results": txResults,
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
 }


### PR DESCRIPTION
## Summary

- Adds `CanonicalRPC` field to `ResultExportTask` client struct, enabling the sidecar to compare local block execution results against a canonical chain and complete when app-hash divergence is detected
- Removes `Schedule` from `ResultExportTask` — comparison mode is a one-shot long-running task, not cron-driven
- Adds `shadow` package with layered block result comparison (layer0: app-hash, layer1: per-tx results)
- Adds `ExportAndCompare` handler that runs continuously until divergence is found, uploading comparison results to S3

## Test plan

- [x] `ResultExportTask` round-trip tests with `CanonicalRPC`
- [x] `CanonicalRPC` param omitted when empty
- [x] Shadow comparator unit tests
- [x] Integration test with mock canonical RPC endpoint