### PR TITLE
refactor: TypedHandler[T] — typed params for all task handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Added by goreleaser init:
 dist/
+
+build/
+seictl
+report_scan.go

--- a/sidecar/engine/typed_handler.go
+++ b/sidecar/engine/typed_handler.go
@@ -1,0 +1,25 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// TypedHandler wraps a function that accepts typed params into a
+// TaskHandler. The map[string]any params are marshaled to JSON and
+// unmarshaled into the typed struct T, giving handlers compile-time
+// type safety without changing the engine's dispatch mechanism.
+func TypedHandler[T any](fn func(ctx context.Context, params T) error) TaskHandler {
+	return func(ctx context.Context, params map[string]any) error {
+		data, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("marshaling params: %w", err)
+		}
+		var typed T
+		if err := json.Unmarshal(data, &typed); err != nil {
+			return fmt.Errorf("parsing params: %w", err)
+		}
+		return fn(ctx, typed)
+	}
+}

--- a/sidecar/engine/typed_handler_test.go
+++ b/sidecar/engine/typed_handler_test.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTypedHandler_HappyPath(t *testing.T) {
+	type req struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	var captured req
+	handler := TypedHandler(func(_ context.Context, r req) error {
+		captured = r
+		return nil
+	})
+
+	err := handler(context.Background(), map[string]any{
+		"name": "alice",
+		"age":  float64(30),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.Name != "alice" {
+		t.Errorf("Name = %q, want %q", captured.Name, "alice")
+	}
+	if captured.Age != 30 {
+		t.Errorf("Age = %d, want 30", captured.Age)
+	}
+}
+
+func TestTypedHandler_MalformedJSON(t *testing.T) {
+	type req struct {
+		Value int `json:"value"`
+	}
+
+	handler := TypedHandler(func(_ context.Context, r req) error {
+		return nil
+	})
+
+	// A channel cannot be marshaled to JSON, causing a marshal error.
+	err := handler(context.Background(), map[string]any{
+		"value": make(chan int),
+	})
+	if err == nil {
+		t.Fatal("expected error for un-marshalable params")
+	}
+}
+
+func TestTypedHandler_NilParams(t *testing.T) {
+	type req struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	var captured req
+	handler := TypedHandler(func(_ context.Context, r req) error {
+		captured = r
+		return nil
+	})
+
+	err := handler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error for nil params: %v", err)
+	}
+	if captured.Name != "" {
+		t.Errorf("Name = %q, want empty string", captured.Name)
+	}
+	if captured.Age != 0 {
+		t.Errorf("Age = %d, want 0", captured.Age)
+	}
+}
+
+func TestTypedHandler_EmptyParams(t *testing.T) {
+	type req struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	var captured req
+	handler := TypedHandler(func(_ context.Context, r req) error {
+		captured = r
+		return nil
+	})
+
+	err := handler(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error for empty params: %v", err)
+	}
+	if captured.Name != "" {
+		t.Errorf("Name = %q, want empty string", captured.Name)
+	}
+	if captured.Age != 0 {
+		t.Errorf("Age = %d, want 0", captured.Age)
+	}
+}
+
+func TestTypedHandler_NestedStruct(t *testing.T) {
+	type inner struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+	type req struct {
+		Nested inner `json:"nested"`
+	}
+
+	var captured req
+	handler := TypedHandler(func(_ context.Context, r req) error {
+		captured = r
+		return nil
+	})
+
+	err := handler(context.Background(), map[string]any{
+		"nested": map[string]any{
+			"key":   "foo",
+			"value": "bar",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.Nested.Key != "foo" {
+		t.Errorf("Nested.Key = %q, want %q", captured.Nested.Key, "foo")
+	}
+	if captured.Nested.Value != "bar" {
+		t.Errorf("Nested.Value = %q, want %q", captured.Nested.Value, "bar")
+	}
+}
+
+func TestTypedHandler_Float64ToInt64Coercion(t *testing.T) {
+	type req struct {
+		Height int64 `json:"height"`
+	}
+
+	var captured req
+	handler := TypedHandler(func(_ context.Context, r req) error {
+		captured = r
+		return nil
+	})
+
+	// JSON numbers arrive as float64 when unmarshaled into map[string]any.
+	err := handler(context.Background(), map[string]any{
+		"height": float64(198030000),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.Height != 198030000 {
+		t.Errorf("Height = %d, want 198030000", captured.Height)
+	}
+}

--- a/sidecar/tasks/assemble_genesis.go
+++ b/sidecar/tasks/assemble_genesis.go
@@ -41,23 +41,23 @@ type GenesisAssembler struct {
 	s3UploaderFactory seis3.UploaderFactory
 }
 
-// assembleNodeEntry represents a single node in the "nodes" list param.
-type assembleNodeEntry struct {
+// AssembleNodeEntry represents a single node in the "nodes" list param.
+type AssembleNodeEntry struct {
 	Name string `json:"name"`
 }
 
-// assembleConfig holds the typed parameters for the assemble-and-upload-genesis task.
-type assembleConfig struct {
+// AssembleGenesisRequest holds the typed parameters for the assemble-and-upload-genesis task.
+type AssembleGenesisRequest struct {
 	Bucket         string              `json:"s3Bucket"`
 	Prefix         string              `json:"s3Prefix"`
 	Region         string              `json:"s3Region"`
 	AccountBalance string              `json:"accountBalance"`
 	Namespace      string              `json:"namespace"`
-	Nodes          []assembleNodeEntry `json:"nodes"`
+	Nodes          []AssembleNodeEntry `json:"nodes"`
 }
 
 // nodeNames returns the list of node name strings from the Nodes entries.
-func (c assembleConfig) nodeNames() []string {
+func (c AssembleGenesisRequest) nodeNames() []string {
 	names := make([]string, len(c.Nodes))
 	for i, n := range c.Nodes {
 		names[i] = n.Name
@@ -95,7 +95,7 @@ func NewGenesisAssembler(homeDir string, _ CommandRunner, s3Factory S3ClientFact
 //	  "nodes":      [{"name": "node-0"}, {"name": "node-1"}, ...]
 //	}
 func (a *GenesisAssembler) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg assembleConfig) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg AssembleGenesisRequest) error {
 		if markerExists(a.homeDir, assembleMarkerFile) {
 			assembleLog.Debug("already completed, skipping")
 			return nil
@@ -151,7 +151,7 @@ func (a *GenesisAssembler) Handler() engine.TaskHandler {
 
 // downloadGentxFiles fetches each node's gentx.json from S3 and writes
 // it to the local config/gentx/ directory.
-func (a *GenesisAssembler) downloadGentxFiles(ctx context.Context, cfg assembleConfig, nodes []string) error {
+func (a *GenesisAssembler) downloadGentxFiles(ctx context.Context, cfg AssembleGenesisRequest, nodes []string) error {
 	s3Client, err := a.s3ClientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("assemble-genesis: building S3 client: %w", err)
@@ -357,7 +357,7 @@ func (a *GenesisAssembler) collectGentxs() error {
 
 // uploadGenesis reads the assembled genesis.json and uploads it to S3
 // at <prefix>/genesis.json where all validators will fetch it from.
-func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg assembleConfig) error {
+func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg AssembleGenesisRequest) error {
 	genesisPath := filepath.Join(a.homeDir, "config", "genesis.json")
 	data, err := os.ReadFile(genesisPath)
 	if err != nil {
@@ -387,7 +387,7 @@ func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg assembleConfig
 // uploadPeers builds a peers.json from each node's identity.json and uploads
 // it to S3 alongside genesis.json. Each entry is a full Tendermint peer address
 // using in-cluster DNS: <nodeID>@<name>-0.<name>.<namespace>.svc.cluster.local:26656
-func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig, nodes []string) error {
+func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg AssembleGenesisRequest, nodes []string) error {
 	s3Client, err := a.s3ClientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("assemble-genesis: building S3 client for peers: %w", err)

--- a/sidecar/tasks/assemble_genesis.go
+++ b/sidecar/tasks/assemble_genesis.go
@@ -41,13 +41,28 @@ type GenesisAssembler struct {
 	s3UploaderFactory seis3.UploaderFactory
 }
 
+// assembleNodeEntry represents a single node in the "nodes" list param.
+type assembleNodeEntry struct {
+	Name string `json:"name"`
+}
+
+// assembleConfig holds the typed parameters for the assemble-and-upload-genesis task.
 type assembleConfig struct {
-	bucket         string
-	prefix         string
-	region         string
-	accountBalance string
-	namespace      string
-	nodes          []string
+	Bucket         string              `json:"s3Bucket"`
+	Prefix         string              `json:"s3Prefix"`
+	Region         string              `json:"s3Region"`
+	AccountBalance string              `json:"accountBalance"`
+	Namespace      string              `json:"namespace"`
+	Nodes          []assembleNodeEntry `json:"nodes"`
+}
+
+// nodeNames returns the list of node name strings from the Nodes entries.
+func (c assembleConfig) nodeNames() []string {
+	names := make([]string, len(c.Nodes))
+	for i, n := range c.Nodes {
+		names[i] = n.Name
+	}
+	return names
 }
 
 // NewGenesisAssembler creates an assembler targeting the given home directory.
@@ -80,22 +95,40 @@ func NewGenesisAssembler(homeDir string, _ CommandRunner, s3Factory S3ClientFact
 //	  "nodes":      [{"name": "node-0"}, {"name": "node-1"}, ...]
 //	}
 func (a *GenesisAssembler) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg assembleConfig) error {
 		if markerExists(a.homeDir, assembleMarkerFile) {
 			assembleLog.Debug("already completed, skipping")
 			return nil
 		}
 
-		cfg, err := parseAssembleConfig(params)
-		if err != nil {
+		if cfg.Bucket == "" {
+			return fmt.Errorf("assemble-genesis: missing required param 's3Bucket'")
+		}
+		if cfg.Region == "" {
+			return fmt.Errorf("assemble-genesis: missing required param 's3Region'")
+		}
+		if cfg.AccountBalance == "" {
+			return fmt.Errorf("assemble-genesis: missing required param 'accountBalance'")
+		}
+		if cfg.Namespace == "" {
+			return fmt.Errorf("assemble-genesis: missing required param 'namespace'")
+		}
+		if len(cfg.Nodes) == 0 {
+			return fmt.Errorf("assemble-genesis: 'nodes' list is empty")
+		}
+		for i, n := range cfg.Nodes {
+			if n.Name == "" {
+				return fmt.Errorf("assemble-genesis: nodes[%d] missing required field 'name'", i)
+			}
+		}
+
+		nodes := cfg.nodeNames()
+
+		if err := a.downloadGentxFiles(ctx, cfg, nodes); err != nil {
 			return err
 		}
 
-		if err := a.downloadGentxFiles(ctx, cfg); err != nil {
-			return err
-		}
-
-		if err := a.addMissingGenesisAccounts(cfg.accountBalance); err != nil {
+		if err := a.addMissingGenesisAccounts(cfg.AccountBalance); err != nil {
 			return err
 		}
 
@@ -107,19 +140,19 @@ func (a *GenesisAssembler) Handler() engine.TaskHandler {
 			return err
 		}
 
-		if err := a.uploadPeers(ctx, cfg); err != nil {
+		if err := a.uploadPeers(ctx, cfg, nodes); err != nil {
 			return err
 		}
 
-		assembleLog.Info("genesis assembled and uploaded", "nodes", len(cfg.nodes))
+		assembleLog.Info("genesis assembled and uploaded", "nodes", len(nodes))
 		return writeMarker(a.homeDir, assembleMarkerFile)
-	}
+	})
 }
 
 // downloadGentxFiles fetches each node's gentx.json from S3 and writes
 // it to the local config/gentx/ directory.
-func (a *GenesisAssembler) downloadGentxFiles(ctx context.Context, cfg assembleConfig) error {
-	s3Client, err := a.s3ClientFactory(ctx, cfg.region)
+func (a *GenesisAssembler) downloadGentxFiles(ctx context.Context, cfg assembleConfig, nodes []string) error {
+	s3Client, err := a.s3ClientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("assemble-genesis: building S3 client: %w", err)
 	}
@@ -129,15 +162,15 @@ func (a *GenesisAssembler) downloadGentxFiles(ctx context.Context, cfg assembleC
 		return fmt.Errorf("assemble-genesis: creating gentx dir: %w", err)
 	}
 
-	prefix := normalizePrefix(cfg.prefix)
+	prefix := normalizePrefix(cfg.Prefix)
 
-	downloaded := make(map[string]bool, len(cfg.nodes))
-	for _, nodeName := range cfg.nodes {
+	downloaded := make(map[string]bool, len(nodes))
+	for _, nodeName := range nodes {
 		key := fmt.Sprintf("%s%s/gentx.json", prefix, nodeName)
 		assembleLog.Info("downloading gentx", "node", nodeName, "key", key)
 
 		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
-			Bucket: aws.String(cfg.bucket),
+			Bucket: aws.String(cfg.Bucket),
 			Key:    aws.String(key),
 		})
 		if err != nil {
@@ -168,7 +201,7 @@ func (a *GenesisAssembler) downloadGentxFiles(ctx context.Context, cfg assembleC
 		}
 	}
 
-	assembleLog.Info("all gentx files downloaded", "count", len(cfg.nodes))
+	assembleLog.Info("all gentx files downloaded", "count", len(nodes))
 	return nil
 }
 
@@ -331,16 +364,16 @@ func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg assembleConfig
 		return fmt.Errorf("assemble-genesis: reading genesis.json: %w", err)
 	}
 
-	uploader, err := a.s3UploaderFactory(ctx, cfg.region)
+	uploader, err := a.s3UploaderFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("assemble-genesis: building S3 uploader: %w", err)
 	}
 
-	key := normalizePrefix(cfg.prefix) + "genesis.json"
+	key := normalizePrefix(cfg.Prefix) + "genesis.json"
 	assembleLog.Info("uploading assembled genesis", "key", key)
 
 	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
-		Bucket:      aws.String(cfg.bucket),
+		Bucket:      aws.String(cfg.Bucket),
 		Key:         aws.String(key),
 		Body:        bytes.NewReader(data),
 		ContentType: aws.String("application/json"),
@@ -354,19 +387,19 @@ func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg assembleConfig
 // uploadPeers builds a peers.json from each node's identity.json and uploads
 // it to S3 alongside genesis.json. Each entry is a full Tendermint peer address
 // using in-cluster DNS: <nodeID>@<name>-0.<name>.<namespace>.svc.cluster.local:26656
-func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig) error {
-	s3Client, err := a.s3ClientFactory(ctx, cfg.region)
+func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig, nodes []string) error {
+	s3Client, err := a.s3ClientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("assemble-genesis: building S3 client for peers: %w", err)
 	}
 
-	prefix := normalizePrefix(cfg.prefix)
+	prefix := normalizePrefix(cfg.Prefix)
 	var peers []string
 
-	for _, nodeName := range cfg.nodes {
+	for _, nodeName := range nodes {
 		key := fmt.Sprintf("%s%s/identity.json", prefix, nodeName)
 		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
-			Bucket: aws.String(cfg.bucket),
+			Bucket: aws.String(cfg.Bucket),
 			Key:    aws.String(key),
 		})
 		if err != nil {
@@ -395,7 +428,7 @@ func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig) 
 			return fmt.Errorf("assemble-genesis: empty node ID for %s", nodeName)
 		}
 
-		dns := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local", nodeName, nodeName, cfg.namespace)
+		dns := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local", nodeName, nodeName, cfg.Namespace)
 		peers = append(peers, fmt.Sprintf("%s@%s:26656", nodeKey.ID, dns))
 	}
 
@@ -404,7 +437,7 @@ func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig) 
 		return fmt.Errorf("assemble-genesis: marshaling peers.json: %w", err)
 	}
 
-	uploader, err := a.s3UploaderFactory(ctx, cfg.region)
+	uploader, err := a.s3UploaderFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("assemble-genesis: building S3 uploader for peers: %w", err)
 	}
@@ -413,7 +446,7 @@ func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig) 
 	assembleLog.Info("uploading peers.json", "key", peersKey, "count", len(peers))
 
 	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
-		Bucket:      aws.String(cfg.bucket),
+		Bucket:      aws.String(cfg.Bucket),
 		Key:         aws.String(peersKey),
 		Body:        bytes.NewReader(peersJSON),
 		ContentType: aws.String("application/json"),
@@ -422,61 +455,4 @@ func (a *GenesisAssembler) uploadPeers(ctx context.Context, cfg assembleConfig) 
 		return fmt.Errorf("assemble-genesis: uploading peers.json: %w", err)
 	}
 	return nil
-}
-
-func parseAssembleConfig(params map[string]any) (assembleConfig, error) {
-	bucket, _ := params["s3Bucket"].(string)
-	prefix, _ := params["s3Prefix"].(string)
-	region, _ := params["s3Region"].(string)
-	accountBalance, _ := params["accountBalance"].(string)
-	namespace, _ := params["namespace"].(string)
-
-	if bucket == "" {
-		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 's3Bucket'")
-	}
-	if region == "" {
-		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 's3Region'")
-	}
-	if accountBalance == "" {
-		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 'accountBalance'")
-	}
-	if namespace == "" {
-		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 'namespace'")
-	}
-
-	rawNodes, ok := params["nodes"]
-	if !ok {
-		return assembleConfig{}, fmt.Errorf("assemble-genesis: missing required param 'nodes'")
-	}
-
-	nodes, err := parseNodeNames(rawNodes)
-	if err != nil {
-		return assembleConfig{}, fmt.Errorf("assemble-genesis: %w", err)
-	}
-	if len(nodes) == 0 {
-		return assembleConfig{}, fmt.Errorf("assemble-genesis: 'nodes' list is empty")
-	}
-
-	return assembleConfig{bucket: bucket, prefix: prefix, region: region, accountBalance: accountBalance, namespace: namespace, nodes: nodes}, nil
-}
-
-func parseNodeNames(raw any) ([]string, error) {
-	items, ok := raw.([]any)
-	if !ok {
-		return nil, fmt.Errorf("'nodes' must be a list, got %T", raw)
-	}
-
-	names := make([]string, 0, len(items))
-	for i, item := range items {
-		m, ok := item.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("nodes[%d] is not an object", i)
-		}
-		name, _ := m["name"].(string)
-		if name == "" {
-			return nil, fmt.Errorf("nodes[%d] missing required field 'name'", i)
-		}
-		names = append(names, name)
-	}
-	return names, nil
 }

--- a/sidecar/tasks/assemble_genesis_test.go
+++ b/sidecar/tasks/assemble_genesis_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -43,15 +44,16 @@ func TestAssembler_DownloadsGentxFiles(t *testing.T) {
 	assembler := NewGenesisAssembler(homeDir, nil, s3Factory, mockUploaderFactory(newMockS3Uploader()))
 
 	cfg := assembleConfig{
-		bucket:         "my-bucket",
-		prefix:         "genesis/",
-		region:         "us-west-2",
-		accountBalance: "10000000usei",
-		namespace:      "default",
-		nodes:          []string{"val-0", "val-1"},
+		Bucket:         "my-bucket",
+		Prefix:         "genesis/",
+		Region:         "us-west-2",
+		AccountBalance: "10000000usei",
+		Namespace:      "default",
+		Nodes:          []assembleNodeEntry{{Name: "val-0"}, {Name: "val-1"}},
 	}
 
-	if err := assembler.downloadGentxFiles(context.Background(), cfg); err != nil {
+	nodes := cfg.nodeNames()
+	if err := assembler.downloadGentxFiles(context.Background(), cfg, nodes); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -104,24 +106,27 @@ func TestAssembler_S3DownloadFailure(t *testing.T) {
 	}
 }
 
-func TestParseNodeNames(t *testing.T) {
-	names, err := parseNodeNames([]any{
-		map[string]any{"name": "val-0"},
-		map[string]any{"name": "val-1"},
-	})
-	if err != nil {
+func TestParseAssembleNodes(t *testing.T) {
+	// Test that assembleNodeEntry JSON round-trips correctly.
+	raw := `[{"name":"val-0"},{"name":"val-1"}]`
+	var nodes []assembleNodeEntry
+	if err := json.Unmarshal([]byte(raw), &nodes); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(names) != 2 || names[0] != "val-0" || names[1] != "val-1" {
-		t.Errorf("names = %v, want [val-0 val-1]", names)
+	if len(nodes) != 2 || nodes[0].Name != "val-0" || nodes[1].Name != "val-1" {
+		t.Errorf("nodes = %v, want [{val-0} {val-1}]", nodes)
 	}
 }
 
-func TestParseNodeNames_MissingName(t *testing.T) {
-	_, err := parseNodeNames([]any{
-		map[string]any{"other": "field"},
-	})
-	if err == nil {
-		t.Fatal("expected error for missing name field")
+func TestParseAssembleNodes_MissingName(t *testing.T) {
+	// Test that empty names are caught by the handler validation.
+	raw := `[{"other":"field"}]`
+	var nodes []assembleNodeEntry
+	if err := json.Unmarshal([]byte(raw), &nodes); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The node should unmarshal but with empty Name — the handler validates this.
+	if nodes[0].Name != "" {
+		t.Fatalf("expected empty name, got %q", nodes[0].Name)
 	}
 }

--- a/sidecar/tasks/assemble_genesis_test.go
+++ b/sidecar/tasks/assemble_genesis_test.go
@@ -43,13 +43,13 @@ func TestAssembler_DownloadsGentxFiles(t *testing.T) {
 
 	assembler := NewGenesisAssembler(homeDir, nil, s3Factory, mockUploaderFactory(newMockS3Uploader()))
 
-	cfg := assembleConfig{
+	cfg := AssembleGenesisRequest{
 		Bucket:         "my-bucket",
 		Prefix:         "genesis/",
 		Region:         "us-west-2",
 		AccountBalance: "10000000usei",
 		Namespace:      "default",
-		Nodes:          []assembleNodeEntry{{Name: "val-0"}, {Name: "val-1"}},
+		Nodes:          []AssembleNodeEntry{{Name: "val-0"}, {Name: "val-1"}},
 	}
 
 	nodes := cfg.nodeNames()
@@ -107,9 +107,9 @@ func TestAssembler_S3DownloadFailure(t *testing.T) {
 }
 
 func TestParseAssembleNodes(t *testing.T) {
-	// Test that assembleNodeEntry JSON round-trips correctly.
+	// Test that AssembleNodeEntry JSON round-trips correctly.
 	raw := `[{"name":"val-0"},{"name":"val-1"}]`
-	var nodes []assembleNodeEntry
+	var nodes []AssembleNodeEntry
 	if err := json.Unmarshal([]byte(raw), &nodes); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestParseAssembleNodes(t *testing.T) {
 func TestParseAssembleNodes_MissingName(t *testing.T) {
 	// Test that empty names are caught by the handler validation.
 	raw := `[{"other":"field"}]`
-	var nodes []assembleNodeEntry
+	var nodes []AssembleNodeEntry
 	if err := json.Unmarshal([]byte(raw), &nodes); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sidecar/tasks/await_condition.go
+++ b/sidecar/tasks/await_condition.go
@@ -20,8 +20,8 @@ const (
 	heightPollInterval = 100 * time.Millisecond
 )
 
-// awaitConditionParams holds the typed parameters for the await-condition task.
-type awaitConditionParams struct {
+// AwaitConditionRequest holds the typed parameters for the await-condition task.
+type AwaitConditionRequest struct {
 	Condition    string `json:"condition"`
 	Action       string `json:"action"`
 	TargetHeight int64  `json:"targetHeight"`
@@ -43,7 +43,7 @@ func NewConditionWaiter(rpcClient *rpc.StatusClient) *ConditionWaiter {
 
 // Handler returns an engine.TaskHandler for the await-condition task type.
 func (w *ConditionWaiter) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, params awaitConditionParams) error {
+	return engine.TypedHandler(func(ctx context.Context, params AwaitConditionRequest) error {
 		if params.Condition == "" {
 			return fmt.Errorf("condition is required")
 		}

--- a/sidecar/tasks/await_condition.go
+++ b/sidecar/tasks/await_condition.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -21,6 +20,13 @@ const (
 	heightPollInterval = 100 * time.Millisecond
 )
 
+// awaitConditionParams holds the typed parameters for the await-condition task.
+type awaitConditionParams struct {
+	Condition    string `json:"condition"`
+	Action       string `json:"action"`
+	TargetHeight int64  `json:"targetHeight"`
+}
+
 // ConditionWaiter polls a local node until a condition is met, then
 // optionally executes a post-condition action.
 type ConditionWaiter struct {
@@ -37,35 +43,31 @@ func NewConditionWaiter(rpcClient *rpc.StatusClient) *ConditionWaiter {
 
 // Handler returns an engine.TaskHandler for the await-condition task type.
 func (w *ConditionWaiter) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		condition, ok := params["condition"].(string)
-		if !ok || condition == "" {
-			return fmt.Errorf("condition is required (got %T)", params["condition"])
+	return engine.TypedHandler(func(ctx context.Context, params awaitConditionParams) error {
+		if params.Condition == "" {
+			return fmt.Errorf("condition is required")
 		}
-		action, _ := params["action"].(string)
 
-		switch condition {
+		switch params.Condition {
 		case conditionHeight:
-			if err := w.awaitHeight(ctx, params); err != nil {
+			if params.TargetHeight <= 0 {
+				return fmt.Errorf("targetHeight must be > 0, got %d", params.TargetHeight)
+			}
+			if err := w.awaitHeight(ctx, params.TargetHeight); err != nil {
 				return err
 			}
 		default:
-			return fmt.Errorf("unknown condition %q", condition)
+			return fmt.Errorf("unknown condition %q", params.Condition)
 		}
 
-		if action == "" {
+		if params.Action == "" {
 			return nil
 		}
-		return w.executeAction(ctx, action)
-	}
+		return w.executeAction(ctx, params.Action)
+	})
 }
 
-func (w *ConditionWaiter) awaitHeight(ctx context.Context, params map[string]any) error {
-	targetHeight, err := parseTargetHeight(params)
-	if err != nil {
-		return err
-	}
-
+func (w *ConditionWaiter) awaitHeight(ctx context.Context, targetHeight int64) error {
 	awaitLog.Info("awaiting height", "target", targetHeight, "rpc", w.rpc.Endpoint())
 
 	var rpcHealthy bool
@@ -100,33 +102,6 @@ func (w *ConditionWaiter) awaitHeight(ctx context.Context, params map[string]any
 			awaitLog.Info("target height reached", "current", height, "target", targetHeight)
 			return nil
 		}
-	}
-}
-
-func parseTargetHeight(params map[string]any) (int64, error) {
-	switch v := params["targetHeight"].(type) {
-	case float64:
-		h := int64(v)
-		if h <= 0 {
-			return 0, fmt.Errorf("targetHeight must be > 0, got %d", h)
-		}
-		return h, nil
-	case int64:
-		if v <= 0 {
-			return 0, fmt.Errorf("targetHeight must be > 0, got %d", v)
-		}
-		return v, nil
-	case json.Number:
-		h, err := v.Int64()
-		if err != nil {
-			return 0, fmt.Errorf("parsing targetHeight: %w", err)
-		}
-		if h <= 0 {
-			return 0, fmt.Errorf("targetHeight must be > 0, got %d", h)
-		}
-		return h, nil
-	default:
-		return 0, fmt.Errorf("targetHeight is required (got %T)", params["targetHeight"])
 	}
 }
 

--- a/sidecar/tasks/config.go
+++ b/sidecar/tasks/config.go
@@ -14,6 +14,13 @@ import (
 
 var patchLog = seilog.NewLogger("seictl", "task", "config-patch")
 
+// configPatchParams holds the typed parameters for the config-patch task.
+// Files is intentionally map[string]map[string]any because TOML patches
+// are inherently untyped.
+type configPatchParams struct {
+	Files map[string]map[string]any `json:"files"`
+}
+
 // ConfigPatcher applies generic TOML merge-patches to seid configuration files.
 type ConfigPatcher struct {
 	homeDir string
@@ -36,13 +43,17 @@ func NewConfigPatcher(homeDir string) *ConfigPatcher {
 //	  }
 //	}
 func (p *ConfigPatcher) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		files, _ := params["files"].(map[string]any)
-		if len(files) == 0 {
+	return engine.TypedHandler(func(ctx context.Context, params configPatchParams) error {
+		if len(params.Files) == 0 {
 			return nil
 		}
+		// Convert to map[string]any for PatchFiles (public API).
+		files := make(map[string]any, len(params.Files))
+		for k, v := range params.Files {
+			files[k] = v
+		}
 		return p.PatchFiles(ctx, files)
-	}
+	})
 }
 
 // PatchFiles merge-patches each named TOML file under homeDir/config/.

--- a/sidecar/tasks/config.go
+++ b/sidecar/tasks/config.go
@@ -14,10 +14,10 @@ import (
 
 var patchLog = seilog.NewLogger("seictl", "task", "config-patch")
 
-// configPatchParams holds the typed parameters for the config-patch task.
+// ConfigPatchRequest holds the typed parameters for the config-patch task.
 // Files is intentionally map[string]map[string]any because TOML patches
 // are inherently untyped.
-type configPatchParams struct {
+type ConfigPatchRequest struct {
 	Files map[string]map[string]any `json:"files"`
 }
 
@@ -43,7 +43,7 @@ func NewConfigPatcher(homeDir string) *ConfigPatcher {
 //	  }
 //	}
 func (p *ConfigPatcher) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, params configPatchParams) error {
+	return engine.TypedHandler(func(ctx context.Context, params ConfigPatchRequest) error {
 		if len(params.Files) == 0 {
 			return nil
 		}

--- a/sidecar/tasks/config_apply.go
+++ b/sidecar/tasks/config_apply.go
@@ -27,14 +27,12 @@ func NewConfigApplier(homeDir string) *ConfigApplier {
 
 // Handler returns an engine.TaskHandler for the config-apply task type.
 func (a *ConfigApplier) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		intent := intentFromParams(params)
-
+	return engine.TypedHandler(func(ctx context.Context, intent seiconfig.ConfigIntent) error {
 		if intent.Incremental {
 			return a.applyIncremental(ctx, intent)
 		}
 		return a.applyFull(ctx, intent)
-	}
+	})
 }
 
 // applyFull resolves an intent from mode defaults and writes the result.
@@ -136,36 +134,4 @@ func diagnosticsError(diags []seiconfig.Diagnostic) error {
 	}
 	data, _ := json.Marshal(out)
 	return fmt.Errorf("config validation failed: %s", data)
-}
-
-// intentFromParams constructs a ConfigIntent from a generic task params map.
-func intentFromParams(params map[string]any) seiconfig.ConfigIntent {
-	mode, _ := params["mode"].(string)
-	incremental, _ := params["incremental"].(bool)
-	tv := 0
-	if raw, ok := params["targetVersion"].(float64); ok {
-		tv = int(raw)
-	}
-	overrides := extractStringMap(params, "overrides")
-
-	return seiconfig.ConfigIntent{
-		Mode:          seiconfig.NodeMode(mode),
-		Overrides:     overrides,
-		Incremental:   incremental,
-		TargetVersion: tv,
-	}
-}
-
-// extractStringMap pulls a map[string]string from a params map[string]any
-// where the inner map may have been deserialized as map[string]interface{}.
-func extractStringMap(params map[string]any, key string) map[string]string {
-	raw, ok := params[key].(map[string]any)
-	if !ok || len(raw) == 0 {
-		return nil
-	}
-	result := make(map[string]string, len(raw))
-	for k, v := range raw {
-		result[k], _ = v.(string)
-	}
-	return result
 }

--- a/sidecar/tasks/config_reload.go
+++ b/sidecar/tasks/config_reload.go
@@ -11,6 +11,11 @@ import (
 
 var reloadLog = seilog.NewLogger("seictl", "task", "config-reload")
 
+// configReloadParams holds the typed parameters for the config-reload task.
+type configReloadParams struct {
+	Fields map[string]string `json:"fields"`
+}
+
 // ConfigReloader patches hot-reloadable fields on disk and signals seid
 // to re-read its configuration. The signal mechanism is deferred to a future
 // release; for now only the on-disk write is performed.
@@ -25,9 +30,8 @@ func NewConfigReloader(homeDir string) *ConfigReloader {
 
 // Handler returns an engine.TaskHandler for the config-reload task type.
 func (r *ConfigReloader) Handler() engine.TaskHandler {
-	return func(_ context.Context, params map[string]any) error {
-		fields := extractStringMap(params, "fields")
-		if len(fields) == 0 {
+	return engine.TypedHandler(func(_ context.Context, params configReloadParams) error {
+		if len(params.Fields) == 0 {
 			return fmt.Errorf("config-reload: at least one field is required")
 		}
 
@@ -35,7 +39,7 @@ func (r *ConfigReloader) Handler() engine.TaskHandler {
 		registry.EnrichAll(seiconfig.DefaultEnrichments())
 
 		var nonHotReload []string
-		for key := range fields {
+		for key := range params.Fields {
 			f := registry.Field(key)
 			if f == nil {
 				return fmt.Errorf("config-reload: unknown field %q", key)
@@ -55,7 +59,7 @@ func (r *ConfigReloader) Handler() engine.TaskHandler {
 			return fmt.Errorf("config-reload: reading config: %w", err)
 		}
 
-		if err := seiconfig.ApplyOverrides(cfg, fields); err != nil {
+		if err := seiconfig.ApplyOverrides(cfg, params.Fields); err != nil {
 			return fmt.Errorf("config-reload: applying fields: %w", err)
 		}
 
@@ -70,8 +74,8 @@ func (r *ConfigReloader) Handler() engine.TaskHandler {
 
 		// TODO: signal seid to re-read config (SIGHUP or API call)
 		reloadLog.Info("hot-reloadable fields written, seid signal pending implementation",
-			"fields", len(fields))
+			"fields", len(params.Fields))
 
 		return nil
-	}
+	})
 }

--- a/sidecar/tasks/config_reload.go
+++ b/sidecar/tasks/config_reload.go
@@ -11,8 +11,8 @@ import (
 
 var reloadLog = seilog.NewLogger("seictl", "task", "config-reload")
 
-// configReloadParams holds the typed parameters for the config-reload task.
-type configReloadParams struct {
+// ConfigReloadRequest holds the typed parameters for the config-reload task.
+type ConfigReloadRequest struct {
 	Fields map[string]string `json:"fields"`
 }
 
@@ -30,7 +30,7 @@ func NewConfigReloader(homeDir string) *ConfigReloader {
 
 // Handler returns an engine.TaskHandler for the config-reload task type.
 func (r *ConfigReloader) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(_ context.Context, params configReloadParams) error {
+	return engine.TypedHandler(func(_ context.Context, params ConfigReloadRequest) error {
 		if len(params.Fields) == 0 {
 			return fmt.Errorf("config-reload: at least one field is required")
 		}

--- a/sidecar/tasks/config_validate.go
+++ b/sidecar/tasks/config_validate.go
@@ -24,7 +24,7 @@ func NewConfigValidator(homeDir string) *ConfigValidator {
 
 // Handler returns an engine.TaskHandler for the config-validate task type.
 func (v *ConfigValidator) Handler() engine.TaskHandler {
-	return func(_ context.Context, _ map[string]any) error {
+	return engine.TypedHandler(func(_ context.Context, _ struct{}) error {
 		cfg, err := seiconfig.ReadConfigFromDir(v.homeDir)
 		if err != nil {
 			return fmt.Errorf("config-validate: reading config: %w", err)
@@ -72,5 +72,5 @@ func (v *ConfigValidator) Handler() engine.TaskHandler {
 			"diagnostics", len(result.Diagnostics),
 		)
 		return nil
-	}
+	})
 }

--- a/sidecar/tasks/generate_gentx.go
+++ b/sidecar/tasks/generate_gentx.go
@@ -46,8 +46,16 @@ const (
 	validatorKeyName = "validator"
 )
 
+// gentxParams holds the typed parameters for the generate-gentx task.
+type gentxParams struct {
+	ChainID        string `json:"chainId"`
+	StakingAmount  string `json:"stakingAmount"`
+	AccountBalance string `json:"accountBalance"`
+	GenesisParams  string `json:"genesisParams"`
+}
+
 // GentxGenerator produces a genesis transaction by calling the same SDK
-// functions as seid keys add → seid add-genesis-account → seid gentx.
+// functions as seid keys add -> seid add-genesis-account -> seid gentx.
 type GentxGenerator struct {
 	homeDir string
 }
@@ -69,22 +77,19 @@ func NewGentxGenerator(homeDir string, _ CommandRunner) *GentxGenerator {
 //	  "genesisParams":  "" (optional, reserved for future genesis customization)
 //	}
 func (g *GentxGenerator) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
+	return engine.TypedHandler(func(ctx context.Context, params gentxParams) error {
 		if markerExists(g.homeDir, gentxMarkerFile) {
 			gentxLog.Debug("already completed, skipping")
 			return nil
 		}
 
-		chainID, _ := params["chainId"].(string)
-		if chainID == "" {
+		if params.ChainID == "" {
 			return fmt.Errorf("generate-gentx: missing required param 'chainId'")
 		}
-		stakingAmount, _ := params["stakingAmount"].(string)
-		if stakingAmount == "" {
+		if params.StakingAmount == "" {
 			return fmt.Errorf("generate-gentx: missing required param 'stakingAmount'")
 		}
-		accountBalance, _ := params["accountBalance"].(string)
-		if accountBalance == "" {
+		if params.AccountBalance == "" {
 			return fmt.Errorf("generate-gentx: missing required param 'accountBalance'")
 		}
 
@@ -96,17 +101,17 @@ func (g *GentxGenerator) Handler() engine.TaskHandler {
 			return err
 		}
 
-		if err := g.addGenesisAccount(cdc, address, accountBalance); err != nil {
+		if err := g.addGenesisAccount(cdc, address, params.AccountBalance); err != nil {
 			return err
 		}
 
-		if err := g.generateGentx(cdc, txCfg, chainID, stakingAmount); err != nil {
+		if err := g.generateGentx(cdc, txCfg, params.ChainID, params.StakingAmount); err != nil {
 			return err
 		}
 
 		gentxLog.Info("gentx generated", "address", address)
 		return writeMarker(g.homeDir, gentxMarkerFile)
-	}
+	})
 }
 
 // addValidatorKey creates a local key and returns its bech32 address.

--- a/sidecar/tasks/generate_gentx.go
+++ b/sidecar/tasks/generate_gentx.go
@@ -46,8 +46,8 @@ const (
 	validatorKeyName = "validator"
 )
 
-// gentxParams holds the typed parameters for the generate-gentx task.
-type gentxParams struct {
+// GenerateGentxRequest holds the typed parameters for the generate-gentx task.
+type GenerateGentxRequest struct {
 	ChainID        string `json:"chainId"`
 	StakingAmount  string `json:"stakingAmount"`
 	AccountBalance string `json:"accountBalance"`
@@ -77,7 +77,7 @@ func NewGentxGenerator(homeDir string, _ CommandRunner) *GentxGenerator {
 //	  "genesisParams":  "" (optional, reserved for future genesis customization)
 //	}
 func (g *GentxGenerator) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, params gentxParams) error {
+	return engine.TypedHandler(func(ctx context.Context, params GenerateGentxRequest) error {
 		if markerExists(g.homeDir, gentxMarkerFile) {
 			gentxLog.Debug("already completed, skipping")
 			return nil

--- a/sidecar/tasks/generate_identity.go
+++ b/sidecar/tasks/generate_identity.go
@@ -18,6 +18,12 @@ var identityLog = seilog.NewLogger("seictl", "task", "generate-identity")
 
 const identityMarkerFile = ".sei-sidecar-identity-done"
 
+// identityParams holds the typed parameters for the generate-identity task.
+type identityParams struct {
+	ChainID string `json:"chainId"`
+	Moniker string `json:"moniker"`
+}
+
 // IdentityGenerator creates the validator identity by calling the same
 // SDK functions as seid init: genutil.InitializeNodeValidatorFilesFromMnemonic
 // for keys, tmcfg.WriteConfigFile for config.toml, and genutil.ExportGenesisFile
@@ -35,22 +41,20 @@ func NewIdentityGenerator(homeDir string, _ CommandRunner) *IdentityGenerator {
 //
 // Expected params: {"chainId": "...", "moniker": "..."}
 func (g *IdentityGenerator) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
+	return engine.TypedHandler(func(ctx context.Context, params identityParams) error {
 		if markerExists(g.homeDir, identityMarkerFile) {
 			identityLog.Debug("already completed, skipping")
 			return nil
 		}
 
-		chainID, _ := params["chainId"].(string)
-		if chainID == "" {
+		if params.ChainID == "" {
 			return fmt.Errorf("generate-identity: missing required param 'chainId'")
 		}
-		moniker, _ := params["moniker"].(string)
-		if moniker == "" {
+		if params.Moniker == "" {
 			return fmt.Errorf("generate-identity: missing required param 'moniker'")
 		}
 
-		identityLog.Info("generating identity", "chainId", chainID, "moniker", moniker)
+		identityLog.Info("generating identity", "chainId", params.ChainID, "moniker", params.Moniker)
 
 		cfg := tmcfg.DefaultConfig()
 		cfg.SetRoot(g.homeDir)
@@ -63,7 +67,7 @@ func (g *IdentityGenerator) Handler() engine.TaskHandler {
 			return fmt.Errorf("generate-identity: initializing validator files: %w", err)
 		}
 
-		cfg.Moniker = moniker
+		cfg.Moniker = params.Moniker
 
 		if err := tmcfg.WriteConfigFile(cfg.RootDir, cfg); err != nil {
 			return fmt.Errorf("generate-identity: writing config.toml: %w", err)
@@ -77,7 +81,7 @@ func (g *IdentityGenerator) Handler() engine.TaskHandler {
 		genFile := cfg.GenesisFile()
 		if _, err := os.Stat(genFile); os.IsNotExist(err) {
 			genDoc := &tmtypes.GenesisDoc{
-				ChainID:  chainID,
+				ChainID:  params.ChainID,
 				AppState: []byte("{}"),
 			}
 			if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
@@ -85,7 +89,7 @@ func (g *IdentityGenerator) Handler() engine.TaskHandler {
 			}
 		}
 
-		identityLog.Info("identity generated", "nodeId", nodeID, "moniker", moniker)
+		identityLog.Info("identity generated", "nodeId", nodeID, "moniker", params.Moniker)
 		return writeMarker(g.homeDir, identityMarkerFile)
-	}
+	})
 }

--- a/sidecar/tasks/generate_identity.go
+++ b/sidecar/tasks/generate_identity.go
@@ -18,8 +18,8 @@ var identityLog = seilog.NewLogger("seictl", "task", "generate-identity")
 
 const identityMarkerFile = ".sei-sidecar-identity-done"
 
-// identityParams holds the typed parameters for the generate-identity task.
-type identityParams struct {
+// GenerateIdentityRequest holds the typed parameters for the generate-identity task.
+type GenerateIdentityRequest struct {
 	ChainID string `json:"chainId"`
 	Moniker string `json:"moniker"`
 }
@@ -41,7 +41,7 @@ func NewIdentityGenerator(homeDir string, _ CommandRunner) *IdentityGenerator {
 //
 // Expected params: {"chainId": "...", "moniker": "..."}
 func (g *IdentityGenerator) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, params identityParams) error {
+	return engine.TypedHandler(func(ctx context.Context, params GenerateIdentityRequest) error {
 		if markerExists(g.homeDir, identityMarkerFile) {
 			identityLog.Debug("already completed, skipping")
 			return nil

--- a/sidecar/tasks/genesis.go
+++ b/sidecar/tasks/genesis.go
@@ -45,6 +45,12 @@ type GenesisS3Config struct {
 	Region string
 }
 
+// genesisParams holds the typed parameters for the configure-genesis task.
+type genesisParams struct {
+	URI    string `json:"uri"`
+	Region string `json:"region"`
+}
+
 // GenesisFetcher writes genesis.json to the config directory. When S3 params
 // are provided in the task, it downloads from S3. Otherwise it writes the
 // embedded genesis for the configured chain ID (from SEI_CHAIN_ID).
@@ -71,21 +77,36 @@ func NewGenesisFetcher(homeDir string, chainID string, factory S3ClientFactory) 
 // Handler returns an engine.TaskHandler that parses params and delegates to
 // the appropriate genesis source.
 func (g *GenesisFetcher) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
+	return engine.TypedHandler(func(ctx context.Context, params genesisParams) error {
 		if markerExists(g.homeDir, genesisMarkerFile) {
 			genesisLog.Debug("already completed, skipping")
 			return nil
 		}
 
-		s3Cfg, err := parseGenesisS3Config(params)
+		if params.URI == "" {
+			return g.writeEmbeddedGenesis()
+		}
+
+		if params.Region == "" {
+			return fmt.Errorf("configure-genesis: 'region' is required when 'uri' is set")
+		}
+
+		parsed, err := url.Parse(params.URI)
 		if err != nil {
-			return err
+			return fmt.Errorf("configure-genesis: invalid uri %q: %w", params.URI, err)
 		}
-		if s3Cfg != nil {
-			return g.fetchFromS3(ctx, *s3Cfg)
+		if parsed.Scheme != "s3" {
+			return fmt.Errorf("configure-genesis: uri must use s3:// scheme, got %q", parsed.Scheme)
 		}
-		return g.writeEmbeddedGenesis()
-	}
+
+		bucket := parsed.Host
+		key := strings.TrimPrefix(parsed.Path, "/")
+		if bucket == "" || key == "" {
+			return fmt.Errorf("configure-genesis: uri must be s3://bucket/key, got %q", params.URI)
+		}
+
+		return g.fetchFromS3(ctx, GenesisS3Config{Bucket: bucket, Key: key, Region: params.Region})
+	})
 }
 
 // Fetch downloads genesis.json from S3, skipping if the marker file exists.
@@ -167,35 +188,4 @@ func (g *GenesisFetcher) writeGenesisFile(writeFn func(*os.File) error) error {
 		return fmt.Errorf("writing %s: %w", destPath, err)
 	}
 	return nil
-}
-
-// parseGenesisS3Config extracts S3 configuration from task params. Returns nil
-// (not an error) when no S3 params are present, indicating the handler should
-// use the embedded genesis.
-func parseGenesisS3Config(params map[string]any) (*GenesisS3Config, error) {
-	uri, _ := params["uri"].(string)
-	if uri == "" {
-		return nil, nil
-	}
-
-	region, _ := params["region"].(string)
-	if region == "" {
-		return nil, fmt.Errorf("configure-genesis: 'region' is required when 'uri' is set")
-	}
-
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		return nil, fmt.Errorf("configure-genesis: invalid uri %q: %w", uri, err)
-	}
-	if parsed.Scheme != "s3" {
-		return nil, fmt.Errorf("configure-genesis: uri must use s3:// scheme, got %q", parsed.Scheme)
-	}
-
-	bucket := parsed.Host
-	key := strings.TrimPrefix(parsed.Path, "/")
-	if bucket == "" || key == "" {
-		return nil, fmt.Errorf("configure-genesis: uri must be s3://bucket/key, got %q", uri)
-	}
-
-	return &GenesisS3Config{Bucket: bucket, Key: key, Region: region}, nil
 }

--- a/sidecar/tasks/genesis.go
+++ b/sidecar/tasks/genesis.go
@@ -45,8 +45,8 @@ type GenesisS3Config struct {
 	Region string
 }
 
-// genesisParams holds the typed parameters for the configure-genesis task.
-type genesisParams struct {
+// ConfigureGenesisRequest holds the typed parameters for the configure-genesis task.
+type ConfigureGenesisRequest struct {
 	URI    string `json:"uri"`
 	Region string `json:"region"`
 }
@@ -77,7 +77,7 @@ func NewGenesisFetcher(homeDir string, chainID string, factory S3ClientFactory) 
 // Handler returns an engine.TaskHandler that parses params and delegates to
 // the appropriate genesis source.
 func (g *GenesisFetcher) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, params genesisParams) error {
+	return engine.TypedHandler(func(ctx context.Context, params ConfigureGenesisRequest) error {
 		if markerExists(g.homeDir, genesisMarkerFile) {
 			genesisLog.Debug("already completed, skipping")
 			return nil

--- a/sidecar/tasks/genesis_peers.go
+++ b/sidecar/tasks/genesis_peers.go
@@ -17,6 +17,13 @@ import (
 
 var genesisPeersLog = seilog.NewLogger("seictl", "task", "set-genesis-peers")
 
+// genesisPeersConfig holds the typed parameters for the set-genesis-peers task.
+type genesisPeersConfig struct {
+	Bucket string `json:"s3Bucket"`
+	Key    string `json:"s3Key"`
+	Region string `json:"s3Region"`
+}
+
 // GenesisPeersSetter downloads a peers.json file produced by the genesis
 // assembler and writes the entries into config.toml as persistent_peers,
 // filtering out the current node's own entry.
@@ -39,20 +46,25 @@ func NewGenesisPeersSetter(homeDir string, s3Factory S3ClientFactory) *GenesisPe
 //
 //	{"s3Bucket": "...", "s3Key": "...", "s3Region": "..."}
 func (g *GenesisPeersSetter) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		cfg, err := parseGenesisPeersConfig(params)
-		if err != nil {
-			return err
+	return engine.TypedHandler(func(ctx context.Context, cfg genesisPeersConfig) error {
+		if cfg.Bucket == "" {
+			return fmt.Errorf("set-genesis-peers: missing required param 's3Bucket'")
+		}
+		if cfg.Key == "" {
+			return fmt.Errorf("set-genesis-peers: missing required param 's3Key'")
+		}
+		if cfg.Region == "" {
+			return fmt.Errorf("set-genesis-peers: missing required param 's3Region'")
 		}
 
-		s3Client, err := g.s3ClientFactory(ctx, cfg.region)
+		s3Client, err := g.s3ClientFactory(ctx, cfg.Region)
 		if err != nil {
 			return fmt.Errorf("set-genesis-peers: building S3 client: %w", err)
 		}
 
 		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
-			Bucket: aws.String(cfg.bucket),
-			Key:    aws.String(cfg.key),
+			Bucket: aws.String(cfg.Bucket),
+			Key:    aws.String(cfg.Key),
 		})
 		if err != nil {
 			return fmt.Errorf("set-genesis-peers: downloading peers.json: %w", err)
@@ -84,7 +96,7 @@ func (g *GenesisPeersSetter) Handler() engine.TaskHandler {
 			"total", len(allPeers), "self", selfID, "peers", len(filtered))
 
 		return writePeersToConfig(g.homeDir, filtered)
-	}
+	})
 }
 
 // readLocalNodeID reads the Tendermint node ID from the local node_key.json.
@@ -105,27 +117,4 @@ func readLocalNodeID(homeDir string) (string, error) {
 		return "", fmt.Errorf("set-genesis-peers: node_key.json has empty id")
 	}
 	return nodeKey.ID, nil
-}
-
-type genesisPeersConfig struct {
-	bucket string
-	key    string
-	region string
-}
-
-func parseGenesisPeersConfig(params map[string]any) (genesisPeersConfig, error) {
-	bucket, _ := params["s3Bucket"].(string)
-	key, _ := params["s3Key"].(string)
-	region, _ := params["s3Region"].(string)
-
-	if bucket == "" {
-		return genesisPeersConfig{}, fmt.Errorf("set-genesis-peers: missing required param 's3Bucket'")
-	}
-	if key == "" {
-		return genesisPeersConfig{}, fmt.Errorf("set-genesis-peers: missing required param 's3Key'")
-	}
-	if region == "" {
-		return genesisPeersConfig{}, fmt.Errorf("set-genesis-peers: missing required param 's3Region'")
-	}
-	return genesisPeersConfig{bucket: bucket, key: key, region: region}, nil
 }

--- a/sidecar/tasks/genesis_peers.go
+++ b/sidecar/tasks/genesis_peers.go
@@ -17,8 +17,8 @@ import (
 
 var genesisPeersLog = seilog.NewLogger("seictl", "task", "set-genesis-peers")
 
-// genesisPeersConfig holds the typed parameters for the set-genesis-peers task.
-type genesisPeersConfig struct {
+// SetGenesisPeersRequest holds the typed parameters for the set-genesis-peers task.
+type SetGenesisPeersRequest struct {
 	Bucket string `json:"s3Bucket"`
 	Key    string `json:"s3Key"`
 	Region string `json:"s3Region"`
@@ -46,7 +46,7 @@ func NewGenesisPeersSetter(homeDir string, s3Factory S3ClientFactory) *GenesisPe
 //
 //	{"s3Bucket": "...", "s3Key": "...", "s3Region": "..."}
 func (g *GenesisPeersSetter) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg genesisPeersConfig) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg SetGenesisPeersRequest) error {
 		if cfg.Bucket == "" {
 			return fmt.Errorf("set-genesis-peers: missing required param 's3Bucket'")
 		}

--- a/sidecar/tasks/genesis_test.go
+++ b/sidecar/tasks/genesis_test.go
@@ -95,37 +95,46 @@ func TestGenesisFetcher_S3TakesPriority(t *testing.T) {
 	}
 }
 
-func TestParseGenesisS3Config_WithURI(t *testing.T) {
-	cfg, err := parseGenesisS3Config(map[string]any{
+func TestGenesisS3Config_WithURI(t *testing.T) {
+	homeDir := t.TempDir()
+	called := false
+	mockFactory := func(ctx context.Context, region string) (S3GetObjectAPI, error) {
+		called = true
+		return nil, fmt.Errorf("intentional error")
+	}
+	fetcher := NewGenesisFetcher(homeDir, "pacific-1", mockFactory)
+	handler := fetcher.Handler()
+
+	err := handler(context.Background(), map[string]any{
 		"uri":    "s3://my-bucket/path/to/genesis.json",
 		"region": "us-west-2",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !called {
+		t.Fatal("expected S3 client factory to be called")
 	}
-	if cfg == nil {
-		t.Fatal("expected non-nil S3 config")
-	}
-	if cfg.Bucket != "my-bucket" {
-		t.Errorf("bucket = %q, want %q", cfg.Bucket, "my-bucket")
-	}
-	if cfg.Key != "path/to/genesis.json" {
-		t.Errorf("key = %q, want %q", cfg.Key, "path/to/genesis.json")
+	if err == nil {
+		t.Fatal("expected error from mock S3 factory")
 	}
 }
 
-func TestParseGenesisS3Config_NoURI(t *testing.T) {
-	cfg, err := parseGenesisS3Config(map[string]any{})
+func TestGenesisS3Config_NoURI(t *testing.T) {
+	homeDir := t.TempDir()
+	fetcher := NewGenesisFetcher(homeDir, "pacific-1", nil)
+	handler := fetcher.Handler()
+
+	// No URI means embedded genesis path is taken.
+	err := handler(context.Background(), map[string]any{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg != nil {
-		t.Errorf("expected nil S3 config, got %+v", cfg)
-	}
 }
 
-func TestParseGenesisS3Config_URIWithoutRegion(t *testing.T) {
-	_, err := parseGenesisS3Config(map[string]any{
+func TestGenesisS3Config_URIWithoutRegion(t *testing.T) {
+	homeDir := t.TempDir()
+	fetcher := NewGenesisFetcher(homeDir, "pacific-1", nil)
+	handler := fetcher.Handler()
+
+	err := handler(context.Background(), map[string]any{
 		"uri": "s3://bucket/key",
 	})
 	if err == nil {

--- a/sidecar/tasks/peers.go
+++ b/sidecar/tasks/peers.go
@@ -61,13 +61,13 @@ type StaticSource struct {
 	Addresses []string
 }
 
-// peerDiscoverParams holds the typed parameters for the discover-peers task.
-type peerDiscoverParams struct {
-	Sources []peerSourceConfig `json:"sources"`
+// DiscoverPeersRequest holds the typed parameters for the discover-peers task.
+type DiscoverPeersRequest struct {
+	Sources []PeerSourceEntry `json:"sources"`
 }
 
-// peerSourceConfig represents a single peer source in the params JSON.
-type peerSourceConfig struct {
+// PeerSourceEntry represents a single peer source in the params JSON.
+type PeerSourceEntry struct {
 	Type      string            `json:"type"`
 	Region    string            `json:"region,omitempty"`
 	Tags      map[string]string `json:"tags,omitempty"`
@@ -168,7 +168,7 @@ func NewPeerDiscoverer(homeDir string, ec2Factory EC2ClientFactory, nodeIDQuerie
 //
 //	{"sources": [{"type": "ec2Tags", "region": "...", "tags": {...}}, ...]}
 func (d *PeerDiscoverer) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, params peerDiscoverParams) error {
+	return engine.TypedHandler(func(ctx context.Context, params DiscoverPeersRequest) error {
 		if len(params.Sources) == 0 {
 			return fmt.Errorf("discover-peers: missing required param 'sources'")
 		}
@@ -215,7 +215,7 @@ func discoverFromSources(ctx context.Context, sources []PeerSource) ([]string, e
 }
 
 // buildSources converts typed source configs into PeerSource instances.
-func (d *PeerDiscoverer) buildSources(configs []peerSourceConfig) ([]PeerSource, error) {
+func (d *PeerDiscoverer) buildSources(configs []PeerSourceEntry) ([]PeerSource, error) {
 	var sources []PeerSource
 	for i, cfg := range configs {
 		switch cfg.Type {

--- a/sidecar/tasks/peers.go
+++ b/sidecar/tasks/peers.go
@@ -61,6 +61,19 @@ type StaticSource struct {
 	Addresses []string
 }
 
+// peerDiscoverParams holds the typed parameters for the discover-peers task.
+type peerDiscoverParams struct {
+	Sources []peerSourceConfig `json:"sources"`
+}
+
+// peerSourceConfig represents a single peer source in the params JSON.
+type peerSourceConfig struct {
+	Type      string            `json:"type"`
+	Region    string            `json:"region,omitempty"`
+	Tags      map[string]string `json:"tags,omitempty"`
+	Addresses []string          `json:"addresses,omitempty"`
+}
+
 // PeerDiscoverer resolves peers from multiple sources and writes them to a file.
 type PeerDiscoverer struct {
 	homeDir          string
@@ -155,13 +168,12 @@ func NewPeerDiscoverer(homeDir string, ec2Factory EC2ClientFactory, nodeIDQuerie
 //
 //	{"sources": [{"type": "ec2Tags", "region": "...", "tags": {...}}, ...]}
 func (d *PeerDiscoverer) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		rawSources, ok := params["sources"]
-		if !ok {
+	return engine.TypedHandler(func(ctx context.Context, params peerDiscoverParams) error {
+		if len(params.Sources) == 0 {
 			return fmt.Errorf("discover-peers: missing required param 'sources'")
 		}
 
-		sources, err := d.parseSources(rawSources)
+		sources, err := d.buildSources(params.Sources)
 		if err != nil {
 			return fmt.Errorf("discover-peers: %w", err)
 		}
@@ -172,7 +184,7 @@ func (d *PeerDiscoverer) Handler() engine.TaskHandler {
 		}
 
 		return writePeersToConfig(d.homeDir, peers)
-	}
+	})
 }
 
 // discoverFromSources iterates all sources, collects peers, and deduplicates.
@@ -202,87 +214,34 @@ func discoverFromSources(ctx context.Context, sources []PeerSource) ([]string, e
 	return all, nil
 }
 
-// parseSources converts the raw "sources" param into typed PeerSource instances.
-func (d *PeerDiscoverer) parseSources(raw any) ([]PeerSource, error) {
-	items, ok := raw.([]any)
-	if !ok {
-		return nil, fmt.Errorf("sources must be a list")
-	}
-	if len(items) == 0 {
-		return nil, fmt.Errorf("sources list is empty")
-	}
-
+// buildSources converts typed source configs into PeerSource instances.
+func (d *PeerDiscoverer) buildSources(configs []peerSourceConfig) ([]PeerSource, error) {
 	var sources []PeerSource
-	for i, item := range items {
-		m, ok := item.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("source[%d] is not an object", i)
-		}
-
-		typ, _ := m["type"].(string)
-		switch typ {
+	for i, cfg := range configs {
+		switch cfg.Type {
 		case "ec2Tags":
-			src, err := d.parseEC2TagsSource(m)
-			if err != nil {
-				return nil, fmt.Errorf("source[%d]: %w", i, err)
+			if cfg.Region == "" {
+				return nil, fmt.Errorf("source[%d]: ec2Tags source missing required field 'region'", i)
 			}
-			sources = append(sources, src)
+			if len(cfg.Tags) == 0 {
+				return nil, fmt.Errorf("source[%d]: ec2Tags source has empty tags", i)
+			}
+			sources = append(sources, &EC2TagsSource{
+				Region:      cfg.Region,
+				Tags:        cfg.Tags,
+				EC2Factory:  d.ec2ClientFactory,
+				QueryNodeID: d.queryNodeID,
+			})
 		case "static":
-			src, err := parseStaticSource(m)
-			if err != nil {
-				return nil, fmt.Errorf("source[%d]: %w", i, err)
+			if len(cfg.Addresses) == 0 {
+				return nil, fmt.Errorf("source[%d]: static source has empty addresses", i)
 			}
-			sources = append(sources, src)
+			sources = append(sources, &StaticSource{Addresses: cfg.Addresses})
 		default:
-			return nil, fmt.Errorf("source[%d]: unknown type %q", i, typ)
+			return nil, fmt.Errorf("source[%d]: unknown type %q", i, cfg.Type)
 		}
 	}
-
 	return sources, nil
-}
-
-func (d *PeerDiscoverer) parseEC2TagsSource(m map[string]any) (*EC2TagsSource, error) {
-	region, _ := m["region"].(string)
-	if region == "" {
-		return nil, fmt.Errorf("ec2Tags source missing required field 'region'")
-	}
-
-	rawTags, ok := m["tags"]
-	if !ok {
-		return nil, fmt.Errorf("ec2Tags source missing required field 'tags'")
-	}
-
-	tags, err := toStringMap(rawTags)
-	if err != nil {
-		return nil, fmt.Errorf("ec2Tags tags: %w", err)
-	}
-	if len(tags) == 0 {
-		return nil, fmt.Errorf("ec2Tags source has empty tags")
-	}
-
-	return &EC2TagsSource{
-		Region:      region,
-		Tags:        tags,
-		EC2Factory:  d.ec2ClientFactory,
-		QueryNodeID: d.queryNodeID,
-	}, nil
-}
-
-func parseStaticSource(m map[string]any) (*StaticSource, error) {
-	rawAddrs, ok := m["addresses"]
-	if !ok {
-		return nil, fmt.Errorf("static source missing required field 'addresses'")
-	}
-
-	addrs, err := toStringSlice(rawAddrs)
-	if err != nil {
-		return nil, fmt.Errorf("static addresses: %w", err)
-	}
-	if len(addrs) == 0 {
-		return nil, fmt.Errorf("static source has empty addresses")
-	}
-
-	return &StaticSource{Addresses: addrs}, nil
 }
 
 func buildPeerAddress(ctx context.Context, querier NodeIDQuerier, instance ec2types.Instance) (string, error) {
@@ -353,44 +312,4 @@ func writePeersToConfig(homeDir string, peers []string) error {
 		},
 	}
 	return mergeAndWrite(configPath, peersPatch)
-}
-
-// toStringMap converts an any to map[string]string.
-func toStringMap(raw any) (map[string]string, error) {
-	switch v := raw.(type) {
-	case map[string]string:
-		return v, nil
-	case map[string]any:
-		result := make(map[string]string, len(v))
-		for k, val := range v {
-			s, ok := val.(string)
-			if !ok {
-				return nil, fmt.Errorf("value for key %q is not a string", k)
-			}
-			result[k] = s
-		}
-		return result, nil
-	default:
-		return nil, fmt.Errorf("expected a map, got %T", raw)
-	}
-}
-
-// toStringSlice converts an any to []string.
-func toStringSlice(raw any) ([]string, error) {
-	switch v := raw.(type) {
-	case []string:
-		return v, nil
-	case []any:
-		result := make([]string, 0, len(v))
-		for _, item := range v {
-			s, ok := item.(string)
-			if !ok {
-				return nil, fmt.Errorf("list item is not a string")
-			}
-			result = append(result, s)
-		}
-		return result, nil
-	default:
-		return nil, fmt.Errorf("expected a list, got %T", raw)
-	}
 }

--- a/sidecar/tasks/ready.go
+++ b/sidecar/tasks/ready.go
@@ -9,7 +9,7 @@ import (
 // MarkReadyHandler returns a no-op TaskHandler. When it succeeds, the engine
 // marks itself as ready.
 func MarkReadyHandler() engine.TaskHandler {
-	return func(_ context.Context, _ map[string]any) error {
+	return engine.TypedHandler(func(_ context.Context, _ struct{}) error {
 		return nil
-	}
+	})
 }

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -25,7 +25,7 @@ type comparisonLoop struct {
 	exporter     *ResultExporter
 	comparator   *shadow.Comparator
 	uploader     seis3.Uploader
-	cfg          ResultExportConfig
+	cfg          ResultExportRequest
 	prefix       string
 	height       int64
 	pageBuf      []shadow.CompareResult
@@ -35,7 +35,7 @@ type comparisonLoop struct {
 // ExportAndCompare runs a continuous comparison between the local shadow node
 // and a canonical chain. It completes successfully when app-hash divergence is
 // detected, uploading a DivergenceReport alongside the comparison pages.
-func (e *ResultExporter) ExportAndCompare(ctx context.Context, cfg ResultExportConfig) error {
+func (e *ResultExporter) ExportAndCompare(ctx context.Context, cfg ResultExportRequest) error {
 	loop, err := e.newComparisonLoop(ctx, cfg)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (e *ResultExporter) ExportAndCompare(ctx context.Context, cfg ResultExportC
 	return loop.run(ctx)
 }
 
-func (e *ResultExporter) newComparisonLoop(ctx context.Context, cfg ResultExportConfig) (*comparisonLoop, error) {
+func (e *ResultExporter) newComparisonLoop(ctx context.Context, cfg ResultExportRequest) (*comparisonLoop, error) {
 	uploader, err := e.s3UploaderFactory(ctx, cfg.Region)
 	if err != nil {
 		return nil, fmt.Errorf("building S3 uploader: %w", err)

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -34,15 +34,15 @@ var defaultRPCEndpoint = fmt.Sprintf("http://localhost:%d", seiconfig.PortRPC)
 
 // ResultExportConfig holds the parameters for the result-export task.
 type ResultExportConfig struct {
-	Bucket      string
-	Prefix      string
-	Region      string
-	RPCEndpoint string
+	Bucket      string `json:"bucket"`
+	Prefix      string `json:"prefix"`
+	Region      string `json:"region"`
+	RPCEndpoint string `json:"rpcEndpoint"`
 
 	// CanonicalRPC enables comparison mode. When set, the exporter compares
 	// local block execution against this canonical RPC endpoint and completes
 	// when app-hash divergence is detected.
-	CanonicalRPC string
+	CanonicalRPC string `json:"canonicalRpc"`
 }
 
 type exportState struct {
@@ -64,16 +64,21 @@ func NewResultExporter(homeDir string, factory seis3.UploaderFactory) *ResultExp
 }
 
 func (e *ResultExporter) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		cfg, err := parseExportConfig(params)
-		if err != nil {
-			return err
+	return engine.TypedHandler(func(ctx context.Context, cfg ResultExportConfig) error {
+		if cfg.Bucket == "" {
+			return fmt.Errorf("result-export: missing required param 'bucket'")
+		}
+		if cfg.Region == "" {
+			return fmt.Errorf("result-export: missing required param 'region'")
+		}
+		if cfg.RPCEndpoint == "" {
+			cfg.RPCEndpoint = defaultRPCEndpoint
 		}
 		if cfg.CanonicalRPC != "" {
 			return e.ExportAndCompare(ctx, cfg)
 		}
 		return e.Export(ctx, cfg)
-	}
+	})
 }
 
 // Export queries the local node for block results and uploads pages to S3.
@@ -294,32 +299,6 @@ func queryBlockResults(ctx context.Context, rpcEndpoint string, height int64) (j
 	}
 
 	return json.RawMessage(body), nil
-}
-
-func parseExportConfig(params map[string]any) (ResultExportConfig, error) {
-	bucket, _ := params["bucket"].(string)
-	prefix, _ := params["prefix"].(string)
-	region, _ := params["region"].(string)
-	rpcEndpoint, _ := params["rpcEndpoint"].(string)
-	canonicalRPC, _ := params["canonicalRpc"].(string)
-
-	if bucket == "" {
-		return ResultExportConfig{}, fmt.Errorf("result-export: missing required param 'bucket'")
-	}
-	if region == "" {
-		return ResultExportConfig{}, fmt.Errorf("result-export: missing required param 'region'")
-	}
-	if rpcEndpoint == "" {
-		rpcEndpoint = defaultRPCEndpoint
-	}
-
-	return ResultExportConfig{
-		Bucket:       bucket,
-		Prefix:       prefix,
-		Region:       region,
-		RPCEndpoint:  rpcEndpoint,
-		CanonicalRPC: canonicalRPC,
-	}, nil
 }
 
 func (e *ResultExporter) readExportState() exportState {

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -32,8 +32,8 @@ const (
 
 var defaultRPCEndpoint = fmt.Sprintf("http://localhost:%d", seiconfig.PortRPC)
 
-// ResultExportConfig holds the parameters for the result-export task.
-type ResultExportConfig struct {
+// ResultExportRequest holds the parameters for the result-export task.
+type ResultExportRequest struct {
 	Bucket      string `json:"bucket"`
 	Prefix      string `json:"prefix"`
 	Region      string `json:"region"`
@@ -64,7 +64,7 @@ func NewResultExporter(homeDir string, factory seis3.UploaderFactory) *ResultExp
 }
 
 func (e *ResultExporter) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg ResultExportConfig) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg ResultExportRequest) error {
 		if cfg.Bucket == "" {
 			return fmt.Errorf("result-export: missing required param 'bucket'")
 		}
@@ -84,7 +84,7 @@ func (e *ResultExporter) Handler() engine.TaskHandler {
 // Export queries the local node for block results and uploads pages to S3.
 // Each invocation exports as many complete pages as are available since the
 // last export height. The state file tracks progress across invocations.
-func (e *ResultExporter) Export(ctx context.Context, cfg ResultExportConfig) error {
+func (e *ResultExporter) Export(ctx context.Context, cfg ResultExportRequest) error {
 	last := e.readExportState()
 	startHeight := last.LastExportedHeight + 1
 

--- a/sidecar/tasks/result_export_test.go
+++ b/sidecar/tasks/result_export_test.go
@@ -104,7 +104,7 @@ func TestExportRPCUnavailable(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
 
-	err := e.Export(context.Background(), ResultExportConfig{
+	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
 		Region:      "us-east-1",
 		RPCEndpoint: srv.URL,
@@ -124,7 +124,7 @@ func TestExportRPCNon200Status(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
 
-	err := e.Export(context.Background(), ResultExportConfig{
+	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
 		Region:      "us-east-1",
 		RPCEndpoint: srv.URL,
@@ -157,7 +157,7 @@ func TestExportS3UploaderFactoryError(t *testing.T) {
 
 	e := NewResultExporter(tmpDir, failingUploaderFactory("simulated AWS error"))
 
-	err := e.Export(context.Background(), ResultExportConfig{
+	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
 		Region:      "us-east-1",
 		RPCEndpoint: srv.URL,
@@ -179,7 +179,7 @@ func TestExportWritesStateAfterPage(t *testing.T) {
 	}
 
 	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
-	err := e.Export(context.Background(), ResultExportConfig{
+	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
 		Prefix:      "results",
 		Region:      "us-east-1",
@@ -218,7 +218,7 @@ func TestExportHandler_MissingParams(t *testing.T) {
 }
 
 func TestExportConfigJSONRoundTrip(t *testing.T) {
-	cfg := ResultExportConfig{
+	cfg := ResultExportRequest{
 		Bucket:       "my-bucket",
 		Region:       "us-east-1",
 		RPCEndpoint:  "http://custom:26657",
@@ -228,7 +228,7 @@ func TestExportConfigJSONRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshaling: %v", err)
 	}
-	var decoded ResultExportConfig
+	var decoded ResultExportRequest
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshaling: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestExportAndCompare_DivergenceDetected(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
 
-	err := e.ExportAndCompare(context.Background(), ResultExportConfig{
+	err := e.ExportAndCompare(context.Background(), ResultExportRequest{
 		Bucket:       "test-bucket",
 		Prefix:       "compare/",
 		Region:       "us-east-1",
@@ -326,7 +326,7 @@ func TestExportAndCompare_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := e.ExportAndCompare(ctx, ResultExportConfig{
+	err := e.ExportAndCompare(ctx, ResultExportRequest{
 		Bucket:       "test-bucket",
 		Region:       "us-east-1",
 		RPCEndpoint:  srv.URL,
@@ -344,7 +344,7 @@ func TestExportAndCompare_S3UploaderError(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := NewResultExporter(tmpDir, failingUploaderFactory("AWS creds expired"))
 
-	err := e.ExportAndCompare(context.Background(), ResultExportConfig{
+	err := e.ExportAndCompare(context.Background(), ResultExportRequest{
 		Bucket:       "test-bucket",
 		Region:       "us-east-1",
 		RPCEndpoint:  srv.URL,
@@ -371,7 +371,7 @@ func TestExportAndCompare_ResumesFromExportState(t *testing.T) {
 	}
 
 	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
-	err := e.ExportAndCompare(context.Background(), ResultExportConfig{
+	err := e.ExportAndCompare(context.Background(), ResultExportRequest{
 		Bucket:       "test-bucket",
 		Region:       "us-east-1",
 		RPCEndpoint:  shadowSrv.URL,
@@ -401,7 +401,7 @@ func TestExportAndCompare_UploadsDivergenceReport(t *testing.T) {
 		return recorder, nil
 	})
 
-	err := e.ExportAndCompare(context.Background(), ResultExportConfig{
+	err := e.ExportAndCompare(context.Background(), ResultExportRequest{
 		Bucket:       "test-bucket",
 		Prefix:       "shadow/pacific-1/",
 		Region:       "us-east-1",

--- a/sidecar/tasks/result_export_test.go
+++ b/sidecar/tasks/result_export_test.go
@@ -195,74 +195,54 @@ func TestExportWritesStateAfterPage(t *testing.T) {
 	}
 }
 
-func TestParseExportConfig(t *testing.T) {
+func TestExportHandler_MissingParams(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	handler := e.Handler()
+
 	cases := []struct {
-		name             string
-		params           map[string]any
-		wantErr          bool
-		wantBucket       string
-		wantRegion       string
-		wantRPCEndpoint  string
-		wantCanonicalRPC string
+		name   string
+		params map[string]any
 	}{
-		{
-			name:    "missing bucket",
-			params:  map[string]any{"region": "us-east-1"},
-			wantErr: true,
-		},
-		{
-			name:    "missing region",
-			params:  map[string]any{"bucket": "my-bucket"},
-			wantErr: true,
-		},
-		{
-			name:            "valid with defaults",
-			params:          map[string]any{"bucket": "my-bucket", "region": "us-east-1"},
-			wantBucket:      "my-bucket",
-			wantRegion:      "us-east-1",
-			wantRPCEndpoint: defaultRPCEndpoint,
-		},
-		{
-			name:            "valid with custom rpc",
-			params:          map[string]any{"bucket": "b", "region": "r", "rpcEndpoint": "http://custom:26657"},
-			wantBucket:      "b",
-			wantRegion:      "r",
-			wantRPCEndpoint: "http://custom:26657",
-		},
-		{
-			name:             "valid with canonicalRpc",
-			params:           map[string]any{"bucket": "b", "region": "r", "canonicalRpc": "http://canonical:26657"},
-			wantBucket:       "b",
-			wantRegion:       "r",
-			wantRPCEndpoint:  defaultRPCEndpoint,
-			wantCanonicalRPC: "http://canonical:26657",
-		},
+		{"missing bucket", map[string]any{"region": "us-east-1"}},
+		{"missing region", map[string]any{"bucket": "my-bucket"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := parseExportConfig(tc.params)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("parseExportConfig() error = %v", err)
-			}
-			if cfg.Bucket != tc.wantBucket {
-				t.Errorf("Bucket = %q, want %q", cfg.Bucket, tc.wantBucket)
-			}
-			if cfg.Region != tc.wantRegion {
-				t.Errorf("Region = %q, want %q", cfg.Region, tc.wantRegion)
-			}
-			if cfg.RPCEndpoint != tc.wantRPCEndpoint {
-				t.Errorf("RPCEndpoint = %q, want %q", cfg.RPCEndpoint, tc.wantRPCEndpoint)
-			}
-			if cfg.CanonicalRPC != tc.wantCanonicalRPC {
-				t.Errorf("CanonicalRPC = %q, want %q", cfg.CanonicalRPC, tc.wantCanonicalRPC)
+			err := handler(context.Background(), tc.params)
+			if err == nil {
+				t.Fatal("expected error, got nil")
 			}
 		})
+	}
+}
+
+func TestExportConfigJSONRoundTrip(t *testing.T) {
+	cfg := ResultExportConfig{
+		Bucket:       "my-bucket",
+		Region:       "us-east-1",
+		RPCEndpoint:  "http://custom:26657",
+		CanonicalRPC: "http://canonical:26657",
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshaling: %v", err)
+	}
+	var decoded ResultExportConfig
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+	if decoded.Bucket != cfg.Bucket {
+		t.Errorf("Bucket = %q, want %q", decoded.Bucket, cfg.Bucket)
+	}
+	if decoded.Region != cfg.Region {
+		t.Errorf("Region = %q, want %q", decoded.Region, cfg.Region)
+	}
+	if decoded.RPCEndpoint != cfg.RPCEndpoint {
+		t.Errorf("RPCEndpoint = %q, want %q", decoded.RPCEndpoint, cfg.RPCEndpoint)
+	}
+	if decoded.CanonicalRPC != cfg.CanonicalRPC {
+		t.Errorf("CanonicalRPC = %q, want %q", decoded.CanonicalRPC, cfg.CanonicalRPC)
 	}
 }
 

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -32,10 +32,10 @@ var snapshotHeightRe = regexp.MustCompile(`snapshot_(\d+)_`)
 
 // SnapshotConfig holds S3 coordinates for snapshot download.
 type SnapshotConfig struct {
-	Bucket  string
-	Prefix  string
-	Region  string
-	ChainID string
+	Bucket  string `json:"bucket"`
+	Prefix  string `json:"prefix"`
+	Region  string `json:"region"`
+	ChainID string `json:"chainId"`
 }
 
 // SnapshotRestorer downloads and extracts a snapshot archive from S3.
@@ -56,16 +56,23 @@ func NewSnapshotRestorer(homeDir string, factory seis3.TransferClientFactory) *S
 	}
 }
 
-// Handler returns an engine.TaskHandler that adapts the map[string]any params
-// to a typed SnapshotConfig and delegates to Restore.
+// Handler returns an engine.TaskHandler for the snapshot-restore task.
 func (r *SnapshotRestorer) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		cfg, err := parseSnapshotConfig(params)
-		if err != nil {
-			return err
+	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotConfig) error {
+		if cfg.Bucket == "" {
+			return fmt.Errorf("snapshot-restore: missing required param 'bucket'")
+		}
+		if cfg.Prefix == "" {
+			return fmt.Errorf("snapshot-restore: missing required param 'prefix'")
+		}
+		if cfg.Region == "" {
+			return fmt.Errorf("snapshot-restore: missing required param 'region'")
+		}
+		if cfg.ChainID == "" {
+			return fmt.Errorf("snapshot-restore: missing required param 'chainId'")
 		}
 		return r.Restore(ctx, cfg)
-	}
+	})
 }
 
 // Restore downloads and extracts the snapshot, skipping if the marker file exists.
@@ -160,28 +167,6 @@ func resolveSnapshotKey(ctx context.Context, client seis3.TransferClient, cfg Sn
 
 	filename := fmt.Sprintf("snapshot_%s_%s_%s.tar.gz", height, cfg.ChainID, cfg.Region)
 	return cfg.Prefix + filename, nil
-}
-
-func parseSnapshotConfig(params map[string]any) (SnapshotConfig, error) {
-	bucket, _ := params["bucket"].(string)
-	prefix, _ := params["prefix"].(string)
-	region, _ := params["region"].(string)
-	chainID, _ := params["chainId"].(string)
-
-	if bucket == "" {
-		return SnapshotConfig{}, fmt.Errorf("snapshot-restore: missing required param 'bucket'")
-	}
-	if prefix == "" {
-		return SnapshotConfig{}, fmt.Errorf("snapshot-restore: missing required param 'prefix'")
-	}
-	if region == "" {
-		return SnapshotConfig{}, fmt.Errorf("snapshot-restore: missing required param 'region'")
-	}
-	if chainID == "" {
-		return SnapshotConfig{}, fmt.Errorf("snapshot-restore: missing required param 'chainId'")
-	}
-
-	return SnapshotConfig{Bucket: bucket, Prefix: prefix, Region: region, ChainID: chainID}, nil
 }
 
 func parseHeightFromKey(key string) int64 {

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -30,8 +30,8 @@ const SnapshotHeightFile = ".sei-sidecar-snapshot-height"
 // snapshotHeightRe extracts heights from S3 keys like snapshot_198030000_pacific-1_eu-central-1.tar.gz.
 var snapshotHeightRe = regexp.MustCompile(`snapshot_(\d+)_`)
 
-// SnapshotConfig holds S3 coordinates for snapshot download.
-type SnapshotConfig struct {
+// SnapshotRestoreRequest holds S3 coordinates for snapshot download.
+type SnapshotRestoreRequest struct {
 	Bucket  string `json:"bucket"`
 	Prefix  string `json:"prefix"`
 	Region  string `json:"region"`
@@ -58,7 +58,7 @@ func NewSnapshotRestorer(homeDir string, factory seis3.TransferClientFactory) *S
 
 // Handler returns an engine.TaskHandler for the snapshot-restore task.
 func (r *SnapshotRestorer) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotConfig) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotRestoreRequest) error {
 		if cfg.Bucket == "" {
 			return fmt.Errorf("snapshot-restore: missing required param 'bucket'")
 		}
@@ -79,7 +79,7 @@ func (r *SnapshotRestorer) Handler() engine.TaskHandler {
 // It reads latest.txt to resolve the current snapshot key, then uses the transfer
 // manager's DownloadObject (io.WriterAt path) for parallel byte-range downloads
 // to a temp file, and finally streams the temp file through gzip+tar extraction.
-func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotConfig) error {
+func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotRestoreRequest) error {
 	if markerExists(r.homeDir, snapshotMarkerFile) {
 		restoreLog.Debug("already completed, skipping")
 		return nil
@@ -149,7 +149,7 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotConfig) erro
 }
 
 // resolveSnapshotKey reads <prefix>latest.txt to find the current snapshot object key.
-func resolveSnapshotKey(ctx context.Context, client seis3.TransferClient, cfg SnapshotConfig) (string, error) {
+func resolveSnapshotKey(ctx context.Context, client seis3.TransferClient, cfg SnapshotRestoreRequest) (string, error) {
 	var buf seis3.WriteAtBuffer
 	_, err := client.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
 		Bucket:   aws.String(cfg.Bucket),

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -86,7 +86,7 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 		},
 	}
 	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotConfig{
+	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
 		Bucket:  "test-bucket",
 		Prefix:  "snapshots/",
 		Region:  "us-east-1",
@@ -124,7 +124,7 @@ func TestSnapshotRestoreSkipsWhenMarkerExists(t *testing.T) {
 		errDefault: fmt.Errorf("should not be called"),
 	}))
 
-	err := restorer.Restore(context.Background(), SnapshotConfig{
+	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
 		Bucket:  "test-bucket",
 		Prefix:  "snapshots/",
 		Region:  "us-east-1",
@@ -142,7 +142,7 @@ func TestSnapshotRestoreNoMarkerOnLatestTxtError(t *testing.T) {
 		errDefault: fmt.Errorf("access denied"),
 	}))
 
-	err := restorer.Restore(context.Background(), SnapshotConfig{
+	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
 		Bucket:  "test-bucket",
 		Prefix:  "snapshots/",
 		Region:  "us-east-1",
@@ -168,7 +168,7 @@ func TestSnapshotRestoreNoMarkerOnDownloadError(t *testing.T) {
 	}
 	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
 
-	err := restorer.Restore(context.Background(), SnapshotConfig{
+	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
 		Bucket:  "test-bucket",
 		Prefix:  "snapshots/",
 		Region:  "us-east-1",
@@ -196,7 +196,7 @@ func TestSnapshotRestoreRejectsPathTraversal(t *testing.T) {
 		},
 	}
 	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotConfig{
+	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
 		Bucket:  "test-bucket",
 		Prefix:  "snapshots/",
 		Region:  "us-east-1",
@@ -221,7 +221,7 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 	}
 
 	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotConfig{
+	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
 		Bucket:  "test-bucket",
 		Prefix:  "snapshots/",
 		Region:  "us-east-1",
@@ -280,7 +280,7 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 		},
 	}
 	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotConfig{
+	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
 		Bucket:  "test-bucket",
 		Prefix:  "snapshots/",
 		Region:  "us-east-1",

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -29,8 +29,8 @@ const (
 	defaultUploadInterval = 7 * 24 * time.Hour // weekly
 )
 
-// SnapshotUploadConfig holds the parameters for the snapshot upload task.
-type SnapshotUploadConfig struct {
+// SnapshotUploadRequest holds the parameters for the snapshot upload task.
+type SnapshotUploadRequest struct {
 	Bucket string `json:"bucket"`
 	Prefix string `json:"prefix"`
 	Region string `json:"region"`
@@ -70,7 +70,7 @@ func NewSnapshotUploader(homeDir string, uploadInterval time.Duration, factory s
 // sleeping for the configured interval between attempts. It stays
 // running until the context is cancelled.
 func (u *SnapshotUploader) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotUploadConfig) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotUploadRequest) error {
 		if cfg.Bucket == "" {
 			return fmt.Errorf("snapshot-upload: missing required param 'bucket'")
 		}
@@ -81,7 +81,7 @@ func (u *SnapshotUploader) Handler() engine.TaskHandler {
 	})
 }
 
-func (u *SnapshotUploader) runLoop(ctx context.Context, cfg SnapshotUploadConfig) error {
+func (u *SnapshotUploader) runLoop(ctx context.Context, cfg SnapshotUploadRequest) error {
 	uploadLog.Info("starting snapshot upload loop", "interval", u.uploadInterval, "bucket", cfg.Bucket)
 	for {
 		if err := u.Upload(ctx, cfg); err != nil {
@@ -103,7 +103,7 @@ func (u *SnapshotUploader) runLoop(ctx context.Context, cfg SnapshotUploadConfig
 //
 // The archive is streamed through an io.Pipe so it never needs to be buffered
 // entirely in memory; the transfermanager handles multipart upload automatically.
-func (u *SnapshotUploader) Upload(ctx context.Context, cfg SnapshotUploadConfig) error {
+func (u *SnapshotUploader) Upload(ctx context.Context, cfg SnapshotUploadRequest) error {
 	snapshotsDir := filepath.Join(u.homeDir, "data", "snapshots")
 
 	height, err := pickUploadCandidate(snapshotsDir)
@@ -312,6 +312,27 @@ func normalizePrefix(prefix string) string {
 		return prefix + "/"
 	}
 	return prefix
+}
+
+// parseUploadConfig converts raw params into SnapshotUploadRequest with validation.
+func parseUploadConfig(params map[string]any) (SnapshotUploadRequest, error) {
+	var cfg SnapshotUploadRequest
+	if b, _ := params["bucket"].(string); b != "" {
+		cfg.Bucket = b
+	}
+	if p, _ := params["prefix"].(string); p != "" {
+		cfg.Prefix = p
+	}
+	if r, _ := params["region"].(string); r != "" {
+		cfg.Region = r
+	}
+	if cfg.Bucket == "" {
+		return cfg, fmt.Errorf("snapshot-upload: missing required param 'bucket'")
+	}
+	if cfg.Region == "" {
+		return cfg, fmt.Errorf("snapshot-upload: missing required param 'region'")
+	}
+	return cfg, nil
 }
 
 func (u *SnapshotUploader) readUploadState() uploadState {

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -303,7 +303,6 @@ func addFileToTar(tw *tar.Writer, path, name string, info os.FileInfo) error {
 	return err
 }
 
-
 func normalizePrefix(prefix string) string {
 	if prefix == "" {
 		return ""

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -31,9 +31,9 @@ const (
 
 // SnapshotUploadConfig holds the parameters for the snapshot upload task.
 type SnapshotUploadConfig struct {
-	Bucket string
-	Prefix string
-	Region string
+	Bucket string `json:"bucket"`
+	Prefix string `json:"prefix"`
+	Region string `json:"region"`
 }
 
 // uploadState tracks the last successfully uploaded snapshot height.
@@ -70,13 +70,15 @@ func NewSnapshotUploader(homeDir string, uploadInterval time.Duration, factory s
 // sleeping for the configured interval between attempts. It stays
 // running until the context is cancelled.
 func (u *SnapshotUploader) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		cfg, err := parseUploadConfig(params)
-		if err != nil {
-			return err
+	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotUploadConfig) error {
+		if cfg.Bucket == "" {
+			return fmt.Errorf("snapshot-upload: missing required param 'bucket'")
+		}
+		if cfg.Region == "" {
+			return fmt.Errorf("snapshot-upload: missing required param 'region'")
 		}
 		return u.runLoop(ctx, cfg)
-	}
+	})
 }
 
 func (u *SnapshotUploader) runLoop(ctx context.Context, cfg SnapshotUploadConfig) error {
@@ -301,20 +303,6 @@ func addFileToTar(tw *tar.Writer, path, name string, info os.FileInfo) error {
 	return err
 }
 
-func parseUploadConfig(params map[string]any) (SnapshotUploadConfig, error) {
-	bucket, _ := params["bucket"].(string)
-	prefix, _ := params["prefix"].(string)
-	region, _ := params["region"].(string)
-
-	if bucket == "" {
-		return SnapshotUploadConfig{}, fmt.Errorf("snapshot-upload: missing required param 'bucket'")
-	}
-	if region == "" {
-		return SnapshotUploadConfig{}, fmt.Errorf("snapshot-upload: missing required param 'region'")
-	}
-
-	return SnapshotUploadConfig{Bucket: bucket, Prefix: prefix, Region: region}, nil
-}
 
 func normalizePrefix(prefix string) string {
 	if prefix == "" {

--- a/sidecar/tasks/snapshot_upload_test.go
+++ b/sidecar/tasks/snapshot_upload_test.go
@@ -101,7 +101,7 @@ func TestUpload_UploadsArchiveAndLatestTxt(t *testing.T) {
 	mock := newMockS3Uploader()
 	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadConfig{
+	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
 		Bucket: "my-bucket",
 		Prefix: "state-sync",
 		Region: "eu-central-1",
@@ -134,7 +134,7 @@ func TestUpload_SkipsWhenAlreadyUploaded(t *testing.T) {
 	mock := newMockS3Uploader()
 	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadConfig{
+	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
 		Bucket: "my-bucket",
 		Prefix: "state-sync",
 		Region: "eu-central-1",
@@ -159,7 +159,7 @@ func TestUpload_UploadsNewerSnapshot(t *testing.T) {
 	mock := newMockS3Uploader()
 	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadConfig{
+	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
 		Bucket: "my-bucket",
 		Prefix: "state-sync",
 		Region: "eu-central-1",
@@ -180,7 +180,7 @@ func TestUpload_NoOpsWhenTooFewSnapshots(t *testing.T) {
 	mock := newMockS3Uploader()
 	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadConfig{
+	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
 		Bucket: "my-bucket",
 		Prefix: "state-sync",
 		Region: "eu-central-1",
@@ -201,7 +201,7 @@ func TestUpload_WritesUploadState(t *testing.T) {
 	mock := newMockS3Uploader()
 	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadConfig{
+	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
 		Bucket: "my-bucket",
 		Prefix: "state-sync",
 		Region: "eu-central-1",

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -63,7 +63,7 @@ func (s *StateSyncConfigurer) Handler() engine.TaskHandler {
 
 // StateSyncRequest groups the caller-provided parameters for state-sync configuration.
 type StateSyncRequest struct {
-	UseLocalSnapshot bool  `json:"useLocalSnapshot"`
+	UseLocalSnapshot bool   `json:"useLocalSnapshot"`
 	TrustPeriod      string `json:"trustPeriod"`
 	BackfillBlocks   int64  `json:"backfillBlocks"`
 }

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -56,29 +56,16 @@ func NewStateSyncConfigurer(homeDir string, client HTTPDoer) *StateSyncConfigure
 
 // Handler returns an engine.TaskHandler.
 func (s *StateSyncConfigurer) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
-		useLocal, _ := params["useLocalSnapshot"].(bool)
-		trustPeriod, _ := params["trustPeriod"].(string)
-		var backfill int64
-		switch v := params["backfillBlocks"].(type) {
-		case float64:
-			backfill = int64(v)
-		case int64:
-			backfill = v
-		}
-		return s.Configure(ctx, StateSyncParams{
-			UseLocalSnapshot: useLocal,
-			TrustPeriod:      trustPeriod,
-			BackfillBlocks:   backfill,
-		})
-	}
+	return engine.TypedHandler(func(ctx context.Context, params StateSyncParams) error {
+		return s.Configure(ctx, params)
+	})
 }
 
 // StateSyncParams groups the caller-provided parameters for state-sync configuration.
 type StateSyncParams struct {
-	UseLocalSnapshot bool
-	TrustPeriod      string
-	BackfillBlocks   int64
+	UseLocalSnapshot bool  `json:"useLocalSnapshot"`
+	TrustPeriod      string `json:"trustPeriod"`
+	BackfillBlocks   int64  `json:"backfillBlocks"`
 }
 
 // Configure reads persistent-peers from config.toml, queries a peer for a

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -56,13 +56,13 @@ func NewStateSyncConfigurer(homeDir string, client HTTPDoer) *StateSyncConfigure
 
 // Handler returns an engine.TaskHandler.
 func (s *StateSyncConfigurer) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, params StateSyncParams) error {
+	return engine.TypedHandler(func(ctx context.Context, params StateSyncRequest) error {
 		return s.Configure(ctx, params)
 	})
 }
 
-// StateSyncParams groups the caller-provided parameters for state-sync configuration.
-type StateSyncParams struct {
+// StateSyncRequest groups the caller-provided parameters for state-sync configuration.
+type StateSyncRequest struct {
 	UseLocalSnapshot bool  `json:"useLocalSnapshot"`
 	TrustPeriod      string `json:"trustPeriod"`
 	BackfillBlocks   int64  `json:"backfillBlocks"`
@@ -72,7 +72,7 @@ type StateSyncParams struct {
 // trust point, and writes the state sync settings back to config.toml.
 // When UseLocalSnapshot is true, the trust height is derived from the
 // locally-restored snapshot and use-local-snapshot is set in config.toml.
-func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncParams) error {
+func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncRequest) error {
 	if markerExists(s.homeDir, stateSyncMarkerFile) {
 		ssLog.Debug("already completed, skipping")
 		return nil

--- a/sidecar/tasks/statesync_test.go
+++ b/sidecar/tasks/statesync_test.go
@@ -66,7 +66,7 @@ func TestStateSyncConfigurer_Success(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, mock)
-	if err := configurer.Configure(context.Background(), StateSyncParams{}); err != nil {
+	if err := configurer.Configure(context.Background(), StateSyncRequest{}); err != nil {
 		t.Fatalf("Configure failed: %v", err)
 	}
 
@@ -101,7 +101,7 @@ func TestStateSyncConfigurer_MarkerSkips(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
-	if err := configurer.Configure(context.Background(), StateSyncParams{}); err != nil {
+	if err := configurer.Configure(context.Background(), StateSyncRequest{}); err != nil {
 		t.Fatalf("expected nil error when marker exists, got: %v", err)
 	}
 }
@@ -111,7 +111,7 @@ func TestStateSyncConfigurer_NoPeers(t *testing.T) {
 	setupPeersInConfig(t, homeDir, nil)
 
 	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
-	err := configurer.Configure(context.Background(), StateSyncParams{})
+	err := configurer.Configure(context.Background(), StateSyncRequest{})
 	if err == nil {
 		t.Fatal("expected error when no peers in config")
 	}
@@ -134,7 +134,7 @@ func TestStateSyncConfigurer_LowHeight(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, mock)
-	if err := configurer.Configure(context.Background(), StateSyncParams{}); err != nil {
+	if err := configurer.Configure(context.Background(), StateSyncRequest{}); err != nil {
 		t.Fatalf("Configure failed: %v", err)
 	}
 
@@ -180,7 +180,7 @@ func TestStateSyncConfigurer_InvalidBlockHash(t *testing.T) {
 			}
 
 			configurer := NewStateSyncConfigurer(homeDir, mock)
-			err := configurer.Configure(context.Background(), StateSyncParams{})
+			err := configurer.Configure(context.Background(), StateSyncRequest{})
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -298,7 +298,7 @@ func TestStateSyncConfigurer_NetworkWithBackfill(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, mock)
-	err := configurer.Configure(context.Background(), StateSyncParams{
+	err := configurer.Configure(context.Background(), StateSyncRequest{
 		TrustPeriod:    "168h0m0s",
 		BackfillBlocks: 6000,
 	})
@@ -339,7 +339,7 @@ func TestStateSyncConfigurer_LocalSnapshot(t *testing.T) {
 	}
 
 	configurer := NewStateSyncConfigurer(homeDir, mock)
-	err := configurer.Configure(context.Background(), StateSyncParams{
+	err := configurer.Configure(context.Background(), StateSyncRequest{
 		UseLocalSnapshot: true,
 		TrustPeriod:      "9999h0m0s",
 		BackfillBlocks:   0,
@@ -373,7 +373,7 @@ func TestStateSyncConfigurer_LocalSnapshotNoDir(t *testing.T) {
 	setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656"})
 
 	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
-	err := configurer.Configure(context.Background(), StateSyncParams{UseLocalSnapshot: true})
+	err := configurer.Configure(context.Background(), StateSyncRequest{UseLocalSnapshot: true})
 	if err == nil {
 		t.Fatal("expected error when no snapshot directory exists")
 	}

--- a/sidecar/tasks/typed_handler_integration_test.go
+++ b/sidecar/tasks/typed_handler_integration_test.go
@@ -388,4 +388,3 @@ func TestDeserialize_GenerateGentx(t *testing.T) {
 		t.Errorf("expected chainId validation error, got: %v", err)
 	}
 }
-

--- a/sidecar/tasks/typed_handler_integration_test.go
+++ b/sidecar/tasks/typed_handler_integration_test.go
@@ -1,0 +1,391 @@
+package tasks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDeserialize_SnapshotRestore verifies that the snapshot-restore handler
+// correctly deserializes simple string fields from the wire format.
+func TestDeserialize_SnapshotRestore(t *testing.T) {
+	homeDir := t.TempDir()
+	// Pre-write a marker so the handler returns early without S3 calls.
+	if err := writeMarker(homeDir, snapshotMarkerFile); err != nil {
+		t.Fatal(err)
+	}
+
+	restorer := NewSnapshotRestorer(homeDir, nil)
+	handler := restorer.Handler()
+
+	params := map[string]any{
+		"bucket":  "my-bucket",
+		"prefix":  "snapshots/",
+		"region":  "us-east-1",
+		"chainId": "pacific-1",
+	}
+
+	// The handler should succeed (skip via marker) without a parse error.
+	err := handler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("snapshot-restore handler returned error: %v", err)
+	}
+}
+
+// TestDeserialize_DiscoverPeers verifies that the discover-peers handler
+// correctly deserializes nested sources arrays from the wire format.
+func TestDeserialize_DiscoverPeers(t *testing.T) {
+	homeDir := t.TempDir()
+	ensureConfigDir(t, homeDir)
+
+	discoverer := NewPeerDiscoverer(homeDir, nil, nil)
+	handler := discoverer.Handler()
+
+	params := map[string]any{
+		"sources": []any{
+			map[string]any{
+				"type":      "static",
+				"addresses": []any{"abc@1.2.3.4:26656"},
+			},
+		},
+	}
+
+	err := handler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("discover-peers handler returned error: %v", err)
+	}
+
+	// Verify the peers were written to config.
+	got := readPeersFromConfigTOML(t, homeDir)
+	if got != "abc@1.2.3.4:26656" {
+		t.Errorf("peers = %q, want %q", got, "abc@1.2.3.4:26656")
+	}
+}
+
+// TestDeserialize_ConfigPatch verifies that the config-patch handler
+// correctly deserializes nested map[string]map[string]any from the wire format.
+func TestDeserialize_ConfigPatch(t *testing.T) {
+	homeDir := t.TempDir()
+	setupConfigFile(t, homeDir, `
+[p2p]
+persistent-peers = ""
+`)
+
+	patcher := NewConfigPatcher(homeDir)
+	handler := patcher.Handler()
+
+	params := map[string]any{
+		"files": map[string]any{
+			"config.toml": map[string]any{
+				"p2p": map[string]any{
+					"persistent-peers": "node1@1.2.3.4:26656",
+				},
+			},
+		},
+	}
+
+	err := handler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("config-patch handler returned error: %v", err)
+	}
+
+	doc := readTOML(t, filepath.Join(homeDir, "config", "config.toml"))
+	p2p := doc["p2p"].(map[string]any)
+	if p2p["persistent-peers"] != "node1@1.2.3.4:26656" {
+		t.Errorf("peers = %q, want %q", p2p["persistent-peers"], "node1@1.2.3.4:26656")
+	}
+}
+
+// TestDeserialize_AssembleGenesis verifies that the assemble-genesis handler
+// correctly deserializes the nodes array with name fields from the wire format.
+func TestDeserialize_AssembleGenesis(t *testing.T) {
+	// We only test deserialization, not the full S3 flow, so we expect
+	// a validation error for missing S3 bucket when bucket is empty.
+	handler := NewGenesisAssembler(t.TempDir(), nil, nil, nil).Handler()
+
+	params := map[string]any{
+		"s3Bucket":       "my-bucket",
+		"s3Region":       "us-east-1",
+		"accountBalance": "10000000usei",
+		"namespace":      "default",
+		"nodes": []any{
+			map[string]any{"name": "val-0"},
+			map[string]any{"name": "val-1"},
+		},
+	}
+
+	// This will fail at the S3 download step (no real S3), but if it gets
+	// past param parsing without a "parsing params" error, deserialization worked.
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error (no S3 client), got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+}
+
+// TestDeserialize_AwaitCondition verifies that the await-condition handler
+// correctly deserializes int64 from float64 (JSON number coercion) and
+// string fields from the wire format.
+func TestDeserialize_AwaitCondition(t *testing.T) {
+	handler := NewConditionWaiter(nil).Handler()
+
+	// float64(500) simulates what json.Unmarshal produces for JSON numbers
+	// when the target is map[string]any.
+	params := map[string]any{
+		"condition":    "height",
+		"targetHeight": float64(500),
+	}
+
+	// The handler will try to poll RPC (and fail because there's no server),
+	// but it should parse params without error. We use a context that
+	// cancels immediately to avoid blocking.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := handler(ctx, params)
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	// If we get a context error (not a parsing error), deserialization succeeded.
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+}
+
+// TestDeserialize_ConfigApply verifies that the config-apply handler
+// correctly deserializes the ConfigIntent (overrides map + mode string).
+func TestDeserialize_ConfigApply(t *testing.T) {
+	homeDir := t.TempDir()
+	applier := NewConfigApplier(homeDir)
+	handler := applier.Handler()
+
+	params := map[string]any{
+		"mode":        "full",
+		"incremental": false,
+		"overrides": map[string]any{
+			"evm.http_port": "9545",
+		},
+	}
+
+	err := handler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("config-apply handler returned error: %v", err)
+	}
+
+	// Verify the config was actually written.
+	configPath := filepath.Join(homeDir, "config", "config.toml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Fatal("config.toml was not written")
+	}
+}
+
+// TestDeserialize_ConfigReload verifies that the config-reload handler
+// correctly deserializes the fields map from the wire format.
+func TestDeserialize_ConfigReload(t *testing.T) {
+	// config-reload needs a valid on-disk config to read.
+	// We just check that deserialization doesn't fail when fields is empty
+	// (it'll fail with a validation error, not a parse error).
+	handler := NewConfigReloader(t.TempDir()).Handler()
+
+	params := map[string]any{
+		"fields": map[string]any{},
+	}
+
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for empty fields, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "at least one field") {
+		t.Errorf("expected 'at least one field' error, got: %v", err)
+	}
+}
+
+// TestDeserialize_SnapshotUpload verifies that the snapshot-upload handler
+// correctly deserializes simple string fields from the wire format.
+func TestDeserialize_SnapshotUpload(t *testing.T) {
+	handler := NewSnapshotUploader(t.TempDir(), 0, nil).Handler()
+
+	params := map[string]any{
+		"bucket": "",
+		"region": "us-east-1",
+	}
+
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for empty bucket, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing required param 'bucket'") {
+		t.Errorf("expected bucket validation error, got: %v", err)
+	}
+}
+
+// TestDeserialize_ConfigureGenesis verifies that the configure-genesis handler
+// correctly deserializes URI and region from the wire format.
+func TestDeserialize_ConfigureGenesis(t *testing.T) {
+	homeDir := t.TempDir()
+	fetcher := NewGenesisFetcher(homeDir, "pacific-1", nil)
+	handler := fetcher.Handler()
+
+	params := map[string]any{
+		"uri":    "s3://bucket/key",
+		"region": "us-east-1",
+	}
+
+	// This will fail at S3 download, but deserialization should succeed.
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected S3 error, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+}
+
+// TestDeserialize_UploadArtifacts verifies that the upload-genesis-artifacts handler
+// correctly deserializes the S3 and node name params from the wire format.
+func TestDeserialize_UploadArtifacts(t *testing.T) {
+	handler := NewGenesisArtifactUploader(t.TempDir(), nil).Handler()
+
+	params := map[string]any{
+		"s3Bucket": "",
+		"s3Region": "us-east-1",
+		"nodeName": "val-0",
+	}
+
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for empty bucket, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing required param 's3Bucket'") {
+		t.Errorf("expected s3Bucket validation error, got: %v", err)
+	}
+}
+
+// TestDeserialize_GenerateIdentity verifies that the generate-identity handler
+// correctly deserializes chainId and moniker from the wire format.
+func TestDeserialize_GenerateIdentity(t *testing.T) {
+	handler := NewIdentityGenerator(t.TempDir(), nil).Handler()
+
+	params := map[string]any{
+		"chainId": "",
+		"moniker": "val-0",
+	}
+
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for empty chainId, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing required param 'chainId'") {
+		t.Errorf("expected chainId validation error, got: %v", err)
+	}
+}
+
+// TestDeserialize_SetGenesisPeers verifies that the set-genesis-peers handler
+// correctly deserializes S3 coordinates from the wire format.
+func TestDeserialize_SetGenesisPeers(t *testing.T) {
+	handler := NewGenesisPeersSetter(t.TempDir(), nil).Handler()
+
+	params := map[string]any{
+		"s3Bucket": "",
+		"s3Key":    "peers.json",
+		"s3Region": "us-east-1",
+	}
+
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for empty bucket, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing required param 's3Bucket'") {
+		t.Errorf("expected s3Bucket validation error, got: %v", err)
+	}
+}
+
+// TestDeserialize_StateSync verifies that the state-sync handler
+// correctly deserializes useLocalSnapshot (bool), trustPeriod (string),
+// and backfillBlocks (int64 from float64) from the wire format.
+func TestDeserialize_StateSync(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, nil)
+
+	handler := NewStateSyncConfigurer(homeDir, nil).Handler()
+
+	params := map[string]any{
+		"useLocalSnapshot": true,
+		"trustPeriod":      "168h0m0s",
+		"backfillBlocks":   float64(6000),
+	}
+
+	// Will fail because there are no peers, but deserialization should succeed.
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error (no peers), got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+}
+
+// TestDeserialize_ResultExport verifies that the result-export handler
+// correctly deserializes the bucket, region, and optional fields.
+func TestDeserialize_ResultExport(t *testing.T) {
+	handler := NewResultExporter(t.TempDir(), nil).Handler()
+
+	params := map[string]any{
+		"bucket": "",
+		"region": "us-east-1",
+	}
+
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for empty bucket, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing required param 'bucket'") {
+		t.Errorf("expected bucket validation error, got: %v", err)
+	}
+}
+
+// TestDeserialize_GenerateGentx verifies that the generate-gentx handler
+// correctly deserializes all string params from the wire format.
+func TestDeserialize_GenerateGentx(t *testing.T) {
+	handler := NewGentxGenerator(t.TempDir(), nil).Handler()
+
+	params := map[string]any{
+		"chainId":        "",
+		"stakingAmount":  "1000usei",
+		"accountBalance": "10000usei",
+	}
+
+	err := handler(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for empty chainId, got nil")
+	}
+	if strings.Contains(err.Error(), "parsing params") {
+		t.Fatalf("deserialization failed: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing required param 'chainId'") {
+		t.Errorf("expected chainId validation error, got: %v", err)
+	}
+}
+

--- a/sidecar/tasks/upload_genesis_artifacts.go
+++ b/sidecar/tasks/upload_genesis_artifacts.go
@@ -20,8 +20,8 @@ var artifactLog = seilog.NewLogger("seictl", "task", "upload-genesis-artifacts")
 
 const artifactUploadMarkerFile = ".sei-sidecar-artifact-upload-done"
 
-// artifactUploadConfig holds the typed parameters for the upload-genesis-artifacts task.
-type artifactUploadConfig struct {
+// UploadArtifactsRequest holds the typed parameters for the upload-genesis-artifacts task.
+type UploadArtifactsRequest struct {
 	Bucket   string `json:"s3Bucket"`
 	Prefix   string `json:"s3Prefix"`
 	Region   string `json:"s3Region"`
@@ -54,7 +54,7 @@ func NewGenesisArtifactUploader(homeDir string, factory seis3.UploaderFactory) *
 //	<prefix>/<nodeName>/gentx.json   - the validator's genesis transaction
 //	<prefix>/<nodeName>/identity.json - node ID and validator pubkey metadata
 func (u *GenesisArtifactUploader) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg artifactUploadConfig) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg UploadArtifactsRequest) error {
 		if markerExists(u.homeDir, artifactUploadMarkerFile) {
 			artifactLog.Debug("already completed, skipping")
 			return nil

--- a/sidecar/tasks/upload_genesis_artifacts.go
+++ b/sidecar/tasks/upload_genesis_artifacts.go
@@ -20,6 +20,14 @@ var artifactLog = seilog.NewLogger("seictl", "task", "upload-genesis-artifacts")
 
 const artifactUploadMarkerFile = ".sei-sidecar-artifact-upload-done"
 
+// artifactUploadConfig holds the typed parameters for the upload-genesis-artifacts task.
+type artifactUploadConfig struct {
+	Bucket   string `json:"s3Bucket"`
+	Prefix   string `json:"s3Prefix"`
+	Region   string `json:"s3Region"`
+	NodeName string `json:"nodeName"`
+}
+
 // GenesisArtifactUploader uploads the gentx file and a node identity
 // manifest to S3 so the assembler can collect them.
 type GenesisArtifactUploader struct {
@@ -46,36 +54,41 @@ func NewGenesisArtifactUploader(homeDir string, factory seis3.UploaderFactory) *
 //	<prefix>/<nodeName>/gentx.json   - the validator's genesis transaction
 //	<prefix>/<nodeName>/identity.json - node ID and validator pubkey metadata
 func (u *GenesisArtifactUploader) Handler() engine.TaskHandler {
-	return func(ctx context.Context, params map[string]any) error {
+	return engine.TypedHandler(func(ctx context.Context, cfg artifactUploadConfig) error {
 		if markerExists(u.homeDir, artifactUploadMarkerFile) {
 			artifactLog.Debug("already completed, skipping")
 			return nil
 		}
 
-		cfg, err := parseArtifactUploadConfig(params)
-		if err != nil {
-			return err
+		if cfg.Bucket == "" {
+			return fmt.Errorf("upload-genesis-artifacts: missing required param 's3Bucket'")
+		}
+		if cfg.Region == "" {
+			return fmt.Errorf("upload-genesis-artifacts: missing required param 's3Region'")
+		}
+		if cfg.NodeName == "" {
+			return fmt.Errorf("upload-genesis-artifacts: missing required param 'nodeName'")
 		}
 
-		uploader, err := u.s3UploaderFactory(ctx, cfg.region)
+		uploader, err := u.s3UploaderFactory(ctx, cfg.Region)
 		if err != nil {
 			return fmt.Errorf("upload-genesis-artifacts: building S3 uploader: %w", err)
 		}
 
-		prefix := normalizePrefix(cfg.prefix)
-		nodePrefix := prefix + cfg.nodeName + "/"
+		prefix := normalizePrefix(cfg.Prefix)
+		nodePrefix := prefix + cfg.NodeName + "/"
 
-		if err := u.uploadGentx(ctx, uploader, cfg.bucket, nodePrefix); err != nil {
+		if err := u.uploadGentx(ctx, uploader, cfg.Bucket, nodePrefix); err != nil {
 			return err
 		}
 
-		if err := u.uploadIdentity(ctx, uploader, cfg.bucket, nodePrefix); err != nil {
+		if err := u.uploadIdentity(ctx, uploader, cfg.Bucket, nodePrefix); err != nil {
 			return err
 		}
 
-		artifactLog.Info("artifacts uploaded", "bucket", cfg.bucket, "prefix", nodePrefix)
+		artifactLog.Info("artifacts uploaded", "bucket", cfg.Bucket, "prefix", nodePrefix)
 		return writeMarker(u.homeDir, artifactUploadMarkerFile)
-	}
+	})
 }
 
 // uploadGentx finds the single gentx file in config/gentx/ and uploads it.
@@ -146,30 +159,4 @@ func (u *GenesisArtifactUploader) uploadIdentity(ctx context.Context, uploader s
 		return fmt.Errorf("upload-genesis-artifacts: uploading identity: %w", err)
 	}
 	return nil
-}
-
-type artifactUploadConfig struct {
-	bucket   string
-	prefix   string
-	region   string
-	nodeName string
-}
-
-func parseArtifactUploadConfig(params map[string]any) (artifactUploadConfig, error) {
-	bucket, _ := params["s3Bucket"].(string)
-	prefix, _ := params["s3Prefix"].(string)
-	region, _ := params["s3Region"].(string)
-	nodeName, _ := params["nodeName"].(string)
-
-	if bucket == "" {
-		return artifactUploadConfig{}, fmt.Errorf("upload-genesis-artifacts: missing required param 's3Bucket'")
-	}
-	if region == "" {
-		return artifactUploadConfig{}, fmt.Errorf("upload-genesis-artifacts: missing required param 's3Region'")
-	}
-	if nodeName == "" {
-		return artifactUploadConfig{}, fmt.Errorf("upload-genesis-artifacts: missing required param 'nodeName'")
-	}
-
-	return artifactUploadConfig{bucket: bucket, prefix: prefix, region: region, nodeName: nodeName}, nil
 }


### PR DESCRIPTION
## Summary

Introduces `engine.TypedHandler[T]` — a generic helper that gives every task handler compile-time typed params without changing the engine, store, server, or client.

All 17 handlers converted. Manual parse functions eliminated. Net -216 lines.

### How it works
```go
// Before: fragile type assertions
func (r *SnapshotRestorer) Handler() engine.TaskHandler {
    return func(ctx context.Context, params map[string]any) error {
        bucket, _ := params["bucket"].(string)  // silent zero on mismatch
        ...
    }
}

// After: typed params with JSON struct tags
func (r *SnapshotRestorer) Handler() engine.TaskHandler {
    return engine.TypedHandler(func(ctx context.Context, cfg SnapshotConfig) error {
        if cfg.Bucket == "" { return fmt.Errorf("missing bucket") }
        return r.Restore(ctx, cfg)
    })
}
```

### What's removed
All manual parse functions: `parseSnapshotConfig`, `parseUploadConfig`, `parseExportConfig`, `parseAssembleConfig`, `parseNodeNames`, `parseArtifactUploadConfig`, `parseGenesisPeersConfig`, `parseGenesisS3Config`, `intentFromParams`, `extractStringMap`, `parseSources`, `parseEC2TagsSource`, `parseStaticSource`, `toStringMap`, `toStringSlice`, `parseTargetHeight`

### What's unchanged
Engine, SQLite store, HTTP server, client, OpenAPI spec, serve.go registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)