### PR TITLE
feat: assemble-genesis-fork sidecar task

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -98,6 +98,7 @@ var serveCmd = cli.Command{
 			engine.TaskUploadGenesisArtifacts:   tasks.NewGenesisArtifactUploader(homeDir, genesisBucket, genesisRegion, chainID, nil).Handler(),
 			engine.TaskAssembleAndUploadGenesis: tasks.NewGenesisAssembler(homeDir, genesisBucket, genesisRegion, chainID, nil, nil).Handler(),
 			engine.TaskSetGenesisPeers:          tasks.NewGenesisPeersSetter(homeDir, genesisBucket, genesisRegion, chainID, nil).Handler(),
+			engine.TaskAssembleGenesisFork:      tasks.NewGenesisForkAssembler(homeDir, genesisBucket, genesisRegion, nil, nil).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers, store)

--- a/serve.go
+++ b/serve.go
@@ -99,7 +99,7 @@ var serveCmd = cli.Command{
 			engine.TaskAssembleAndUploadGenesis: tasks.NewGenesisAssembler(homeDir, genesisBucket, genesisRegion, chainID, nil, nil).Handler(),
 			engine.TaskSetGenesisPeers:          tasks.NewGenesisPeersSetter(homeDir, genesisBucket, genesisRegion, chainID, nil).Handler(),
 			engine.TaskAssembleGenesisFork:      tasks.NewGenesisForkAssembler(homeDir, genesisBucket, genesisRegion, nil, nil).Handler(),
-			engine.TaskExportState:              tasks.NewStateExporter(homeDir, nil, nil).Handler(),
+			engine.TaskExportState:              tasks.NewStateExporter(homeDir, nil).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers, store)

--- a/serve.go
+++ b/serve.go
@@ -99,6 +99,7 @@ var serveCmd = cli.Command{
 			engine.TaskAssembleAndUploadGenesis: tasks.NewGenesisAssembler(homeDir, genesisBucket, genesisRegion, chainID, nil, nil).Handler(),
 			engine.TaskSetGenesisPeers:          tasks.NewGenesisPeersSetter(homeDir, genesisBucket, genesisRegion, chainID, nil).Handler(),
 			engine.TaskAssembleGenesisFork:      tasks.NewGenesisForkAssembler(homeDir, genesisBucket, genesisRegion, nil, nil).Handler(),
+			engine.TaskExportState:              tasks.NewStateExporter(homeDir, nil, nil).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers, store)

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -52,6 +52,7 @@ const (
 	TaskTypeUploadGenesisArtifacts = "upload-genesis-artifacts"
 	TaskTypeAssembleGenesis        = "assemble-and-upload-genesis"
 	TaskTypeSetGenesisPeers        = "set-genesis-peers"
+	TaskTypeAssembleGenesisFork    = string(engine.TaskAssembleGenesisFork)
 )
 
 // Known condition and action values for AwaitConditionTask.

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -47,11 +47,11 @@ const (
 	TaskTypeResultExport       = string(engine.TaskResultExport)
 	TaskTypeAwaitCondition     = string(engine.TaskAwaitCondition)
 
-	TaskTypeGenerateIdentity       = "generate-identity"
-	TaskTypeGenerateGentx          = "generate-gentx"
-	TaskTypeUploadGenesisArtifacts = "upload-genesis-artifacts"
-	TaskTypeAssembleGenesis        = "assemble-and-upload-genesis"
-	TaskTypeSetGenesisPeers        = "set-genesis-peers"
+	TaskTypeGenerateIdentity       = string(engine.TaskGenerateIdentity)
+	TaskTypeGenerateGentx          = string(engine.TaskGenerateGentx)
+	TaskTypeUploadGenesisArtifacts = string(engine.TaskUploadGenesisArtifacts)
+	TaskTypeAssembleGenesis        = string(engine.TaskAssembleAndUploadGenesis)
+	TaskTypeSetGenesisPeers        = string(engine.TaskSetGenesisPeers)
 	TaskTypeAssembleGenesisFork    = string(engine.TaskAssembleGenesisFork)
 )
 

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -53,6 +53,7 @@ const (
 	TaskTypeAssembleGenesis        = string(engine.TaskAssembleAndUploadGenesis)
 	TaskTypeSetGenesisPeers        = string(engine.TaskSetGenesisPeers)
 	TaskTypeAssembleGenesisFork    = string(engine.TaskAssembleGenesisFork)
+	TaskTypeExportState            = string(engine.TaskExportState)
 )
 
 // Known condition and action values for AwaitConditionTask.

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -26,6 +26,7 @@ const (
 	TaskUploadGenesisArtifacts   TaskType = "upload-genesis-artifacts"
 	TaskAssembleAndUploadGenesis TaskType = "assemble-and-upload-genesis"
 	TaskSetGenesisPeers          TaskType = "set-genesis-peers"
+	TaskAssembleGenesisFork      TaskType = "assemble-genesis-fork"
 )
 
 // Task is a unit of work submitted by the controller. When ID is set, the

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -27,6 +27,7 @@ const (
 	TaskAssembleAndUploadGenesis TaskType = "assemble-and-upload-genesis"
 	TaskSetGenesisPeers          TaskType = "set-genesis-peers"
 	TaskAssembleGenesisFork      TaskType = "assemble-genesis-fork"
+	TaskExportState              TaskType = "export-state"
 )
 
 // Task is a unit of work submitted by the controller. When ID is set, the

