### PR TITLE
feat: environment-driven snapshot restore with targetHeight selection

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -42,11 +42,15 @@ var serveCmd = cli.Command{
 		chainID := os.Getenv("SEI_CHAIN_ID")
 		genesisBucket := os.Getenv("SEI_GENESIS_BUCKET")
 		genesisRegion := os.Getenv("SEI_GENESIS_REGION")
+		snapshotBucket := os.Getenv("SEI_SNAPSHOT_BUCKET")
+		snapshotRegion := os.Getenv("SEI_SNAPSHOT_REGION")
 
 		for _, kv := range []struct{ name, val string }{
 			{"SEI_CHAIN_ID", chainID},
 			{"SEI_GENESIS_BUCKET", genesisBucket},
 			{"SEI_GENESIS_REGION", genesisRegion},
+			{"SEI_SNAPSHOT_BUCKET", snapshotBucket},
+			{"SEI_SNAPSHOT_REGION", snapshotRegion},
 		} {
 			if kv.val == "" {
 				return fmt.Errorf("required environment variable %s is not set", kv.name)
@@ -72,7 +76,7 @@ var serveCmd = cli.Command{
 		}
 
 		handlers := map[engine.TaskType]engine.TaskHandler{
-			engine.TaskSnapshotRestore:          tasks.NewSnapshotRestorer(homeDir, nil).Handler(),
+			engine.TaskSnapshotRestore:          tasks.NewSnapshotRestorer(homeDir, snapshotBucket, snapshotRegion, chainID, nil, nil).Handler(),
 			engine.TaskDiscoverPeers:            tasks.NewPeerDiscoverer(homeDir, nil, nil).Handler(),
 			engine.TaskConfigPatch:              tasks.NewConfigPatcher(homeDir).Handler(),
 			engine.TaskConfigApply:              tasks.NewConfigApplier(homeDir).Handler(),

--- a/serve.go
+++ b/serve.go
@@ -75,8 +75,13 @@ var serveCmd = cli.Command{
 			return fmt.Errorf("open result store: %w", err)
 		}
 
+		snapshotRestorer, err := tasks.NewSnapshotRestorer(homeDir, snapshotBucket, snapshotRegion, chainID, nil, nil)
+		if err != nil {
+			return fmt.Errorf("creating snapshot restorer: %w", err)
+		}
+
 		handlers := map[engine.TaskType]engine.TaskHandler{
-			engine.TaskSnapshotRestore:          tasks.NewSnapshotRestorer(homeDir, snapshotBucket, snapshotRegion, chainID, nil, nil).Handler(),
+			engine.TaskSnapshotRestore:          snapshotRestorer.Handler(),
 			engine.TaskDiscoverPeers:            tasks.NewPeerDiscoverer(homeDir, nil, nil).Handler(),
 			engine.TaskConfigPatch:              tasks.NewConfigPatcher(homeDir).Handler(),
 			engine.TaskConfigApply:              tasks.NewConfigApplier(homeDir).Handler(),

--- a/sidecar/client/client_test.go
+++ b/sidecar/client/client_test.go
@@ -69,8 +69,8 @@ func TestSubmitTask_HTTP201(t *testing.T) {
 			t.Fatal("Params is nil")
 		}
 		params := *req.Params
-		if params["bucket"] != "my-bucket" {
-			t.Errorf("bucket = %v, want my-bucket", params["bucket"])
+		if params["targetHeight"] != float64(100000000) {
+			t.Errorf("targetHeight = %v, want 100000000", params["targetHeight"])
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -78,10 +78,7 @@ func TestSubmitTask_HTTP201(t *testing.T) {
 	}))
 
 	task := SnapshotRestoreTask{
-		Bucket:  "my-bucket",
-		Prefix:  "snapshots",
-		Region:  "us-east-1",
-		ChainID: "sei-chain",
+		TargetHeight: 100000000,
 	}
 	id, err := c.SubmitSnapshotRestoreTask(context.Background(), task)
 	if err != nil {
@@ -206,7 +203,8 @@ func TestSubmitTask_ValidationFailure(t *testing.T) {
 		t.Fatal("server should not be called when validation fails")
 	}))
 
-	_, err := c.SubmitSnapshotRestoreTask(context.Background(), SnapshotRestoreTask{})
+	// SnapshotUploadTask requires Bucket — empty should fail validation.
+	_, err := c.SubmitSnapshotUploadTask(context.Background(), SnapshotUploadTask{})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -61,40 +61,25 @@ const (
 )
 
 // SnapshotRestoreTask downloads and extracts a snapshot archive from S3.
+// S3 coordinates are derived by the sidecar from its environment.
+// TargetHeight selects the highest available snapshot <= that height.
+// When zero, the latest snapshot (from latest.txt) is used.
 type SnapshotRestoreTask struct {
 	TaskMeta
-	Bucket  string
-	Prefix  string
-	Region  string
-	ChainID string
+	TargetHeight int64
 }
 
 func (t SnapshotRestoreTask) TaskType() string { return TaskTypeSnapshotRestore }
 
-func (t SnapshotRestoreTask) Validate() error {
-	if t.Bucket == "" {
-		return fmt.Errorf("snapshot-restore: missing required field Bucket")
-	}
-	if t.Prefix == "" {
-		return fmt.Errorf("snapshot-restore: missing required field Prefix")
-	}
-	if t.Region == "" {
-		return fmt.Errorf("snapshot-restore: missing required field Region")
-	}
-	if t.ChainID == "" {
-		return fmt.Errorf("snapshot-restore: missing required field ChainID")
-	}
-	return nil
-}
+func (t SnapshotRestoreTask) Validate() error { return nil }
 
 func (t SnapshotRestoreTask) ToTaskRequest() TaskRequest {
-	p := map[string]interface{}{
-		"bucket":  t.Bucket,
-		"prefix":  t.Prefix,
-		"region":  t.Region,
-		"chainId": t.ChainID,
+	var p *map[string]interface{}
+	if t.TargetHeight > 0 {
+		m := map[string]interface{}{"targetHeight": t.TargetHeight}
+		p = &m
 	}
-	req := TaskRequest{Type: t.TaskType(), Params: &p}
+	req := TaskRequest{Type: t.TaskType(), Params: p}
 	t.applyMeta(&req)
 	return req
 }
@@ -102,13 +87,14 @@ func (t SnapshotRestoreTask) ToTaskRequest() TaskRequest {
 // SnapshotRestoreTaskFromParams reconstructs a SnapshotRestoreTask from
 // a generic params map. Useful for round-trip testing.
 func SnapshotRestoreTaskFromParams(params map[string]interface{}) SnapshotRestoreTask {
-	s := func(k string) string { v, _ := params[k].(string); return v }
-	return SnapshotRestoreTask{
-		Bucket:  s("bucket"),
-		Prefix:  s("prefix"),
-		Region:  s("region"),
-		ChainID: s("chainId"),
+	var t SnapshotRestoreTask
+	switch h := params["targetHeight"].(type) {
+	case float64:
+		t.TargetHeight = int64(h)
+	case int64:
+		t.TargetHeight = h
 	}
+	return t
 }
 
 // SnapshotUploadTask archives and streams a local snapshot to S3.

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -14,18 +14,8 @@ func genNonEmptyString() gopter.Gen {
 }
 
 func genSnapshotRestoreTask() gopter.Gen {
-	return gopter.CombineGens(
-		genNonEmptyString(),
-		genNonEmptyString(),
-		genNonEmptyString(),
-		genNonEmptyString(),
-	).Map(func(v []interface{}) SnapshotRestoreTask {
-		return SnapshotRestoreTask{
-			Bucket:  v[0].(string),
-			Prefix:  v[1].(string),
-			Region:  v[2].(string),
-			ChainID: v[3].(string),
-		}
+	return gen.Int64Range(0, 300000000).Map(func(h int64) SnapshotRestoreTask {
+		return SnapshotRestoreTask{TargetHeight: h}
 	})
 }
 
@@ -111,11 +101,11 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 			if req.Type != TaskTypeSnapshotRestore {
 				return false
 			}
+			if task.TargetHeight == 0 {
+				return req.Params == nil
+			}
 			rebuilt := SnapshotRestoreTaskFromParams(*req.Params)
-			return rebuilt.Bucket == task.Bucket &&
-				rebuilt.Prefix == task.Prefix &&
-				rebuilt.Region == task.Region &&
-				rebuilt.ChainID == task.ChainID
+			return rebuilt.TargetHeight == task.TargetHeight
 		},
 		genSnapshotRestoreTask(),
 	))
@@ -269,21 +259,19 @@ func TestMarkReadyRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSnapshotRestoreValidationRejectsMissingFields(t *testing.T) {
+func TestSnapshotRestoreValidation(t *testing.T) {
+	// SnapshotRestoreTask has no required fields — TargetHeight=0 means "use latest"
 	cases := []struct {
 		name string
 		task SnapshotRestoreTask
 	}{
-		{"missing bucket", SnapshotRestoreTask{Prefix: "p", Region: "r", ChainID: "c"}},
-		{"missing prefix", SnapshotRestoreTask{Bucket: "b", Region: "r", ChainID: "c"}},
-		{"missing region", SnapshotRestoreTask{Bucket: "b", Prefix: "p", ChainID: "c"}},
-		{"missing chainId", SnapshotRestoreTask{Bucket: "b", Prefix: "p", Region: "r"}},
-		{"all empty", SnapshotRestoreTask{}},
+		{"zero height (latest)", SnapshotRestoreTask{}},
+		{"with target height", SnapshotRestoreTask{TargetHeight: 100000000}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.task.Validate(); err == nil {
-				t.Error("expected validation error, got nil")
+			if err := tc.task.Validate(); err != nil {
+				t.Errorf("unexpected validation error: %v", err)
 			}
 		})
 	}

--- a/sidecar/s3/client.go
+++ b/sidecar/s3/client.go
@@ -46,6 +46,23 @@ func DefaultUploaderFactory(ctx context.Context, region string) (Uploader, error
 	return transfermanager.New(s3.NewFromConfig(cfg)), nil
 }
 
+// ObjectLister abstracts S3 ListObjectsV2 for snapshot discovery.
+type ObjectLister interface {
+	ListObjectsV2(ctx context.Context, input *s3.ListObjectsV2Input, opts ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+}
+
+// ObjectListerFactory builds an ObjectLister for a given region.
+type ObjectListerFactory func(ctx context.Context, region string) (ObjectLister, error)
+
+// DefaultObjectListerFactory creates a real S3 client for listing objects.
+func DefaultObjectListerFactory(ctx context.Context, region string) (ObjectLister, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return s3.NewFromConfig(cfg), nil
+}
+
 // WriteAtBuffer is a goroutine-safe in-memory io.WriterAt, used for
 // downloading small S3 objects (e.g. latest.txt) via DownloadObject.
 type WriteAtBuffer struct {

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/sei-protocol/seictl/sidecar/engine"
 	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
 	"github.com/sei-protocol/seilog"
@@ -21,83 +22,96 @@ import (
 
 var restoreLog = seilog.NewLogger("seictl", "task", "snapshot-restore")
 
-const snapshotMarkerFile = ".sei-sidecar-snapshot-done"
+const restoreMarkerFile = ".sei-sidecar-snapshot-done"
 
-// SnapshotHeightFile stores the height of the restored snapshot so that
-// downstream tasks (e.g. result export) can auto-discover their start point.
+// SnapshotHeightFile records the snapshot height the node was restored from.
+// The result-export task uses this to know where to start exporting.
 const SnapshotHeightFile = ".sei-sidecar-snapshot-height"
 
-// snapshotHeightRe extracts heights from S3 keys like snapshot_198030000_pacific-1_eu-central-1.tar.gz.
-var snapshotHeightRe = regexp.MustCompile(`snapshot_(\d+)_`)
+// snapshotHeightRe extracts heights from S3 keys like pacific-1/200440000.tar.gz.
+var snapshotHeightRe = regexp.MustCompile(`(\d+)\.tar\.gz$`)
 
-// SnapshotRestoreRequest holds S3 coordinates for snapshot download.
+// SnapshotRestoreRequest holds the typed parameters for the snapshot-restore task.
+// S3 bucket, region, and chain prefix are derived from the sidecar's environment.
+// TargetHeight, when set, selects the highest available snapshot <= that height.
+// When zero, the latest snapshot (from latest.txt) is used.
 type SnapshotRestoreRequest struct {
-	Bucket  string `json:"bucket"`
-	Prefix  string `json:"prefix"`
-	Region  string `json:"region"`
-	ChainID string `json:"chainId"`
+	TargetHeight int64 `json:"targetHeight,omitempty"`
 }
 
 // SnapshotRestorer downloads and extracts a snapshot archive from S3.
 type SnapshotRestorer struct {
 	homeDir       string
+	bucket        string
+	region        string
+	chainID       string
 	clientFactory seis3.TransferClientFactory
+	listerFactory seis3.ObjectListerFactory
 }
 
 // NewSnapshotRestorer creates a restorer targeting the given home directory.
-// Pass nil to use the default AWS transfer manager.
-func NewSnapshotRestorer(homeDir string, factory seis3.TransferClientFactory) *SnapshotRestorer {
-	if factory == nil {
-		factory = seis3.DefaultTransferClientFactory
+// Bucket, region, and chainID are read from environment at construction time.
+func NewSnapshotRestorer(homeDir, bucket, region, chainID string, clientFactory seis3.TransferClientFactory, listerFactory seis3.ObjectListerFactory) *SnapshotRestorer {
+	if clientFactory == nil {
+		clientFactory = seis3.DefaultTransferClientFactory
+	}
+	if listerFactory == nil {
+		listerFactory = seis3.DefaultObjectListerFactory
 	}
 	return &SnapshotRestorer{
 		homeDir:       homeDir,
-		clientFactory: factory,
+		bucket:        bucket,
+		region:        region,
+		chainID:       chainID,
+		clientFactory: clientFactory,
+		listerFactory: listerFactory,
 	}
 }
 
 // Handler returns an engine.TaskHandler for the snapshot-restore task.
 func (r *SnapshotRestorer) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotRestoreRequest) error {
-		if cfg.Bucket == "" {
-			return fmt.Errorf("snapshot-restore: missing required param 'bucket'")
-		}
-		if cfg.Prefix == "" {
-			return fmt.Errorf("snapshot-restore: missing required param 'prefix'")
-		}
-		if cfg.Region == "" {
-			return fmt.Errorf("snapshot-restore: missing required param 'region'")
-		}
-		if cfg.ChainID == "" {
-			return fmt.Errorf("snapshot-restore: missing required param 'chainId'")
-		}
-		return r.Restore(ctx, cfg)
+	return engine.TypedHandler(func(ctx context.Context, req SnapshotRestoreRequest) error {
+		return r.Restore(ctx, req.TargetHeight)
 	})
 }
 
 // Restore downloads and extracts the snapshot, skipping if the marker file exists.
-// It reads latest.txt to resolve the current snapshot key, then uses the transfer
-// manager's DownloadObject (io.WriterAt path) for parallel byte-range downloads
-// to a temp file, and finally streams the temp file through gzip+tar extraction.
-func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotRestoreRequest) error {
-	if markerExists(r.homeDir, snapshotMarkerFile) {
+// When targetHeight > 0, it lists objects and picks the highest snapshot <= targetHeight.
+// When targetHeight == 0, it reads latest.txt for the newest snapshot.
+func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) error {
+	if markerExists(r.homeDir, restoreMarkerFile) {
 		restoreLog.Debug("already completed, skipping")
 		return nil
 	}
 
-	client, err := r.clientFactory(ctx, cfg.Region)
+	if r.bucket == "" || r.region == "" || r.chainID == "" {
+		return fmt.Errorf("snapshot-restore: SEI_SNAPSHOT_BUCKET, SEI_SNAPSHOT_REGION, and SEI_CHAIN_ID are required")
+	}
+
+	prefix := r.chainID + "/"
+
+	client, err := r.clientFactory(ctx, r.region)
 	if err != nil {
 		return fmt.Errorf("building S3 transfer client: %w", err)
 	}
 
-	snapshotKey, err := resolveSnapshotKey(ctx, client, cfg)
+	var snapshotKey string
+	if targetHeight > 0 {
+		lister, err := r.listerFactory(ctx, r.region)
+		if err != nil {
+			return fmt.Errorf("building S3 lister: %w", err)
+		}
+		snapshotKey, err = resolveKeyForHeight(ctx, lister, r.bucket, prefix, targetHeight)
+	} else {
+		snapshotKey, err = resolveLatestKey(ctx, client, r.bucket, prefix)
+	}
 	if err != nil {
 		return err
 	}
 
 	tmpDir := filepath.Join(r.homeDir, "tmp")
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
-		return fmt.Errorf("creating tmp directory: %w", err)
+		return fmt.Errorf("creating temp dir: %w", err)
 	}
 
 	tmpFile, err := os.CreateTemp(tmpDir, "snapshot-*.tar.gz")
@@ -107,31 +121,15 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotRestoreReque
 	tmpPath := tmpFile.Name()
 	defer func() { _ = os.Remove(tmpPath) }()
 
-	restoreLog.Info("downloading snapshot", "bucket", cfg.Bucket, "key", snapshotKey, "dest", tmpPath)
+	restoreLog.Info("downloading snapshot", "bucket", r.bucket, "key", snapshotKey, "dest", tmpPath)
 	_, err = client.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
-		Bucket:   aws.String(cfg.Bucket),
+		Bucket:   aws.String(r.bucket),
 		Key:      aws.String(snapshotKey),
 		WriterAt: tmpFile,
 	})
 	_ = tmpFile.Close()
 	if err != nil {
 		return fmt.Errorf("s3 DownloadObject %s: %w", snapshotKey, err)
-	}
-
-	snapshotDir := filepath.Join(r.homeDir, "data", "snapshots")
-	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
-		return fmt.Errorf("creating snapshot directory: %w", err)
-	}
-
-	f, err := os.Open(tmpPath)
-	if err != nil {
-		return fmt.Errorf("opening downloaded archive: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	restoreLog.Info("extracting archive", "dest", snapshotDir)
-	if err := extractTarStream(ctx, f, snapshotDir); err != nil {
-		return fmt.Errorf("extracting snapshot: %w", err)
 	}
 
 	if h := parseHeightFromKey(snapshotKey); h > 0 {
@@ -144,16 +142,22 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, cfg SnapshotRestoreReque
 		}
 	}
 
+	destDir := filepath.Join(r.homeDir, "data", "snapshots")
+	restoreLog.Info("extracting archive", "dest", destDir)
+	if err := extractArchive(ctx, tmpPath, destDir); err != nil {
+		return fmt.Errorf("extracting snapshot: %w", err)
+	}
+
 	restoreLog.Info("restore complete")
-	return writeMarker(r.homeDir, snapshotMarkerFile)
+	return writeMarker(r.homeDir, restoreMarkerFile)
 }
 
-// resolveSnapshotKey reads <prefix>latest.txt to find the current snapshot object key.
-func resolveSnapshotKey(ctx context.Context, client seis3.TransferClient, cfg SnapshotRestoreRequest) (string, error) {
+// resolveLatestKey reads <prefix>latest.txt and constructs the snapshot key.
+func resolveLatestKey(ctx context.Context, client seis3.TransferClient, bucket, prefix string) (string, error) {
 	var buf seis3.WriteAtBuffer
 	_, err := client.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
-		Bucket:   aws.String(cfg.Bucket),
-		Key:      aws.String(cfg.Prefix + "latest.txt"),
+		Bucket:   aws.String(bucket),
+		Key:      aws.String(prefix + "latest.txt"),
 		WriterAt: &buf,
 	})
 	if err != nil {
@@ -165,8 +169,53 @@ func resolveSnapshotKey(ctx context.Context, client seis3.TransferClient, cfg Sn
 		return "", fmt.Errorf("latest.txt is empty")
 	}
 
-	filename := fmt.Sprintf("snapshot_%s_%s_%s.tar.gz", height, cfg.ChainID, cfg.Region)
-	return cfg.Prefix + filename, nil
+	return prefix + height + ".tar.gz", nil
+}
+
+// resolveKeyForHeight lists snapshot objects and returns the key with the
+// highest height that is <= targetHeight.
+func resolveKeyForHeight(ctx context.Context, lister seis3.ObjectLister, bucket, prefix string, targetHeight int64) (string, error) {
+	var bestHeight int64
+	var bestKey string
+
+	var continuationToken *string
+	for {
+		output, err := lister.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bucket),
+			Prefix:            aws.String(prefix),
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return "", fmt.Errorf("listing snapshots in s3://%s/%s: %w", bucket, prefix, err)
+		}
+
+		for _, obj := range output.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			h := parseHeightFromKey(*obj.Key)
+			if h <= 0 || h > targetHeight {
+				continue
+			}
+			if h > bestHeight {
+				bestHeight = h
+				bestKey = *obj.Key
+			}
+		}
+
+		if !aws.ToBool(output.IsTruncated) {
+			break
+		}
+		continuationToken = output.NextContinuationToken
+	}
+
+	if bestKey == "" {
+		return "", fmt.Errorf("no snapshot found at or below height %d in s3://%s/%s", targetHeight, bucket, prefix)
+	}
+
+	restoreLog.Info("resolved snapshot for target height",
+		"targetHeight", targetHeight, "snapshotHeight", bestHeight, "key", bestKey)
+	return bestKey, nil
 }
 
 func parseHeightFromKey(key string) int64 {
@@ -174,12 +223,24 @@ func parseHeightFromKey(key string) int64 {
 	if len(m) < 2 {
 		return 0
 	}
-	h, _ := strconv.ParseInt(m[1], 10, 64)
+	h, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0
+	}
 	return h
 }
 
-// extractTarStream reads a gzip-compressed tar archive from r and extracts
-// entries to destDir.
+// extractArchive opens a .tar.gz file and extracts it to destDir.
+func extractArchive(ctx context.Context, archivePath, destDir string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("opening archive: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	return extractTarStream(ctx, f, destDir)
+}
+
 func extractTarStream(ctx context.Context, r io.Reader, destDir string) error {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
@@ -202,7 +263,6 @@ func extractTarStream(ctx context.Context, r io.Reader, destDir string) error {
 
 		target := filepath.Join(destDir, filepath.Clean(header.Name))
 
-		// Path traversal guard: reject entries that escape destDir.
 		if !isInsideDir(target, destDir) {
 			return fmt.Errorf("tar entry %q escapes destination directory", header.Name)
 		}
@@ -224,8 +284,6 @@ func extractTarStream(ctx context.Context, r io.Reader, destDir string) error {
 			if err := os.Symlink(header.Linkname, target); err != nil {
 				return fmt.Errorf("creating symlink %s: %w", target, err)
 			}
-		default:
-			// Skip unsupported entry types (block devices, char devices, etc.)
 		}
 	}
 }
@@ -234,13 +292,11 @@ func extractFile(r io.Reader, path string, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("creating parent directory for %s: %w", path, err)
 	}
-
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode|0o600)
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
-
 	if _, err := io.Copy(f, r); err != nil {
 		return fmt.Errorf("writing file %s: %w", path, err)
 	}

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -84,6 +84,10 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 		return nil
 	}
 
+	if targetHeight < 0 {
+		return fmt.Errorf("snapshot-restore: targetHeight must be >= 0, got %d", targetHeight)
+	}
+
 	if r.bucket == "" || r.region == "" || r.chainID == "" {
 		return fmt.Errorf("snapshot-restore: SEI_SNAPSHOT_BUCKET, SEI_SNAPSHOT_REGION, and SEI_CHAIN_ID are required")
 	}

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -51,7 +51,10 @@ type SnapshotRestorer struct {
 
 // NewSnapshotRestorer creates a restorer targeting the given home directory.
 // Bucket, region, and chainID are read from environment at construction time.
-func NewSnapshotRestorer(homeDir, bucket, region, chainID string, clientFactory seis3.TransferClientFactory, listerFactory seis3.ObjectListerFactory) *SnapshotRestorer {
+func NewSnapshotRestorer(homeDir, bucket, region, chainID string, clientFactory seis3.TransferClientFactory, listerFactory seis3.ObjectListerFactory) (*SnapshotRestorer, error) {
+	if bucket == "" || region == "" || chainID == "" {
+		return nil, fmt.Errorf("snapshot-restore: bucket, region, and chainID are required")
+	}
 	if clientFactory == nil {
 		clientFactory = seis3.DefaultTransferClientFactory
 	}
@@ -65,7 +68,7 @@ func NewSnapshotRestorer(homeDir, bucket, region, chainID string, clientFactory 
 		chainID:       chainID,
 		clientFactory: clientFactory,
 		listerFactory: listerFactory,
-	}
+	}, nil
 }
 
 // Handler returns an engine.TaskHandler for the snapshot-restore task.
@@ -86,10 +89,6 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 
 	if targetHeight < 0 {
 		return fmt.Errorf("snapshot-restore: targetHeight must be >= 0, got %d", targetHeight)
-	}
-
-	if r.bucket == "" || r.region == "" || r.chainID == "" {
-		return fmt.Errorf("snapshot-restore: SEI_SNAPSHOT_BUCKET, SEI_SNAPSHOT_REGION, and SEI_CHAIN_ID are required")
 	}
 
 	prefix := r.chainID + "/"

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -92,6 +92,15 @@ func (m *mockObjectLister) ListObjectsV2(_ context.Context, input *s3.ListObject
 	}, nil
 }
 
+func mustNewRestorer(t *testing.T, homeDir, bucket, region, chainID string, cf seis3.TransferClientFactory, lf seis3.ObjectListerFactory) *SnapshotRestorer {
+	t.Helper()
+	r, err := NewSnapshotRestorer(homeDir, bucket, region, chainID, cf, lf)
+	if err != nil {
+		t.Fatalf("NewSnapshotRestorer: %v", err)
+	}
+	return r
+}
+
 func mockListerFactory(lister seis3.ObjectLister) seis3.ObjectListerFactory {
 	return func(_ context.Context, _ string) (seis3.ObjectLister, error) {
 		return lister, nil
@@ -136,7 +145,7 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 			"testchain/100000000.tar.gz": archive,
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, "test-bucket", "us-east-1", "testchain", mockClientFactory(client), nil)
+	restorer := mustNewRestorer(t, homeDir, "test-bucket", "us-east-1", "testchain", mockClientFactory(client), nil)
 	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
@@ -160,7 +169,7 @@ func TestSnapshotRestoreSkipsWhenMarkerExists(t *testing.T) {
 		t.Fatalf("writing marker: %v", err)
 	}
 
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(&mockTransferClient{
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(&mockTransferClient{
 		errDefault: fmt.Errorf("should not be called"),
 	}), nil)
 
@@ -171,7 +180,7 @@ func TestSnapshotRestoreSkipsWhenMarkerExists(t *testing.T) {
 
 func TestSnapshotRestoreNoMarkerOnLatestTxtError(t *testing.T) {
 	homeDir := t.TempDir()
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(&mockTransferClient{
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(&mockTransferClient{
 		errDefault: fmt.Errorf("access denied"),
 	}), nil)
 
@@ -192,7 +201,7 @@ func TestSnapshotRestoreNoMarkerOnDownloadError(t *testing.T) {
 		},
 		errDefault: fmt.Errorf("access denied"),
 	}
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
 
 	if err := restorer.Restore(context.Background(), 0); err == nil {
 		t.Fatal("expected error on snapshot download failure")
@@ -215,7 +224,7 @@ func TestSnapshotRestoreRejectsPathTraversal(t *testing.T) {
 			"c/100000000.tar.gz": archive,
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
 	if err := restorer.Restore(context.Background(), 0); err == nil {
 		t.Fatal("expected error for path traversal attempt")
 	}
@@ -233,7 +242,7 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 			"c/100000000.tar.gz": archive,
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
 	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
@@ -262,7 +271,7 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 			"c/100000000.tar.gz": archive,
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
 	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
@@ -295,7 +304,7 @@ func TestSnapshotRestoreWithTargetHeight(t *testing.T) {
 			"c/latest.txt",
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	// Target 99500000 — should pick 99000000 (highest <= target)
 	if err := restorer.Restore(context.Background(), 99500000); err != nil {
 		t.Fatalf("Restore failed: %v", err)
@@ -318,7 +327,7 @@ func TestSnapshotRestoreTargetHeightNoMatch(t *testing.T) {
 			"c/200000000.tar.gz",
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", nil, mockListerFactory(lister))
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", nil, mockListerFactory(lister))
 	// Target 50000000 — no snapshots at or below
 	err := restorer.Restore(context.Background(), 50000000)
 	if err == nil {
@@ -348,7 +357,7 @@ func TestSnapshotRestoreTargetHeightPagination(t *testing.T) {
 			"c/latest.txt",
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 99500000); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
@@ -364,7 +373,7 @@ func TestSnapshotRestoreTargetHeightPagination(t *testing.T) {
 
 func TestSnapshotRestoreNegativeTargetHeight(t *testing.T) {
 	homeDir := t.TempDir()
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", nil, nil)
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", nil, nil)
 	err := restorer.Restore(context.Background(), -1)
 	if err == nil {
 		t.Fatal("expected error for negative targetHeight")

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
 )
 
 // mockTransferClient implements seis3.TransferClient for testing.
-// It maps S3 object keys to their body bytes and writes them to the
-// provided WriterAt.
 type mockTransferClient struct {
 	responses  map[string][]byte
 	errDefault error
@@ -39,13 +39,32 @@ func (m *mockTransferClient) DownloadObject(_ context.Context, in *transfermanag
 	return nil, fmt.Errorf("unexpected key: %s", key)
 }
 
-func mockFactory(client seis3.TransferClient) seis3.TransferClientFactory {
+func mockClientFactory(client seis3.TransferClient) seis3.TransferClientFactory {
 	return func(_ context.Context, _ string) (seis3.TransferClient, error) {
 		return client, nil
 	}
 }
 
-// buildTarGzArchive creates a gzip-compressed tar archive with the given file entries.
+// mockObjectLister implements seis3.ObjectLister for testing.
+type mockObjectLister struct {
+	keys []string
+}
+
+func (m *mockObjectLister) ListObjectsV2(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	var contents []types.Object
+	for _, k := range m.keys {
+		key := k
+		contents = append(contents, types.Object{Key: &key})
+	}
+	return &s3.ListObjectsV2Output{Contents: contents}, nil
+}
+
+func mockListerFactory(lister seis3.ObjectLister) seis3.ObjectListerFactory {
+	return func(_ context.Context, _ string) (seis3.ObjectLister, error) {
+		return lister, nil
+	}
+}
+
 func buildTarGzArchive(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -76,23 +95,16 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 	homeDir := t.TempDir()
 	archive := buildTarGzArchive(t, map[string]string{
 		"data/chain.db": "chaindata",
-		"config.toml":   "[p2p]\npersistent_peers = \"\"",
 	})
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"snapshots/latest.txt": []byte("100000000"),
-			"snapshots/snapshot_100000000_testchain_us-east-1.tar.gz": archive,
+			"testchain/latest.txt":      []byte("100000000"),
+			"testchain/100000000.tar.gz": archive,
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
-		Bucket:  "test-bucket",
-		Prefix:  "snapshots/",
-		Region:  "us-east-1",
-		ChainID: "testchain",
-	})
-	if err != nil {
+	restorer := NewSnapshotRestorer(homeDir, "test-bucket", "us-east-1", "testchain", mockClientFactory(client), nil)
+	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
 
@@ -104,81 +116,56 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 		t.Fatalf("expected 'chaindata', got %q", string(content))
 	}
 
-	if _, err := os.Stat(filepath.Join(homeDir, "data", "snapshots")); os.IsNotExist(err) {
-		t.Fatal("data/snapshots directory should exist")
-	}
-
-	if !markerExists(homeDir, snapshotMarkerFile) {
+	if !markerExists(homeDir, restoreMarkerFile) {
 		t.Fatal("marker file should exist after successful restore")
 	}
 }
 
 func TestSnapshotRestoreSkipsWhenMarkerExists(t *testing.T) {
 	homeDir := t.TempDir()
-
-	if err := writeMarker(homeDir, snapshotMarkerFile); err != nil {
+	if err := writeMarker(homeDir, restoreMarkerFile); err != nil {
 		t.Fatalf("writing marker: %v", err)
 	}
 
-	restorer := NewSnapshotRestorer(homeDir, mockFactory(&mockTransferClient{
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(&mockTransferClient{
 		errDefault: fmt.Errorf("should not be called"),
-	}))
+	}), nil)
 
-	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
-		Bucket:  "test-bucket",
-		Prefix:  "snapshots/",
-		Region:  "us-east-1",
-		ChainID: "testchain",
-	})
-	if err != nil {
+	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("expected nil error when marker exists, got: %v", err)
 	}
 }
 
 func TestSnapshotRestoreNoMarkerOnLatestTxtError(t *testing.T) {
 	homeDir := t.TempDir()
-
-	restorer := NewSnapshotRestorer(homeDir, mockFactory(&mockTransferClient{
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(&mockTransferClient{
 		errDefault: fmt.Errorf("access denied"),
-	}))
+	}), nil)
 
-	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
-		Bucket:  "test-bucket",
-		Prefix:  "snapshots/",
-		Region:  "us-east-1",
-		ChainID: "testchain",
-	})
-	if err == nil {
+	if err := restorer.Restore(context.Background(), 0); err == nil {
 		t.Fatal("expected error on S3 failure")
 	}
 
-	if markerExists(homeDir, snapshotMarkerFile) {
+	if markerExists(homeDir, restoreMarkerFile) {
 		t.Fatal("marker file should not exist after failed restore")
 	}
 }
 
 func TestSnapshotRestoreNoMarkerOnDownloadError(t *testing.T) {
 	homeDir := t.TempDir()
-
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"snapshots/latest.txt": []byte("100000000"),
+			"c/latest.txt": []byte("100000000"),
 		},
 		errDefault: fmt.Errorf("access denied"),
 	}
-	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
 
-	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
-		Bucket:  "test-bucket",
-		Prefix:  "snapshots/",
-		Region:  "us-east-1",
-		ChainID: "testchain",
-	})
-	if err == nil {
+	if err := restorer.Restore(context.Background(), 0); err == nil {
 		t.Fatal("expected error on snapshot download failure")
 	}
 
-	if markerExists(homeDir, snapshotMarkerFile) {
+	if markerExists(homeDir, restoreMarkerFile) {
 		t.Fatal("marker file should not exist after failed restore")
 	}
 }
@@ -191,18 +178,12 @@ func TestSnapshotRestoreRejectsPathTraversal(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"snapshots/latest.txt": []byte("100000000"),
-			"snapshots/snapshot_100000000_testchain_us-east-1.tar.gz": archive,
+			"c/latest.txt":      []byte("100000000"),
+			"c/100000000.tar.gz": archive,
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
-		Bucket:  "test-bucket",
-		Prefix:  "snapshots/",
-		Region:  "us-east-1",
-		ChainID: "testchain",
-	})
-	if err == nil {
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	if err := restorer.Restore(context.Background(), 0); err == nil {
 		t.Fatal("expected error for path traversal attempt")
 	}
 }
@@ -215,19 +196,12 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"snapshots/latest.txt": []byte("100000000"),
-			"snapshots/snapshot_100000000_testchain_us-east-1.tar.gz": archive,
+			"c/latest.txt":      []byte("100000000"),
+			"c/100000000.tar.gz": archive,
 		},
 	}
-
-	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
-		Bucket:  "test-bucket",
-		Prefix:  "snapshots/",
-		Region:  "us-east-1",
-		ChainID: "testchain",
-	})
-	if err != nil {
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
 
@@ -243,30 +217,6 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 	}
 }
 
-func TestSnapshotHandlerParamValidation(t *testing.T) {
-	restorer := NewSnapshotRestorer(t.TempDir(), nil)
-	handler := restorer.Handler()
-
-	tests := []struct {
-		name   string
-		params map[string]any
-	}{
-		{"missing bucket", map[string]any{"prefix": "snapshots/", "region": "us-east-1", "chainId": "c"}},
-		{"missing prefix", map[string]any{"bucket": "b", "region": "us-east-1", "chainId": "c"}},
-		{"missing region", map[string]any{"bucket": "b", "prefix": "snapshots/", "chainId": "c"}},
-		{"missing chainId", map[string]any{"bucket": "b", "prefix": "snapshots/", "region": "us-east-1"}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := handler(context.Background(), tt.params)
-			if err == nil {
-				t.Fatal("expected validation error")
-			}
-		})
-	}
-}
-
 func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 	homeDir := t.TempDir()
 	archive := buildTarGzArchive(t, map[string]string{
@@ -275,18 +225,12 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"snapshots/latest.txt": []byte("100000000"),
-			"snapshots/snapshot_100000000_testchain_us-east-1.tar.gz": archive,
+			"c/latest.txt":      []byte("100000000"),
+			"c/100000000.tar.gz": archive,
 		},
 	}
-	restorer := NewSnapshotRestorer(homeDir, mockFactory(client))
-	err := restorer.Restore(context.Background(), SnapshotRestoreRequest{
-		Bucket:  "test-bucket",
-		Prefix:  "snapshots/",
-		Region:  "us-east-1",
-		ChainID: "testchain",
-	})
-	if err != nil {
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
 
@@ -296,5 +240,55 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 	}
 	if string(heightBytes) != "100000000" {
 		t.Errorf("snapshot height file = %q, want %q", string(heightBytes), "100000000")
+	}
+}
+
+func TestSnapshotRestoreWithTargetHeight(t *testing.T) {
+	homeDir := t.TempDir()
+	archive := buildTarGzArchive(t, map[string]string{
+		"data/chain.db": "chaindata",
+	})
+
+	client := &mockTransferClient{
+		responses: map[string][]byte{
+			"c/99000000.tar.gz": archive,
+		},
+	}
+	lister := &mockObjectLister{
+		keys: []string{
+			"c/98000000.tar.gz",
+			"c/99000000.tar.gz",
+			"c/100000000.tar.gz",
+			"c/latest.txt",
+		},
+	}
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
+	// Target 99500000 — should pick 99000000 (highest <= target)
+	if err := restorer.Restore(context.Background(), 99500000); err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+
+	heightBytes, err := os.ReadFile(filepath.Join(homeDir, SnapshotHeightFile))
+	if err != nil {
+		t.Fatalf("reading snapshot height file: %v", err)
+	}
+	if string(heightBytes) != "99000000" {
+		t.Errorf("snapshot height = %q, want %q", string(heightBytes), "99000000")
+	}
+}
+
+func TestSnapshotRestoreTargetHeightNoMatch(t *testing.T) {
+	homeDir := t.TempDir()
+	lister := &mockObjectLister{
+		keys: []string{
+			"c/100000000.tar.gz",
+			"c/200000000.tar.gz",
+		},
+	}
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", nil, mockListerFactory(lister))
+	// Target 50000000 — no snapshots at or below
+	err := restorer.Restore(context.Background(), 50000000)
+	if err == nil {
+		t.Fatal("expected error when no snapshot found at or below target height")
 	}
 }

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -46,17 +46,50 @@ func mockClientFactory(client seis3.TransferClient) seis3.TransferClientFactory 
 }
 
 // mockObjectLister implements seis3.ObjectLister for testing.
+// pageSize controls pagination — 0 means return all keys in one page.
 type mockObjectLister struct {
-	keys []string
+	keys     []string
+	pageSize int
 }
 
 func (m *mockObjectLister) ListObjectsV2(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	pageSize := m.pageSize
+	if pageSize <= 0 {
+		pageSize = len(m.keys)
+	}
+
+	startIdx := 0
+	if input.ContinuationToken != nil {
+		for i, k := range m.keys {
+			if k == *input.ContinuationToken {
+				startIdx = i
+				break
+			}
+		}
+	}
+
+	end := startIdx + pageSize
+	if end > len(m.keys) {
+		end = len(m.keys)
+	}
+
 	var contents []types.Object
-	for _, k := range m.keys {
+	for _, k := range m.keys[startIdx:end] {
 		key := k
 		contents = append(contents, types.Object{Key: &key})
 	}
-	return &s3.ListObjectsV2Output{Contents: contents}, nil
+
+	truncated := end < len(m.keys)
+	var nextToken *string
+	if truncated {
+		nextToken = &m.keys[end]
+	}
+
+	return &s3.ListObjectsV2Output{
+		Contents:              contents,
+		IsTruncated:           &truncated,
+		NextContinuationToken: nextToken,
+	}, nil
 }
 
 func mockListerFactory(lister seis3.ObjectLister) seis3.ObjectListerFactory {
@@ -290,5 +323,50 @@ func TestSnapshotRestoreTargetHeightNoMatch(t *testing.T) {
 	err := restorer.Restore(context.Background(), 50000000)
 	if err == nil {
 		t.Fatal("expected error when no snapshot found at or below target height")
+	}
+}
+
+func TestSnapshotRestoreTargetHeightPagination(t *testing.T) {
+	homeDir := t.TempDir()
+	archive := buildTarGzArchive(t, map[string]string{
+		"data/chain.db": "chaindata",
+	})
+
+	client := &mockTransferClient{
+		responses: map[string][]byte{
+			"c/99000000.tar.gz": archive,
+		},
+	}
+	// Page size of 2 forces pagination across 3 pages
+	lister := &mockObjectLister{
+		pageSize: 2,
+		keys: []string{
+			"c/97000000.tar.gz",
+			"c/98000000.tar.gz",
+			"c/99000000.tar.gz",
+			"c/100000000.tar.gz",
+			"c/latest.txt",
+		},
+	}
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
+	if err := restorer.Restore(context.Background(), 99500000); err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+
+	heightBytes, err := os.ReadFile(filepath.Join(homeDir, SnapshotHeightFile))
+	if err != nil {
+		t.Fatalf("reading snapshot height file: %v", err)
+	}
+	if string(heightBytes) != "99000000" {
+		t.Errorf("snapshot height = %q, want %q", string(heightBytes), "99000000")
+	}
+}
+
+func TestSnapshotRestoreNegativeTargetHeight(t *testing.T) {
+	homeDir := t.TempDir()
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", nil, nil)
+	err := restorer.Restore(context.Background(), -1)
+	if err == nil {
+		t.Fatal("expected error for negative targetHeight")
 	}
 }

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -99,7 +99,7 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"testchain/latest.txt":      []byte("100000000"),
+			"testchain/latest.txt":       []byte("100000000"),
 			"testchain/100000000.tar.gz": archive,
 		},
 	}
@@ -178,7 +178,7 @@ func TestSnapshotRestoreRejectsPathTraversal(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/latest.txt":      []byte("100000000"),
+			"c/latest.txt":       []byte("100000000"),
 			"c/100000000.tar.gz": archive,
 		},
 	}
@@ -196,7 +196,7 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/latest.txt":      []byte("100000000"),
+			"c/latest.txt":       []byte("100000000"),
 			"c/100000000.tar.gz": archive,
 		},
 	}
@@ -225,7 +225,7 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/latest.txt":      []byte("100000000"),
+			"c/latest.txt":       []byte("100000000"),
 			"c/100000000.tar.gz": archive,
 		},
 	}

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -313,27 +313,6 @@ func normalizePrefix(prefix string) string {
 	return prefix
 }
 