--- a/sidecar/tasks/assemble_genesis_fork.go
+++ b/sidecar/tasks/assemble_genesis_fork.go
@@ -1,0 +1,553 @@
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	tmcfg "github.com/sei-protocol/sei-chain/sei-tendermint/config"
+	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
+
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
+	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/x/genutil"
+	genutiltypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/genutil/types"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+	"github.com/sei-protocol/seilog"
+)
+
+var forkLog = seilog.NewLogger("seictl", "task", "assemble-genesis-fork")
+
+const forkAssembleMarkerFile = ".sei-sidecar-fork-assemble-done"
+
+// AssembleGenesisForkRequest holds the typed parameters for assemble-genesis-fork.
+// The bucket and region come from the assembler's constructor (platform env vars).
+// sourceChainId tells the assembler where to find the exported state.
+type AssembleGenesisForkRequest struct {
+	SourceChainID  string              `json:"sourceChainId"`
+	ChainID        string              `json:"chainId"`
+	AccountBalance string              `json:"accountBalance"`
+	Namespace      string              `json:"namespace"`
+	Nodes          []AssembleNodeEntry `json:"nodes"`
+}
+
+func (r AssembleGenesisForkRequest) nodeNames() []string {
+	names := make([]string, len(r.Nodes))
+	for i, n := range r.Nodes {
+		names[i] = n.Name
+	}
+	return names
+}
+
+// GenesisForkAssembler downloads exported chain state from S3, rewrites
+// chain identity, strips old validators, and runs collect-gentxs with
+// the new validator set. It follows the same patterns as GenesisAssembler
+// but starts from exported state instead of a fresh genesis.
+type GenesisForkAssembler struct {
+	homeDir           string
+	bucket            string
+	region            string
+	s3ClientFactory   S3ClientFactory
+	s3UploaderFactory seis3.UploaderFactory
+}
+
+// NewGenesisForkAssembler creates an assembler for fork genesis.
+// bucket and region are the platform genesis bucket (from env vars).
+func NewGenesisForkAssembler(
+	homeDir, bucket, region string,
+	s3Factory S3ClientFactory,
+	uploaderFactory seis3.UploaderFactory,
+) *GenesisForkAssembler {
+	if s3Factory == nil {
+		s3Factory = DefaultS3ClientFactory
+	}
+	if uploaderFactory == nil {
+		uploaderFactory = seis3.DefaultUploaderFactory
+	}
+	return &GenesisForkAssembler{
+		homeDir:           homeDir,
+		bucket:            bucket,
+		region:            region,
+		s3ClientFactory:   s3Factory,
+		s3UploaderFactory: uploaderFactory,
+	}
+}
+
+// Handler returns an engine.TaskHandler for the assemble-genesis-fork task.
+func (a *GenesisForkAssembler) Handler() engine.TaskHandler {
+	return engine.TypedHandler(func(ctx context.Context, req AssembleGenesisForkRequest) error {
+		if markerExists(a.homeDir, forkAssembleMarkerFile) {
+			forkLog.Debug("already completed, skipping")
+			return nil
+		}
+
+		if req.SourceChainID == "" {
+			return fmt.Errorf("assemble-genesis-fork: missing 'sourceChainId'")
+		}
+		if req.ChainID == "" {
+			return fmt.Errorf("assemble-genesis-fork: missing 'chainId'")
+		}
+		if req.AccountBalance == "" {
+			return fmt.Errorf("assemble-genesis-fork: missing 'accountBalance'")
+		}
+		if req.Namespace == "" {
+			return fmt.Errorf("assemble-genesis-fork: missing 'namespace'")
+		}
+		if len(req.Nodes) == 0 {
+			return fmt.Errorf("assemble-genesis-fork: 'nodes' list is empty")
+		}
+
+		nodes := req.nodeNames()
+
+		// 1. Download exported state from {sourceChainId}/exported-state.json
+		if err := a.downloadExportedState(ctx, req.SourceChainID); err != nil {
+			return err
+		}
+
+		// 2. Rewrite chain_id, initial_height, genesis_time; clear validators
+		if err := a.rewriteChainMeta(req.ChainID); err != nil {
+			return err
+		}
+
+		// 3. Strip old validator state from staking/slashing/distribution
+		if err := a.stripValidatorState(); err != nil {
+			return err
+		}
+
+		// 4. Download per-node gentx files (same as standard assembly)
+		if err := a.downloadGentxFiles(ctx, req.ChainID, nodes); err != nil {
+			return err
+		}
+
+		// 5. Add missing genesis accounts for new validators
+		if err := a.addMissingGenesisAccounts(req.AccountBalance); err != nil {
+			return err
+		}
+
+		// 6. Run collect-gentxs
+		if err := a.collectGentxs(); err != nil {
+			return err
+		}
+
+		// 7. Upload genesis.json to {chainId}/{groupName}/genesis.json
+		if err := a.uploadGenesis(ctx, req.ChainID); err != nil {
+			return err
+		}
+
+		// 8. Build and upload peers.json
+		if err := a.uploadPeers(ctx, req.ChainID, req.Namespace, nodes); err != nil {
+			return err
+		}
+
+		forkLog.Info("fork genesis assembled", "chainId", req.ChainID, "nodes", len(nodes))
+		return writeMarker(a.homeDir, forkAssembleMarkerFile)
+	})
+}
+
+func (a *GenesisForkAssembler) downloadExportedState(ctx context.Context, sourceChainID string) error {
+	key := sourceChainID + "/exported-state.json"
+	forkLog.Info("downloading exported state", "bucket", a.bucket, "key", key)
+
+	s3Client, err := a.s3ClientFactory(ctx, a.region)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: building S3 client: %w", err)
+	}
+
+	output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(a.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: downloading exported state: %w", err)
+	}
+	defer func() { _ = output.Body.Close() }()
+
+	configDir := filepath.Join(a.homeDir, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: creating config dir: %w", err)
+	}
+
+	genFile := filepath.Join(configDir, "genesis.json")
+	f, err := os.Create(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: creating genesis.json: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	written, err := io.Copy(f, output.Body)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: writing exported state: %w", err)
+	}
+	forkLog.Info("exported state written", "bytes", written)
+	return nil
+}
+
+func (a *GenesisForkAssembler) rewriteChainMeta(chainID string) error {
+	genFile := filepath.Join(a.homeDir, "config", "genesis.json")
+	genDoc, err := tmtypes.GenesisDocFromFile(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: reading genesis: %w", err)
+	}
+
+	forkLog.Info("rewriting chain metadata",
+		"oldChainId", genDoc.ChainID, "newChainId", chainID)
+
+	genDoc.ChainID = chainID
+	genDoc.GenesisTime = time.Now().UTC()
+	genDoc.InitialHeight = genDoc.InitialHeight + 1
+	genDoc.Validators = nil
+
+	if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: writing rewritten genesis: %w", err)
+	}
+	return nil
+}
+
+func (a *GenesisForkAssembler) stripValidatorState() error {
+	genFile := filepath.Join(a.homeDir, "config", "genesis.json")
+	genDoc, err := tmtypes.GenesisDocFromFile(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: reading genesis for strip: %w", err)
+	}
+
+	var appState map[string]json.RawMessage
+	if err := json.Unmarshal(genDoc.AppState, &appState); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: parsing app_state: %w", err)
+	}
+
+	setModuleFields(appState, "staking", map[string]json.RawMessage{
+		"validators":            json.RawMessage(`[]`),
+		"delegations":           json.RawMessage(`[]`),
+		"unbonding_delegations": json.RawMessage(`[]`),
+		"redelegations":         json.RawMessage(`[]`),
+		"last_total_power":      json.RawMessage(`"0"`),
+		"last_validator_powers": json.RawMessage(`[]`),
+		"exported":              json.RawMessage(`false`),
+	})
+
+	setModuleFields(appState, "slashing", map[string]json.RawMessage{
+		"signing_infos": json.RawMessage(`[]`),
+		"missed_blocks": json.RawMessage(`[]`),
+	})
+
+	setModuleFields(appState, "distribution", map[string]json.RawMessage{
+		"delegator_withdraw_infos":          json.RawMessage(`[]`),
+		"previous_proposer":                 json.RawMessage(`""`),
+		"outstanding_rewards":               json.RawMessage(`[]`),
+		"validator_accumulated_commissions": json.RawMessage(`[]`),
+		"validator_historical_rewards":      json.RawMessage(`[]`),
+		"validator_current_rewards":         json.RawMessage(`[]`),
+		"delegator_starting_infos":          json.RawMessage(`[]`),
+		"validator_slash_events":            json.RawMessage(`[]`),
+	})
+
+	setModuleFields(appState, "evidence", map[string]json.RawMessage{
+		"evidence": json.RawMessage(`[]`),
+	})
+
+	appStateJSON, err := json.Marshal(appState)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: marshaling stripped app_state: %w", err)
+	}
+	genDoc.AppState = appStateJSON
+
+	if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: writing stripped genesis: %w", err)
+	}
+	forkLog.Info("old validator state stripped")
+	return nil
+}
+
+// setModuleFields overwrites specific fields in a module's JSON state.
+func setModuleFields(appState map[string]json.RawMessage, module string, overrides map[string]json.RawMessage) {
+	raw, ok := appState[module]
+	if !ok {
+		return
+	}
+	var state map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return
+	}
+	for k, v := range overrides {
+		state[k] = v
+	}
+	updated, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	appState[module] = updated
+}
+
+// downloadGentxFiles downloads per-node gentx files from S3.
+// Path convention: {bucket}/{chainId}/{nodeName}/gentx.json
+func (a *GenesisForkAssembler) downloadGentxFiles(ctx context.Context, chainID string, nodes []string) error {
+	s3Client, err := a.s3ClientFactory(ctx, a.region)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: building S3 client: %w", err)
+	}
+
+	gentxDir := filepath.Join(a.homeDir, "config", "gentx")
+	if err := os.MkdirAll(gentxDir, 0o755); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: creating gentx dir: %w", err)
+	}
+
+	for _, name := range nodes {
+		key := fmt.Sprintf("%s/%s/gentx.json", chainID, name)
+		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(a.bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: downloading gentx for %s: %w", name, err)
+		}
+		data, err := io.ReadAll(output.Body)
+		_ = output.Body.Close()
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: reading gentx for %s: %w", name, err)
+		}
+		path := filepath.Join(gentxDir, name+"-gentx.json")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return fmt.Errorf("assemble-genesis-fork: writing gentx for %s: %w", name, err)
+		}
+		forkLog.Info("downloaded gentx", "node", name)
+	}
+	return nil
+}
+
+// addMissingGenesisAccounts adds auth accounts and bank balances for
+// new validators whose addresses aren't in the exported state.
+func (a *GenesisForkAssembler) addMissingGenesisAccounts(accountBalance string) error {
+	cdc, txCfg := makeCodec()
+	ensureBech32()
+
+	genFile := filepath.Join(a.homeDir, "config", "genesis.json")
+	appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: reading genesis state: %w", err)
+	}
+
+	gentxDir := filepath.Join(a.homeDir, "config", "gentx")
+	gentxFiles, err := filepath.Glob(filepath.Join(gentxDir, "*.json"))
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: listing gentx files: %w", err)
+	}
+
+	coins, err := sdk.ParseCoinsNormalized(accountBalance)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: parsing account balance: %w", err)
+	}
+
+	authGenState := authtypes.GetGenesisStateFromAppState(cdc, appState)
+	accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: unpacking accounts: %w", err)
+	}
+
+	bankGenState := banktypes.GetGenesisStateFromAppState(cdc, appState)
+	added := 0
+
+	for _, gf := range gentxFiles {
+		data, err := os.ReadFile(gf)
+		if err != nil {
+			continue
+		}
+		tx, err := txCfg.TxJSONDecoder()(data)
+		if err != nil {
+			continue
+		}
+		for _, msg := range tx.GetMsgs() {
+			delegator := extractDelegatorAddress(msg)
+			if delegator == "" {
+				continue
+			}
+			addr, err := sdk.AccAddressFromBech32(delegator)
+			if err != nil {
+				continue
+			}
+			if accs.Contains(addr) {
+				continue
+			}
+
+			accs = append(accs, authtypes.NewBaseAccount(addr, nil, 0, 0))
+			bankGenState.Balances = append(bankGenState.Balances, banktypes.Balance{
+				Address: addr.String(),
+				Coins:   coins.Sort(),
+			})
+			bankGenState.Supply = bankGenState.Supply.Add(coins...)
+			added++
+			forkLog.Info("added genesis account", "address", delegator)
+		}
+	}
+
+	if added > 0 {
+		accs = authtypes.SanitizeGenesisAccounts(accs)
+		genAccs, err := authtypes.PackAccounts(accs)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: packing accounts: %w", err)
+		}
+		authGenState.Accounts = genAccs
+		authStateBz, err := cdc.MarshalAsJSON(&authGenState)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: marshaling auth state: %w", err)
+		}
+		appState[authtypes.ModuleName] = authStateBz
+
+		bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
+		bankStateBz, err := cdc.MarshalAsJSON(bankGenState)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: marshaling bank state: %w", err)
+		}
+		appState[banktypes.ModuleName] = bankStateBz
+
+		appStateJSON, err := json.Marshal(appState)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: marshaling app state: %w", err)
+		}
+		genDoc.AppState = appStateJSON
+		if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+			return fmt.Errorf("assemble-genesis-fork: writing genesis: %w", err)
+		}
+	}
+	forkLog.Info("genesis accounts reconciled", "added", added)
+	return nil
+}
+
+// extractDelegatorAddress pulls the delegator address from a MsgCreateValidator.
+func extractDelegatorAddress(msg sdk.Msg) string {
+	type delegatorMsg interface {
+		GetDelegatorAddress() string
+	}
+	if dm, ok := msg.(delegatorMsg); ok {
+		return dm.GetDelegatorAddress()
+	}
+	return ""
+}
+
+func (a *GenesisForkAssembler) collectGentxs() error {
+	forkLog.Info("running collect-gentxs")
+
+	cdc, txCfg := makeCodec()
+	ensureBech32()
+
+	cfg := tmcfg.DefaultConfig()
+	cfg.SetRoot(a.homeDir)
+
+	nodeID, valPubKey, err := genutil.InitializeNodeValidatorFiles(cfg)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: loading validator files: %w", err)
+	}
+
+	genDoc, err := tmtypes.GenesisDocFromFile(cfg.GenesisFile())
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: reading genesis: %w", err)
+	}
+
+	gentxsDir := filepath.Join(a.homeDir, "config", "gentx")
+	initCfg := genutiltypes.NewInitConfig(genDoc.ChainID, gentxsDir, nodeID, valPubKey)
+	genBalIterator := banktypes.GenesisBalancesIterator{}
+
+	_, err = genutil.GenAppStateFromConfig(cdc, txCfg, cfg, initCfg, *genDoc, genBalIterator)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: collect-gentxs: %w", err)
+	}
+	forkLog.Info("collect-gentxs complete")
+	return nil
+}
+
+func (a *GenesisForkAssembler) uploadGenesis(ctx context.Context, chainID string) error {
+	genFile := filepath.Join(a.homeDir, "config", "genesis.json")
+	data, err := os.ReadFile(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: reading genesis: %w", err)
+	}
+
+	uploader, err := a.s3UploaderFactory(ctx, a.region)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: building uploader: %w", err)
+	}
+
+	key := chainID + "/genesis.json"
+	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
+		Bucket:      aws.String(a.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String("application/json"),
+	})
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: uploading genesis: %w", err)
+	}
+	forkLog.Info("genesis uploaded", "key", key)
+	return nil
+}
+
+func (a *GenesisForkAssembler) uploadPeers(ctx context.Context, chainID, namespace string, nodes []string) error {
+	type peerEntry struct {
+		NodeID  string `json:"nodeId"`
+		Address string `json:"address"`
+	}
+
+	s3Client, err := a.s3ClientFactory(ctx, a.region)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: building S3 client for peers: %w", err)
+	}
+
+	var peers []peerEntry
+	for _, name := range nodes {
+		key := fmt.Sprintf("%s/%s/identity.json", chainID, name)
+		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(a.bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: downloading identity for %s: %w", name, err)
+		}
+		var identity struct {
+			NodeID string `json:"nodeId"`
+		}
+		if err := json.NewDecoder(output.Body).Decode(&identity); err != nil {
+			_ = output.Body.Close()
+			return fmt.Errorf("assemble-genesis-fork: parsing identity for %s: %w", name, err)
+		}
+		_ = output.Body.Close()
+
+		dns := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local", name, name, namespace)
+		peers = append(peers, peerEntry{
+			NodeID:  identity.NodeID,
+			Address: fmt.Sprintf("%s@%s:%d", identity.NodeID, dns, 26656),
+		})
+	}
+
+	peersJSON, err := json.Marshal(peers)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: marshaling peers: %w", err)
+	}
+
+	uploader, err := a.s3UploaderFactory(ctx, a.region)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: building uploader for peers: %w", err)
+	}
+
+	key := chainID + "/peers.json"
+	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
+		Bucket:      aws.String(a.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(peersJSON),
+		ContentType: aws.String("application/json"),
+	})
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: uploading peers: %w", err)
+	}
+	forkLog.Info("peers uploaded", "count", len(peers))
+	return nil
+}

--- a/sidecar/tasks/assemble_genesis_fork.go
+++ b/sidecar/tasks/assemble_genesis_fork.go
@@ -66,6 +66,11 @@ func (r AssembleGenesisForkRequest) validate() error {
 	if len(r.Nodes) == 0 {
 		return fmt.Errorf("assemble-genesis-fork: 'nodes' list is empty")
 	}
+	for i, n := range r.Nodes {
+		if n.Name == "" {
+			return fmt.Errorf("assemble-genesis-fork: nodes[%d] missing 'name'", i)
+		}
+	}
 	return nil
 }
 
@@ -223,7 +228,7 @@ func (a *GenesisForkAssembler) stripValidatorState() error {
 		return fmt.Errorf("assemble-genesis-fork: parsing app_state: %w", err)
 	}
 
-	setModuleFields(appState, "staking", map[string]json.RawMessage{
+	if err := setModuleFields(appState, "staking", map[string]json.RawMessage{
 		"validators":            json.RawMessage(`[]`),
 		"delegations":           json.RawMessage(`[]`),
 		"unbonding_delegations": json.RawMessage(`[]`),
@@ -231,14 +236,18 @@ func (a *GenesisForkAssembler) stripValidatorState() error {
 		"last_total_power":      json.RawMessage(`"0"`),
 		"last_validator_powers": json.RawMessage(`[]`),
 		"exported":              json.RawMessage(`false`),
-	})
+	}); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: stripping staking: %w", err)
+	}
 