-// parseUploadConfig converts raw params into SnapshotUploadRequest with validation.
-func parseUploadConfig(params map[string]any) (SnapshotUploadRequest, error) {
-	var cfg SnapshotUploadRequest
-	if b, _ := params["bucket"].(string); b != "" {
-		cfg.Bucket = b
-	}
-	if p, _ := params["prefix"].(string); p != "" {
-		cfg.Prefix = p
-	}
-	if r, _ := params["region"].(string); r != "" {
-		cfg.Region = r
-	}
-	if cfg.Bucket == "" {
-		return cfg, fmt.Errorf("snapshot-upload: missing required param 'bucket'")
-	}
-	if cfg.Region == "" {
-		return cfg, fmt.Errorf("snapshot-upload: missing required param 'region'")
-	}
-	return cfg, nil
-}
-
 func (u *SnapshotUploader) readUploadState() uploadState {
 	data, err := os.ReadFile(filepath.Join(u.homeDir, uploadStateFile))
 	if err != nil {

--- a/sidecar/tasks/typed_handler_integration_test.go
+++ b/sidecar/tasks/typed_handler_integration_test.go
@@ -17,11 +17,14 @@ func TestDeserialize_SnapshotRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", nil, nil)
+	restorer, err := NewSnapshotRestorer(homeDir, "b", "r", "c", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	handler := restorer.Handler()
 
 	// The handler should succeed (skip via marker) without a parse error.
-	err := handler(context.Background(), map[string]any{})
+	err = handler(context.Background(), map[string]any{})
 	if err != nil {
 		t.Fatalf("snapshot-restore handler returned error: %v", err)
 	}

--- a/sidecar/tasks/typed_handler_integration_test.go
+++ b/sidecar/tasks/typed_handler_integration_test.go
@@ -13,22 +13,15 @@ import (
 func TestDeserialize_SnapshotRestore(t *testing.T) {
 	homeDir := t.TempDir()
 	// Pre-write a marker so the handler returns early without S3 calls.
-	if err := writeMarker(homeDir, snapshotMarkerFile); err != nil {
+	if err := writeMarker(homeDir, restoreMarkerFile); err != nil {
 		t.Fatal(err)
 	}
 
-	restorer := NewSnapshotRestorer(homeDir, nil)
+	restorer := NewSnapshotRestorer(homeDir, "b", "r", "c", nil, nil)
 	handler := restorer.Handler()
 
-	params := map[string]any{
-		"bucket":  "my-bucket",
-		"prefix":  "snapshots/",
-		"region":  "us-east-1",
-		"chainId": "pacific-1",
-	}
-
 	// The handler should succeed (skip via marker) without a parse error.
-	err := handler(context.Background(), params)
+	err := handler(context.Background(), map[string]any{})
 	if err != nil {
 		t.Fatalf("snapshot-restore handler returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Snapshot restore derives S3 bucket/region/chainID from environment (SEI_SNAPSHOT_BUCKET, SEI_SNAPSHOT_REGION, SEI_CHAIN_ID)
- Only task param is now `targetHeight`:
  - `> 0`: lists S3 objects, picks highest snapshot <= target
  - `== 0`: reads latest.txt for newest snapshot
- Simplified filename convention: `{height}.tar.gz` (removed chain/region suffix)
- Added ObjectLister interface for S3 ListObjectsV2 pagination
- serve.go validates snapshot env vars at startup

## Test plan
- [x] All sidecar tests pass
- [x] Target height selection tested (picks correct snapshot, errors on no match)
- [x] Latest.txt path tested
- [x] Client round-trip tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)