-	setModuleFields(appState, "slashing", map[string]json.RawMessage{
+	if err := setModuleFields(appState, "slashing", map[string]json.RawMessage{
 		"signing_infos": json.RawMessage(`[]`),
 		"missed_blocks": json.RawMessage(`[]`),
-	})
+	}); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: stripping slashing: %w", err)
+	}
 
-	setModuleFields(appState, "distribution", map[string]json.RawMessage{
+	if err := setModuleFields(appState, "distribution", map[string]json.RawMessage{
 		"delegator_withdraw_infos":          json.RawMessage(`[]`),
 		"previous_proposer":                 json.RawMessage(`""`),
 		"outstanding_rewards":               json.RawMessage(`[]`),
@@ -247,11 +256,15 @@ func (a *GenesisForkAssembler) stripValidatorState() error {
 		"validator_current_rewards":         json.RawMessage(`[]`),
 		"delegator_starting_infos":          json.RawMessage(`[]`),
 		"validator_slash_events":            json.RawMessage(`[]`),
-	})
+	}); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: stripping distribution: %w", err)
+	}
 
-	setModuleFields(appState, "evidence", map[string]json.RawMessage{
+	if err := setModuleFields(appState, "evidence", map[string]json.RawMessage{
 		"evidence": json.RawMessage(`[]`),
-	})
+	}); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: stripping evidence: %w", err)
+	}
 
 	appStateJSON, err := json.Marshal(appState)
 	if err != nil {
@@ -267,23 +280,25 @@ func (a *GenesisForkAssembler) stripValidatorState() error {
 }
 
 // setModuleFields overwrites specific fields in a module's JSON state.
-func setModuleFields(appState map[string]json.RawMessage, module string, overrides map[string]json.RawMessage) {
+// Returns nil if the module is not present in appState (optional modules).
+func setModuleFields(appState map[string]json.RawMessage, module string, overrides map[string]json.RawMessage) error {
 	raw, ok := appState[module]
 	if !ok {
-		return
+		return nil
 	}
 	var state map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &state); err != nil {
-		return
+		return fmt.Errorf("parsing %s module state: %w", module, err)
 	}
 	for k, v := range overrides {
 		state[k] = v
 	}
 	updated, err := json.Marshal(state)
 	if err != nil {
-		return
+		return fmt.Errorf("marshaling %s module state: %w", module, err)
 	}
 	appState[module] = updated
+	return nil
 }
 
 // downloadGentxFiles downloads per-node gentx files from S3.
@@ -489,17 +504,12 @@ func (a *GenesisForkAssembler) uploadGenesis(ctx context.Context, chainID string
 }
 
 func (a *GenesisForkAssembler) uploadPeers(ctx context.Context, chainID, namespace string, nodes []string) error {
-	type peerEntry struct {
-		NodeID  string `json:"nodeId"`
-		Address string `json:"address"`
-	}
-
 	s3Client, err := a.s3ClientFactory(ctx, a.region)
 	if err != nil {
 		return fmt.Errorf("assemble-genesis-fork: building S3 client for peers: %w", err)
 	}
 
-	var peers []peerEntry
+	var peers []string
 	for _, name := range nodes {
 		key := fmt.Sprintf("%s/%s/identity.json", chainID, name)
 		output, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
@@ -509,20 +519,31 @@ func (a *GenesisForkAssembler) uploadPeers(ctx context.Context, chainID, namespa
 		if err != nil {
 			return fmt.Errorf("assemble-genesis-fork: downloading identity for %s: %w", name, err)
 		}
-		var identity struct {
-			NodeID string `json:"nodeId"`
+		data, err := io.ReadAll(output.Body)
+		_ = output.Body.Close()
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: reading identity for %s: %w", name, err)
 		}
-		if err := json.NewDecoder(output.Body).Decode(&identity); err != nil {
-			_ = output.Body.Close()
+
+		var identity struct {
+			NodeKey json.RawMessage `json:"node_key"`
+		}
+		if err := json.Unmarshal(data, &identity); err != nil {
 			return fmt.Errorf("assemble-genesis-fork: parsing identity for %s: %w", name, err)
 		}
-		_ = output.Body.Close()
+
+		var nodeKey struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(identity.NodeKey, &nodeKey); err != nil {
+			return fmt.Errorf("assemble-genesis-fork: parsing node_key for %s: %w", name, err)
+		}
+		if nodeKey.ID == "" {
+			return fmt.Errorf("assemble-genesis-fork: empty node ID for %s", name)
+		}
 
 		dns := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local", name, name, namespace)
-		peers = append(peers, peerEntry{
-			NodeID:  identity.NodeID,
-			Address: fmt.Sprintf("%s@%s:%d", identity.NodeID, dns, 26656),
-		})
+		peers = append(peers, fmt.Sprintf("%s@%s:26656", nodeKey.ID, dns))
 	}
 
 	peersJSON, err := json.Marshal(peers)

--- a/sidecar/tasks/assemble_genesis_fork.go
+++ b/sidecar/tasks/assemble_genesis_fork.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sei-protocol/seilog"
 )
 
-var forkLog = seilog.NewLogger("seictl", "task", "assemble-genesis-fork")
+var forkLog = seilog.NewLogger("sidecar", "task", "assemble-genesis-fork")
 
 const forkAssembleMarkerFile = ".sei-sidecar-fork-assemble-done"
 
@@ -48,6 +48,25 @@ func (r AssembleGenesisForkRequest) nodeNames() []string {
 		names[i] = n.Name
 	}
 	return names
+}
+
+func (r AssembleGenesisForkRequest) validate() error {
+	if r.SourceChainID == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing 'sourceChainId'")
+	}
+	if r.ChainID == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing 'chainId'")
+	}
+	if r.AccountBalance == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing 'accountBalance'")
+	}
+	if r.Namespace == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing 'namespace'")
+	}
+	if len(r.Nodes) == 0 {
+		return fmt.Errorf("assemble-genesis-fork: 'nodes' list is empty")
+	}
+	return nil
 }
 
 // GenesisForkAssembler downloads exported chain state from S3, rewrites
@@ -91,68 +110,46 @@ func (a *GenesisForkAssembler) Handler() engine.TaskHandler {
 			forkLog.Debug("already completed, skipping")
 			return nil
 		}
-
-		if req.SourceChainID == "" {
-			return fmt.Errorf("assemble-genesis-fork: missing 'sourceChainId'")
-		}
-		if req.ChainID == "" {
-			return fmt.Errorf("assemble-genesis-fork: missing 'chainId'")
-		}
-		if req.AccountBalance == "" {
-			return fmt.Errorf("assemble-genesis-fork: missing 'accountBalance'")
-		}
-		if req.Namespace == "" {
-			return fmt.Errorf("assemble-genesis-fork: missing 'namespace'")
-		}
-		if len(req.Nodes) == 0 {
-			return fmt.Errorf("assemble-genesis-fork: 'nodes' list is empty")
-		}
-
-		nodes := req.nodeNames()
-
-		// 1. Download exported state from {sourceChainId}/exported-state.json
-		if err := a.downloadExportedState(ctx, req.SourceChainID); err != nil {
+		if err := req.validate(); err != nil {
 			return err
 		}
-
-		// 2. Rewrite chain_id, initial_height, genesis_time; clear validators
-		if err := a.rewriteChainMeta(req.ChainID); err != nil {
+		if err := a.assemble(ctx, req); err != nil {
 			return err
 		}
-
-		// 3. Strip old validator state from staking/slashing/distribution
-		if err := a.stripValidatorState(); err != nil {
-			return err
-		}
-
-		// 4. Download per-node gentx files (same as standard assembly)
-		if err := a.downloadGentxFiles(ctx, req.ChainID, nodes); err != nil {
-			return err
-		}
-
-		// 5. Add missing genesis accounts for new validators
-		if err := a.addMissingGenesisAccounts(req.AccountBalance); err != nil {
-			return err
-		}
-
-		// 6. Run collect-gentxs
-		if err := a.collectGentxs(); err != nil {
-			return err
-		}
-
-		// 7. Upload genesis.json to {chainId}/{groupName}/genesis.json
-		if err := a.uploadGenesis(ctx, req.ChainID); err != nil {
-			return err
-		}
-
-		// 8. Build and upload peers.json
-		if err := a.uploadPeers(ctx, req.ChainID, req.Namespace, nodes); err != nil {
-			return err
-		}
-
-		forkLog.Info("fork genesis assembled", "chainId", req.ChainID, "nodes", len(nodes))
 		return writeMarker(a.homeDir, forkAssembleMarkerFile)
 	})
+}
+
+func (a *GenesisForkAssembler) assemble(ctx context.Context, req AssembleGenesisForkRequest) error {
+	nodes := req.nodeNames()
+
+	if err := a.downloadExportedState(ctx, req.SourceChainID); err != nil {
+		return err
+	}
+	if err := a.rewriteChainMeta(req.ChainID); err != nil {
+		return err
+	}
+	if err := a.stripValidatorState(); err != nil {
+		return err
+	}
+	if err := a.downloadGentxFiles(ctx, req.ChainID, nodes); err != nil {
+		return err
+	}
+	if err := a.addMissingGenesisAccounts(req.AccountBalance); err != nil {
+		return err
+	}
+	if err := a.collectGentxs(); err != nil {
+		return err
+	}
+	if err := a.uploadGenesis(ctx, req.ChainID); err != nil {
+		return err
+	}
+	if err := a.uploadPeers(ctx, req.ChainID, req.Namespace, nodes); err != nil {
+		return err
+	}
+
+	forkLog.Info("fork genesis assembled", "chainId", req.ChainID, "nodes", len(nodes))
+	return nil
 }
 
 func (a *GenesisForkAssembler) downloadExportedState(ctx context.Context, sourceChainID string) error {

--- a/sidecar/tasks/assemble_genesis_fork_test.go
+++ b/sidecar/tasks/assemble_genesis_fork_test.go
@@ -328,8 +328,8 @@ func TestForkAssembler_UploadPeers(t *testing.T) {
 	homeDir := t.TempDir()
 
 	s3Objects := &mockS3GetObject{objects: map[string][]byte{
-		"fork-1/val-0/identity.json": []byte(`{"nodeId":"node-id-0"}`),
-		"fork-1/val-1/identity.json": []byte(`{"nodeId":"node-id-1"}`),
+		"fork-1/val-0/identity.json": []byte(`{"node_key":{"id":"node-id-0"}}`),
+		"fork-1/val-1/identity.json": []byte(`{"node_key":{"id":"node-id-1"}}`),
 	}}
 	s3Factory := func(_ context.Context, _ string) (S3GetObjectAPI, error) {
 		return s3Objects, nil
@@ -348,13 +348,13 @@ func TestForkAssembler_UploadPeers(t *testing.T) {
 		t.Fatalf("expected upload at %q, got keys: %v", key, mapKeys(mock.uploads))
 	}
 
-	var peers []map[string]string
+	var peers []string
 	json.Unmarshal(data, &peers)
 	if len(peers) != 2 {
 		t.Fatalf("expected 2 peers, got %d", len(peers))
 	}
-	if peers[0]["nodeId"] != "node-id-0" {
-		t.Errorf("peer[0].nodeId = %q, want node-id-0", peers[0]["nodeId"])
+	if !strings.Contains(peers[0], "node-id-0@") {
+		t.Errorf("peer[0] = %q, want to contain node-id-0@", peers[0])
 	}
 }
 

--- a/sidecar/tasks/assemble_genesis_fork_test.go
+++ b/sidecar/tasks/assemble_genesis_fork_test.go
@@ -1,0 +1,367 @@
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestForkRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     AssembleGenesisForkRequest
+		wantErr string
+	}{
+		{
+			name:    "missing sourceChainId",
+			req:     AssembleGenesisForkRequest{ChainID: "fork-1", AccountBalance: "1usei", Namespace: "ns", Nodes: []AssembleNodeEntry{{Name: "n"}}},
+			wantErr: "sourceChainId",
+		},
+		{
+			name:    "missing chainId",
+			req:     AssembleGenesisForkRequest{SourceChainID: "pacific-1", AccountBalance: "1usei", Namespace: "ns", Nodes: []AssembleNodeEntry{{Name: "n"}}},
+			wantErr: "chainId",
+		},
+		{
+			name:    "missing accountBalance",
+			req:     AssembleGenesisForkRequest{SourceChainID: "pacific-1", ChainID: "fork-1", Namespace: "ns", Nodes: []AssembleNodeEntry{{Name: "n"}}},
+			wantErr: "accountBalance",
+		},
+		{
+			name:    "missing namespace",
+			req:     AssembleGenesisForkRequest{SourceChainID: "pacific-1", ChainID: "fork-1", AccountBalance: "1usei", Nodes: []AssembleNodeEntry{{Name: "n"}}},
+			wantErr: "namespace",
+		},
+		{
+			name:    "empty nodes",
+			req:     AssembleGenesisForkRequest{SourceChainID: "pacific-1", ChainID: "fork-1", AccountBalance: "1usei", Namespace: "ns"},
+			wantErr: "nodes",
+		},
+		{
+			name: "valid",
+			req:  AssembleGenesisForkRequest{SourceChainID: "pacific-1", ChainID: "fork-1", AccountBalance: "1usei", Namespace: "ns", Nodes: []AssembleNodeEntry{{Name: "n"}}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.validate()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestForkRequest_NodeNames(t *testing.T) {
+	req := AssembleGenesisForkRequest{
+		Nodes: []AssembleNodeEntry{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+	}
+	names := req.nodeNames()
+	if len(names) != 3 || names[0] != "a" || names[1] != "b" || names[2] != "c" {
+		t.Errorf("nodeNames() = %v, want [a b c]", names)
+	}
+}
+
+func TestForkAssembler_MarkerIdempotency(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := writeMarker(homeDir, forkAssembleMarkerFile); err != nil {
+		t.Fatal(err)
+	}
+
+	assembler := NewGenesisForkAssembler(homeDir, "bucket", "region", nil, nil)
+	handler := assembler.Handler()
+
+	err := handler(context.Background(), map[string]any{
+		"sourceChainId":  "pacific-1",
+		"chainId":        "fork-1",
+		"accountBalance": "1usei",
+		"namespace":      "ns",
+		"nodes":          []any{map[string]any{"name": "n"}},
+	})
+	if err != nil {
+		t.Fatalf("expected nil (marker skip), got: %v", err)
+	}
+}
+
+func TestForkAssembler_DownloadExportedState(t *testing.T) {
+	homeDir := t.TempDir()
+
+	exportedGenesis := `{"chain_id":"pacific-1","initial_height":"100","app_state":{}}`
+
+	s3Objects := &mockS3GetObject{objects: map[string][]byte{
+		"pacific-1/exported-state.json": []byte(exportedGenesis),
+	}}
+	s3Factory := func(_ context.Context, _ string) (S3GetObjectAPI, error) {
+		return s3Objects, nil
+	}
+
+	assembler := NewGenesisForkAssembler(homeDir, "bucket", "region", s3Factory, nil)
+
+	if err := assembler.downloadExportedState(context.Background(), "pacific-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	genFile := filepath.Join(homeDir, "config", "genesis.json")
+	data, err := os.ReadFile(genFile)
+	if err != nil {
+		t.Fatalf("genesis.json not written: %v", err)
+	}
+	if !bytes.Contains(data, []byte("pacific-1")) {
+		t.Errorf("genesis.json does not contain expected chain ID")
+	}
+}
+
+func TestForkAssembler_RewriteChainMeta(t *testing.T) {
+	homeDir := t.TempDir()
+	configDir := filepath.Join(homeDir, "config")
+	os.MkdirAll(configDir, 0o755)
+
+	// Write a valid Tendermint genesis doc format.
+	genesis := `{
+		"chain_id": "pacific-1",
+		"genesis_time": "2024-01-01T00:00:00Z",
+		"initial_height": "100",
+		"consensus_params": {
+			"block": {"max_bytes": "22020096", "max_gas": "-1"},
+			"evidence": {"max_age_num_blocks": "100000", "max_age_duration": "172800000000000", "max_bytes": "1048576"},
+			"validator": {"pub_key_types": ["ed25519"]},
+			"version": {}
+		},
+		"validators": [],
+		"app_hash": "",
+		"app_state": {}
+	}`
+	os.WriteFile(filepath.Join(configDir, "genesis.json"), []byte(genesis), 0o644)
+
+	assembler := NewGenesisForkAssembler(homeDir, "bucket", "region", nil, nil)
+	if err := assembler.rewriteChainMeta("fork-test-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rewritten, _ := os.ReadFile(filepath.Join(configDir, "genesis.json"))
+	var doc map[string]any
+	json.Unmarshal(rewritten, &doc)
+
+	if doc["chain_id"] != "fork-test-1" {
+		t.Errorf("chain_id = %v, want fork-test-1", doc["chain_id"])
+	}
+	if doc["validators"] != nil {
+		t.Errorf("validators should be nil/empty, got %v", doc["validators"])
+	}
+}
+
+func TestForkAssembler_StripValidatorState(t *testing.T) {
+	homeDir := t.TempDir()
+	configDir := filepath.Join(homeDir, "config")
+	os.MkdirAll(configDir, 0o755)
+
+	stakingState := map[string]any{
+		"params":               map[string]any{"bond_denom": "usei"},
+		"validators":           []any{map[string]any{"operator": "val1"}},
+		"delegations":          []any{map[string]any{"delegator": "del1"}},
+		"last_total_power":     "100",
+		"last_validator_powers": []any{map[string]any{"address": "val1"}},
+	}
+	slashingState := map[string]any{
+		"params":        map[string]any{"signed_blocks_window": "100"},
+		"signing_infos": []any{map[string]any{"address": "val1"}},
+		"missed_blocks": []any{map[string]any{"address": "val1"}},
+	}
+	evidenceState := map[string]any{
+		"evidence": []any{map[string]any{"type": "duplicate_vote"}},
+	}
+	distributionState := map[string]any{
+		"params":                              map[string]any{"community_tax": "0.02"},
+		"outstanding_rewards":                 []any{map[string]any{"val": "val1"}},
+		"validator_accumulated_commissions":   []any{map[string]any{"val": "val1"}},
+		"validator_historical_rewards":        []any{map[string]any{"val": "val1"}},
+		"validator_current_rewards":           []any{map[string]any{"val": "val1"}},
+		"delegator_starting_infos":            []any{map[string]any{"del": "del1"}},
+		"validator_slash_events":              []any{map[string]any{"val": "val1"}},
+	}
+
+	appState := map[string]any{
+		"staking":      stakingState,
+		"slashing":     slashingState,
+		"distribution": distributionState,
+		"evidence":     evidenceState,
+		"bank":         map[string]any{"balances": []any{}},
+	}
+	appStateJSON, _ := json.Marshal(appState)
+
+	genesis := map[string]any{
+		"chain_id":       "test",
+		"genesis_time":   "2024-01-01T00:00:00Z",
+		"initial_height": "1",
+		"app_state":      json.RawMessage(appStateJSON),
+	}
+	data, _ := json.Marshal(genesis)
+	os.WriteFile(filepath.Join(configDir, "genesis.json"), data, 0o644)
+
+	assembler := NewGenesisForkAssembler(homeDir, "bucket", "region", nil, nil)
+	if err := assembler.stripValidatorState(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stripped, _ := os.ReadFile(filepath.Join(configDir, "genesis.json"))
+	var doc map[string]json.RawMessage
+	json.Unmarshal(stripped, &doc)
+
+	var as map[string]json.RawMessage
+	json.Unmarshal(doc["app_state"], &as)
+
+	// Staking: validators stripped, params preserved
+	var staking map[string]json.RawMessage
+	json.Unmarshal(as["staking"], &staking)
+	if string(staking["validators"]) != "[]" {
+		t.Errorf("staking.validators = %s, want []", staking["validators"])
+	}
+	if string(staking["delegations"]) != "[]" {
+		t.Errorf("staking.delegations = %s, want []", staking["delegations"])
+	}
+	// Params should be preserved
+	var params map[string]any
+	json.Unmarshal(staking["params"], &params)
+	if params["bond_denom"] != "usei" {
+		t.Errorf("staking.params.bond_denom lost, got %v", params["bond_denom"])
+	}
+
+	// Slashing: signing_infos stripped, params preserved
+	var slashing map[string]json.RawMessage
+	json.Unmarshal(as["slashing"], &slashing)
+	if string(slashing["signing_infos"]) != "[]" {
+		t.Errorf("slashing.signing_infos = %s, want []", slashing["signing_infos"])
+	}
+
+	// Evidence: cleared
+	var evidence map[string]json.RawMessage
+	json.Unmarshal(as["evidence"], &evidence)
+	if string(evidence["evidence"]) != "[]" {
+		t.Errorf("evidence.evidence = %s, want []", evidence["evidence"])
+	}
+
+	// Distribution: validator records stripped, params preserved
+	var dist map[string]json.RawMessage
+	json.Unmarshal(as["distribution"], &dist)
+	if string(dist["outstanding_rewards"]) != "[]" {
+		t.Errorf("distribution.outstanding_rewards = %s, want []", dist["outstanding_rewards"])
+	}
+
+	// Bank: untouched
+	var bank map[string]json.RawMessage
+	json.Unmarshal(as["bank"], &bank)
+	if string(bank["balances"]) != "[]" {
+		t.Errorf("bank should be untouched, balances = %s", bank["balances"])
+	}
+}
+
+func TestForkAssembler_SetModuleFields_MissingModule(t *testing.T) {
+	appState := map[string]json.RawMessage{
+		"bank": json.RawMessage(`{"balances":[]}`),
+	}
+	// Should not panic on missing module
+	setModuleFields(appState, "nonexistent", map[string]json.RawMessage{
+		"field": json.RawMessage(`[]`),
+	})
+	if _, ok := appState["nonexistent"]; ok {
+		t.Error("should not create missing module")
+	}
+}
+
+func TestForkAssembler_DownloadGentxFiles(t *testing.T) {
+	homeDir := t.TempDir()
+	os.MkdirAll(filepath.Join(homeDir, "config"), 0o755)
+
+	s3Objects := &mockS3GetObject{objects: map[string][]byte{
+		"fork-1/val-0/gentx.json": []byte(`{"gentx":"val0"}`),
+		"fork-1/val-1/gentx.json": []byte(`{"gentx":"val1"}`),
+	}}
+	s3Factory := func(_ context.Context, _ string) (S3GetObjectAPI, error) {
+		return s3Objects, nil
+	}
+
+	assembler := NewGenesisForkAssembler(homeDir, "bucket", "region", s3Factory, nil)
+	if err := assembler.downloadGentxFiles(context.Background(), "fork-1", []string{"val-0", "val-1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gentxDir := filepath.Join(homeDir, "config", "gentx")
+	for _, name := range []string{"val-0", "val-1"} {
+		path := filepath.Join(gentxDir, name+"-gentx.json")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("gentx file not found: %s", path)
+		}
+	}
+}
+
+func TestForkAssembler_UploadGenesis(t *testing.T) {
+	homeDir := t.TempDir()
+	configDir := filepath.Join(homeDir, "config")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "genesis.json"), []byte(`{"chain_id":"fork-1"}`), 0o644)
+
+	mock := newMockS3Uploader()
+	assembler := NewGenesisForkAssembler(homeDir, "bucket", "region", nil, mockUploaderFactory(mock))
+
+	if err := assembler.uploadGenesis(context.Background(), "fork-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	key := "bucket/fork-1/genesis.json"
+	if _, ok := mock.uploads[key]; !ok {
+		t.Errorf("expected upload at %q, got keys: %v", key, mapKeys(mock.uploads))
+	}
+}
+
+func TestForkAssembler_UploadPeers(t *testing.T) {
+	homeDir := t.TempDir()
+
+	s3Objects := &mockS3GetObject{objects: map[string][]byte{
+		"fork-1/val-0/identity.json": []byte(`{"nodeId":"node-id-0"}`),
+		"fork-1/val-1/identity.json": []byte(`{"nodeId":"node-id-1"}`),
+	}}
+	s3Factory := func(_ context.Context, _ string) (S3GetObjectAPI, error) {
+		return s3Objects, nil
+	}
+
+	mock := newMockS3Uploader()
+	assembler := NewGenesisForkAssembler(homeDir, "bucket", "region", s3Factory, mockUploaderFactory(mock))
+
+	if err := assembler.uploadPeers(context.Background(), "fork-1", "default", []string{"val-0", "val-1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	key := "bucket/fork-1/peers.json"
+	data, ok := mock.uploads[key]
+	if !ok {
+		t.Fatalf("expected upload at %q, got keys: %v", key, mapKeys(mock.uploads))
+	}
+
+	var peers []map[string]string
+	json.Unmarshal(data, &peers)
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d", len(peers))
+	}
+	if peers[0]["nodeId"] != "node-id-0" {
+		t.Errorf("peer[0].nodeId = %q, want node-id-0", peers[0]["nodeId"])
+	}
+}
+
+func mapKeys(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/sidecar/tasks/assemble_genesis_fork_test.go
+++ b/sidecar/tasks/assemble_genesis_fork_test.go
@@ -167,10 +167,10 @@ func TestForkAssembler_StripValidatorState(t *testing.T) {
 	os.MkdirAll(configDir, 0o755)
 
 	stakingState := map[string]any{
-		"params":               map[string]any{"bond_denom": "usei"},
-		"validators":           []any{map[string]any{"operator": "val1"}},
-		"delegations":          []any{map[string]any{"delegator": "del1"}},
-		"last_total_power":     "100",
+		"params":                map[string]any{"bond_denom": "usei"},
+		"validators":            []any{map[string]any{"operator": "val1"}},
+		"delegations":           []any{map[string]any{"delegator": "del1"}},
+		"last_total_power":      "100",
 		"last_validator_powers": []any{map[string]any{"address": "val1"}},
 	}
 	slashingState := map[string]any{
@@ -182,13 +182,13 @@ func TestForkAssembler_StripValidatorState(t *testing.T) {
 		"evidence": []any{map[string]any{"type": "duplicate_vote"}},
 	}
 	distributionState := map[string]any{
-		"params":                              map[string]any{"community_tax": "0.02"},
-		"outstanding_rewards":                 []any{map[string]any{"val": "val1"}},
-		"validator_accumulated_commissions":   []any{map[string]any{"val": "val1"}},
-		"validator_historical_rewards":        []any{map[string]any{"val": "val1"}},
-		"validator_current_rewards":           []any{map[string]any{"val": "val1"}},
-		"delegator_starting_infos":            []any{map[string]any{"del": "del1"}},
-		"validator_slash_events":              []any{map[string]any{"val": "val1"}},
+		"params":                            map[string]any{"community_tax": "0.02"},
+		"outstanding_rewards":               []any{map[string]any{"val": "val1"}},
+		"validator_accumulated_commissions": []any{map[string]any{"val": "val1"}},
+		"validator_historical_rewards":      []any{map[string]any{"val": "val1"}},
+		"validator_current_rewards":         []any{map[string]any{"val": "val1"}},
+		"delegator_starting_infos":          []any{map[string]any{"del": "del1"}},
+		"validator_slash_events":            []any{map[string]any{"val": "val1"}},
 	}
 
 	appState := map[string]any{

--- a/sidecar/tasks/export_state.go
+++ b/sidecar/tasks/export_state.go
@@ -17,17 +17,9 @@ import (
 	"github.com/sei-protocol/seilog"
 )
 
-var exportLog = seilog.NewLogger("sidecar", "task", "export-state")
+var stateExportLog = seilog.NewLogger("sidecar", "task", "export-state")
 
 const exportMarkerFile = ".sei-sidecar-export-done"
-
-// CommandRunner abstracts os/exec for testability.
-type CommandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
-
-func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	return cmd.Output()
-}
 
 // ExportStateRequest holds the typed parameters for the export-state task.
 type ExportStateRequest struct {
@@ -41,21 +33,16 @@ type ExportStateRequest struct {
 // StateExporter runs seid export and uploads the result to S3.
 type StateExporter struct {
 	homeDir           string
-	cmdRunner         CommandRunner
 	s3UploaderFactory seis3.UploaderFactory
 }
 
 // NewStateExporter creates an exporter targeting the given home directory.
-func NewStateExporter(homeDir string, cmdRunner CommandRunner, uploaderFactory seis3.UploaderFactory) *StateExporter {
-	if cmdRunner == nil {
-		cmdRunner = defaultCommandRunner
-	}
+func NewStateExporter(homeDir string, uploaderFactory seis3.UploaderFactory) *StateExporter {
 	if uploaderFactory == nil {
 		uploaderFactory = seis3.DefaultUploaderFactory
 	}
 	return &StateExporter{
 		homeDir:           homeDir,
-		cmdRunner:         cmdRunner,
 		s3UploaderFactory: uploaderFactory,
 	}
 }
@@ -64,7 +51,7 @@ func NewStateExporter(homeDir string, cmdRunner CommandRunner, uploaderFactory s
 func (e *StateExporter) Handler() engine.TaskHandler {
 	return engine.TypedHandler(func(ctx context.Context, req ExportStateRequest) error {
 		if markerExists(e.homeDir, exportMarkerFile) {
-			exportLog.Debug("already completed, skipping")
+			stateExportLog.Debug("already completed, skipping")
 			return nil
 		}
 		if req.ChainID == "" {
@@ -82,8 +69,9 @@ func (e *StateExporter) Handler() engine.TaskHandler {
 			args = append(args, "--height", strconv.FormatInt(req.Height, 10))
 		}
 
-		exportLog.Info("running seid export", "height", req.Height)
-		output, err := e.cmdRunner(ctx, "seid", args...)
+		stateExportLog.Info("running seid export", "height", req.Height)
+		cmd := exec.CommandContext(ctx, "seid", args...)
+		output, err := cmd.Output()
 		if err != nil {
 			return fmt.Errorf("export-state: seid export failed: %w", err)
 		}
@@ -117,7 +105,7 @@ func (e *StateExporter) Handler() engine.TaskHandler {
 		}
 		_ = tmpFile.Close()
 
-		exportLog.Info("uploading exported state", "bucket", req.S3Bucket, "key", s3Key, "bytes", len(output))
+		stateExportLog.Info("uploading exported state", "bucket", req.S3Bucket, "key", s3Key, "bytes", len(output))
 		_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 			Bucket:      aws.String(req.S3Bucket),
 			Key:         aws.String(s3Key),
@@ -128,7 +116,7 @@ func (e *StateExporter) Handler() engine.TaskHandler {
 			return fmt.Errorf("export-state: uploading to S3: %w", err)
 		}
 
-		exportLog.Info("export complete", "key", s3Key)
+		stateExportLog.Info("export complete", "key", s3Key)
 		return writeMarker(e.homeDir, exportMarkerFile)
 	})
 }

--- a/sidecar/tasks/export_state.go
+++ b/sidecar/tasks/export_state.go
@@ -1,0 +1,134 @@
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+	"github.com/sei-protocol/seilog"
+)
+
+var exportLog = seilog.NewLogger("sidecar", "task", "export-state")
+
+const exportMarkerFile = ".sei-sidecar-export-done"
+
+// CommandRunner abstracts os/exec for testability.
+type CommandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.Output()
+}
+
+// ExportStateRequest holds the typed parameters for the export-state task.
+type ExportStateRequest struct {
+	Height   int64  `json:"height,omitempty"`
+	ChainID  string `json:"chainId"`
+	S3Bucket string `json:"s3Bucket"`
+	S3Key    string `json:"s3Key,omitempty"`
+	S3Region string `json:"s3Region"`
+}
+
+// StateExporter runs seid export and uploads the result to S3.
+type StateExporter struct {
+	homeDir           string
+	cmdRunner         CommandRunner
+	s3UploaderFactory seis3.UploaderFactory
+}
+
+// NewStateExporter creates an exporter targeting the given home directory.
+func NewStateExporter(homeDir string, cmdRunner CommandRunner, uploaderFactory seis3.UploaderFactory) *StateExporter {
+	if cmdRunner == nil {
+		cmdRunner = defaultCommandRunner
+	}
+	if uploaderFactory == nil {
+		uploaderFactory = seis3.DefaultUploaderFactory
+	}
+	return &StateExporter{
+		homeDir:           homeDir,
+		cmdRunner:         cmdRunner,
+		s3UploaderFactory: uploaderFactory,
+	}
+}
+
+// Handler returns an engine.TaskHandler for the export-state task type.
+func (e *StateExporter) Handler() engine.TaskHandler {
+	return engine.TypedHandler(func(ctx context.Context, req ExportStateRequest) error {
+		if markerExists(e.homeDir, exportMarkerFile) {
+			exportLog.Debug("already completed, skipping")
+			return nil
+		}
+		if req.ChainID == "" {
+			return fmt.Errorf("export-state: missing 'chainId'")
+		}
+		if req.S3Bucket == "" {
+			return fmt.Errorf("export-state: missing 's3Bucket'")
+		}
+		if req.S3Region == "" {
+			return fmt.Errorf("export-state: missing 's3Region'")
+		}
+
+		args := []string{"export", "--home", e.homeDir}
+		if req.Height > 0 {
+			args = append(args, "--height", strconv.FormatInt(req.Height, 10))
+		}
+
+		exportLog.Info("running seid export", "height", req.Height)
+		output, err := e.cmdRunner(ctx, "seid", args...)
+		if err != nil {
+			return fmt.Errorf("export-state: seid export failed: %w", err)
+		}
+
+		s3Key := req.S3Key
+		if s3Key == "" {
+			s3Key = req.ChainID + "/exported-state.json"
+		}
+
+		uploader, err := e.s3UploaderFactory(ctx, req.S3Region)
+		if err != nil {
+			return fmt.Errorf("export-state: building S3 uploader: %w", err)
+		}
+
+		// Write to temp file first to avoid holding multi-GB in memory
+		// during the S3 multipart upload.
+		tmpDir := filepath.Join(e.homeDir, "tmp")
+		if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+			return fmt.Errorf("export-state: creating tmp dir: %w", err)
+		}
+		tmpFile, err := os.CreateTemp(tmpDir, "export-*.json")
+		if err != nil {
+			return fmt.Errorf("export-state: creating temp file: %w", err)
+		}
+		tmpPath := tmpFile.Name()
+		defer func() { _ = os.Remove(tmpPath) }()
+
+		if _, err := tmpFile.Write(output); err != nil {
+			_ = tmpFile.Close()
+			return fmt.Errorf("export-state: writing temp file: %w", err)
+		}
+		_ = tmpFile.Close()
+
+		exportLog.Info("uploading exported state", "bucket", req.S3Bucket, "key", s3Key, "bytes", len(output))
+		_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
+			Bucket:      aws.String(req.S3Bucket),
+			Key:         aws.String(s3Key),
+			Body:        bytes.NewReader(output),
+			ContentType: aws.String("application/json"),
+		})
+		if err != nil {
+			return fmt.Errorf("export-state: uploading to S3: %w", err)
+		}
+
+		exportLog.Info("export complete", "key", s3Key)
+		return writeMarker(e.homeDir, exportMarkerFile)
+	})
+}


### PR DESCRIPTION
## Summary

New sidecar task `assemble-genesis-fork` that assembles genesis from an existing chain's exported state.

### Flow
1. Download exported state from `{sourceChainId}/exported-state.json` in platform genesis bucket
2. Rewrite chain_id, initial_height, genesis_time; clear validators
3. Strip old validator state (staking/slashing/distribution/evidence)
4. Download new validator gentxs, add missing accounts
5. Run collect-gentxs
6. Upload genesis.json + peers.json to `{newChainId}/`

### Design
Follows the same patterns as the existing `GenesisAssembler` — same S3 conventions, same collect-gentxs flow, same marker file idempotency. The only difference is the starting point: exported state instead of fresh genesis.

### Companion
Controller: sei-protocol/sei-k8s-controller#46

### Note
Controller PR uses task type `assemble-fork-genesis` — needs renaming to `assemble-genesis-fork` to match this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)