### PR TITLE
refactor: environment-driven snapshot upload

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -90,7 +90,7 @@ var serveCmd = cli.Command{
 			engine.TaskMarkReady:                tasks.MarkReadyHandler(),
 			engine.TaskConfigureGenesis:         tasks.NewGenesisFetcher(homeDir, chainID, genesisBucket, genesisRegion, nil).Handler(),
 			engine.TaskConfigureStateSync:       tasks.NewStateSyncConfigurer(homeDir, nil).Handler(),
-			engine.TaskSnapshotUpload:           tasks.NewSnapshotUploader(homeDir, snapshotUploadInterval, nil).Handler(),
+			engine.TaskSnapshotUpload:           tasks.NewSnapshotUploader(homeDir, snapshotBucket, snapshotRegion, chainID, snapshotUploadInterval, nil).Handler(),
 			engine.TaskResultExport:             tasks.NewResultExporter(homeDir, nil).Handler(),
 			engine.TaskAwaitCondition:           tasks.NewConditionWaiter(nil).Handler(),
 			engine.TaskGenerateIdentity:         tasks.NewIdentityGenerator(homeDir).Handler(),

--- a/sidecar/client/client_test.go
+++ b/sidecar/client/client_test.go
@@ -203,8 +203,8 @@ func TestSubmitTask_ValidationFailure(t *testing.T) {
 		t.Fatal("server should not be called when validation fails")
 	}))
 
-	// SnapshotUploadTask requires Bucket — empty should fail validation.
-	_, err := c.SubmitSnapshotUploadTask(context.Background(), SnapshotUploadTask{})
+	// DiscoverPeersTask requires at least one source — empty should fail validation.
+	_, err := c.SubmitDiscoverPeersTask(context.Background(), DiscoverPeersTask{})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -98,47 +98,25 @@ func SnapshotRestoreTaskFromParams(params map[string]interface{}) SnapshotRestor
 }
 
 // SnapshotUploadTask archives and streams a local snapshot to S3.
+// S3 coordinates are derived by the sidecar from its environment.
 type SnapshotUploadTask struct {
 	TaskMeta
-	Bucket string
-	Prefix string
-	Region string
 }
 
 func (t SnapshotUploadTask) TaskType() string { return TaskTypeSnapshotUpload }
 
-func (t SnapshotUploadTask) Validate() error {
-	if t.Bucket == "" {
-		return fmt.Errorf("snapshot-upload: missing required field Bucket")
-	}
-	if t.Region == "" {
-		return fmt.Errorf("snapshot-upload: missing required field Region")
-	}
-	return nil
-}
+func (t SnapshotUploadTask) Validate() error { return nil }
 
 func (t SnapshotUploadTask) ToTaskRequest() TaskRequest {
-	p := map[string]interface{}{
-		"bucket": t.Bucket,
-		"region": t.Region,
-	}
-	if t.Prefix != "" {
-		p["prefix"] = t.Prefix
-	}
-	req := TaskRequest{Type: t.TaskType(), Params: &p}
+	req := TaskRequest{Type: t.TaskType()}
 	t.applyMeta(&req)
 	return req
 }
 
 // SnapshotUploadTaskFromParams reconstructs a SnapshotUploadTask from
 // a generic params map.
-func SnapshotUploadTaskFromParams(params map[string]interface{}) SnapshotUploadTask {
-	s := func(k string) string { v, _ := params[k].(string); return v }
-	return SnapshotUploadTask{
-		Bucket: s("bucket"),
-		Prefix: s("prefix"),
-		Region: s("region"),
-	}
+func SnapshotUploadTaskFromParams(_ map[string]interface{}) SnapshotUploadTask {
+	return SnapshotUploadTask{}
 }
 
 // ConfigureGenesisTask instructs the sidecar to resolve and write genesis.json.

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -20,17 +20,7 @@ func genSnapshotRestoreTask() gopter.Gen {
 }
 
 func genSnapshotUploadTask() gopter.Gen {
-	return gopter.CombineGens(
-		genNonEmptyString(),
-		genNonEmptyString(),
-		genNonEmptyString(),
-	).Map(func(v []interface{}) SnapshotUploadTask {
-		return SnapshotUploadTask{
-			Bucket: v[0].(string),
-			Prefix: v[1].(string),
-			Region: v[2].(string),
-		}
-	})
+	return gen.Const(SnapshotUploadTask{})
 }
 
 func genConfigureGenesisTask() gopter.Gen {
@@ -120,13 +110,7 @@ func TestSnapshotUploadRoundTrip(t *testing.T) {
 				return false
 			}
 			req := task.ToTaskRequest()
-			if req.Type != TaskTypeSnapshotUpload {
-				return false
-			}
-			rebuilt := SnapshotUploadTaskFromParams(*req.Params)
-			return rebuilt.Bucket == task.Bucket &&
-				rebuilt.Prefix == task.Prefix &&
-				rebuilt.Region == task.Region
+			return req.Type == TaskTypeSnapshotUpload && req.Params == nil
 		},
 		genSnapshotUploadTask(),
 	))
@@ -278,27 +262,9 @@ func TestSnapshotRestoreValidation(t *testing.T) {
 }
 
 func TestSnapshotUploadValidation(t *testing.T) {
-	cases := []struct {
-		name string
-		task SnapshotUploadTask
-		ok   bool
-	}{
-		{"valid", SnapshotUploadTask{Bucket: "b", Region: "r"}, true},
-		{"valid with prefix", SnapshotUploadTask{Bucket: "b", Prefix: "p", Region: "r"}, true},
-		{"missing bucket", SnapshotUploadTask{Region: "r"}, false},
-		{"missing region", SnapshotUploadTask{Bucket: "b"}, false},
-		{"all empty", SnapshotUploadTask{}, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.task.Validate()
-			if tc.ok && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if !tc.ok && err == nil {
-				t.Error("expected validation error, got nil")
-			}
-		})
+	task := SnapshotUploadTask{}
+	if err := task.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -30,11 +30,8 @@ const (
 )
 
 // SnapshotUploadRequest holds the parameters for the snapshot upload task.
-type SnapshotUploadRequest struct {
-	Bucket string `json:"bucket"`
-	Prefix string `json:"prefix"`
-	Region string `json:"region"`
-}
+// S3 bucket, region, and prefix are derived from the sidecar's environment.
+type SnapshotUploadRequest struct{}
 
 // uploadState tracks the last successfully uploaded snapshot height.
 type uploadState struct {
@@ -46,12 +43,16 @@ type uploadState struct {
 // at the configured interval until the context is cancelled.
 type SnapshotUploader struct {
 	homeDir           string
+	bucket            string
+	region            string
+	chainID           string
 	uploadInterval    time.Duration
 	s3UploaderFactory seis3.UploaderFactory
 }
 
 // NewSnapshotUploader creates an uploader targeting the given home directory.
-func NewSnapshotUploader(homeDir string, uploadInterval time.Duration, factory seis3.UploaderFactory) *SnapshotUploader {
+// Bucket, region, and chainID are read from environment at construction time.
+func NewSnapshotUploader(homeDir, bucket, region, chainID string, uploadInterval time.Duration, factory seis3.UploaderFactory) *SnapshotUploader {
 	if factory == nil {
 		factory = seis3.DefaultUploaderFactory
 	}
@@ -60,6 +61,9 @@ func NewSnapshotUploader(homeDir string, uploadInterval time.Duration, factory s
 	}
 	return &SnapshotUploader{
 		homeDir:           homeDir,
+		bucket:            bucket,
+		region:            region,
+		chainID:           chainID,
 		uploadInterval:    uploadInterval,
 		s3UploaderFactory: factory,
 	}
@@ -70,21 +74,15 @@ func NewSnapshotUploader(homeDir string, uploadInterval time.Duration, factory s
 // sleeping for the configured interval between attempts. It stays
 // running until the context is cancelled.
 func (u *SnapshotUploader) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, cfg SnapshotUploadRequest) error {
-		if cfg.Bucket == "" {
-			return fmt.Errorf("snapshot-upload: missing required param 'bucket'")
-		}
-		if cfg.Region == "" {
-			return fmt.Errorf("snapshot-upload: missing required param 'region'")
-		}
-		return u.runLoop(ctx, cfg)
+	return engine.TypedHandler(func(ctx context.Context, _ SnapshotUploadRequest) error {
+		return u.runLoop(ctx)
 	})
 }
 
-func (u *SnapshotUploader) runLoop(ctx context.Context, cfg SnapshotUploadRequest) error {
-	uploadLog.Info("starting snapshot upload loop", "interval", u.uploadInterval, "bucket", cfg.Bucket)
+func (u *SnapshotUploader) runLoop(ctx context.Context) error {
+	uploadLog.Info("starting snapshot upload loop", "interval", u.uploadInterval, "bucket", u.bucket)
 	for {
-		if err := u.Upload(ctx, cfg); err != nil {
+		if err := u.Upload(ctx); err != nil {
 			uploadLog.Warn("upload attempt failed, will retry next interval", "error", err)
 		}
 
@@ -103,7 +101,7 @@ func (u *SnapshotUploader) runLoop(ctx context.Context, cfg SnapshotUploadReques
 //
 // The archive is streamed through an io.Pipe so it never needs to be buffered
 // entirely in memory; the transfermanager handles multipart upload automatically.
-func (u *SnapshotUploader) Upload(ctx context.Context, cfg SnapshotUploadRequest) error {
+func (u *SnapshotUploader) Upload(ctx context.Context) error {
 	snapshotsDir := filepath.Join(u.homeDir, "data", "snapshots")
 
 	height, err := pickUploadCandidate(snapshotsDir)
@@ -121,25 +119,25 @@ func (u *SnapshotUploader) Upload(ctx context.Context, cfg SnapshotUploadRequest
 		return nil
 	}
 
-	uploadLog.Info("uploading snapshot", "height", height, "bucket", cfg.Bucket, "region", cfg.Region)
+	uploadLog.Info("uploading snapshot", "height", height, "bucket", u.bucket, "region", u.region)
 
-	uploader, err := u.s3UploaderFactory(ctx, cfg.Region)
+	uploader, err := u.s3UploaderFactory(ctx, u.region)
 	if err != nil {
 		return fmt.Errorf("building S3 uploader: %w", err)
 	}
 
-	prefix := normalizePrefix(cfg.Prefix)
+	prefix := u.chainID + "/"
 
 	archiveKey := fmt.Sprintf("%s%d.tar.gz", prefix, height)
 	uploadLog.Info("streaming archive to S3", "key", archiveKey)
-	if err := u.streamUpload(ctx, uploader, cfg.Bucket, archiveKey, snapshotsDir, height); err != nil {
+	if err := u.streamUpload(ctx, uploader, u.bucket, archiveKey, snapshotsDir, height); err != nil {
 		return fmt.Errorf("uploading %s: %w", archiveKey, err)
 	}
 
 	latestKey := prefix + "latest.txt"
 	latestBody := []byte(strconv.FormatInt(height, 10))
 	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
-		Bucket: aws.String(cfg.Bucket),
+		Bucket: aws.String(u.bucket),
 		Key:    aws.String(latestKey),
 		Body:   bytes.NewReader(latestBody),
 	})

--- a/sidecar/tasks/snapshot_upload_test.go
+++ b/sidecar/tasks/snapshot_upload_test.go
@@ -99,22 +99,18 @@ func TestUpload_UploadsArchiveAndLatestTxt(t *testing.T) {
 	setupSnapshotDirs(t, homeDir, []int64{1000, 2000})
 
 	mock := newMockS3Uploader()
-	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
+	uploader := NewSnapshotUploader(homeDir, "my-bucket", "eu-central-1", "testchain", 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
-		Bucket: "my-bucket",
-		Prefix: "state-sync",
-		Region: "eu-central-1",
-	})
+	err := uploader.Upload(context.Background())
 	if err != nil {
 		t.Fatalf("Upload() error = %v", err)
 	}
 
-	if _, ok := mock.uploads["my-bucket/state-sync/1000.tar.gz"]; !ok {
+	if _, ok := mock.uploads["my-bucket/testchain/1000.tar.gz"]; !ok {
 		t.Error("expected archive upload at state-sync/1000.tar.gz")
 	}
 
-	latest, ok := mock.uploads["my-bucket/state-sync/latest.txt"]
+	latest, ok := mock.uploads["my-bucket/testchain/latest.txt"]
 	if !ok {
 		t.Fatal("expected latest.txt upload")
 	}
@@ -132,13 +128,9 @@ func TestUpload_SkipsWhenAlreadyUploaded(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(homeDir, uploadStateFile), data, 0o644)
 
 	mock := newMockS3Uploader()
-	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
+	uploader := NewSnapshotUploader(homeDir, "my-bucket", "eu-central-1", "testchain", 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
-		Bucket: "my-bucket",
-		Prefix: "state-sync",
-		Region: "eu-central-1",
-	})
+	err := uploader.Upload(context.Background())
 	if err != nil {
 		t.Fatalf("Upload() error = %v", err)
 	}
@@ -157,18 +149,14 @@ func TestUpload_UploadsNewerSnapshot(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(homeDir, uploadStateFile), data, 0o644)
 
 	mock := newMockS3Uploader()
-	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
+	uploader := NewSnapshotUploader(homeDir, "my-bucket", "eu-central-1", "testchain", 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
-		Bucket: "my-bucket",
-		Prefix: "state-sync",
-		Region: "eu-central-1",
-	})
+	err := uploader.Upload(context.Background())
 	if err != nil {
 		t.Fatalf("Upload() error = %v", err)
 	}
 
-	if _, ok := mock.uploads["my-bucket/state-sync/2000.tar.gz"]; !ok {
+	if _, ok := mock.uploads["my-bucket/testchain/2000.tar.gz"]; !ok {
 		t.Error("expected archive upload at state-sync/2000.tar.gz")
 	}
 }
@@ -178,13 +166,9 @@ func TestUpload_NoOpsWhenTooFewSnapshots(t *testing.T) {
 	setupSnapshotDirs(t, homeDir, []int64{1000})
 
 	mock := newMockS3Uploader()
-	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
+	uploader := NewSnapshotUploader(homeDir, "my-bucket", "eu-central-1", "testchain", 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
-		Bucket: "my-bucket",
-		Prefix: "state-sync",
-		Region: "eu-central-1",
-	})
+	err := uploader.Upload(context.Background())
 	if err != nil {
 		t.Fatalf("Upload() error = %v", err)
 	}
@@ -199,13 +183,9 @@ func TestUpload_WritesUploadState(t *testing.T) {
 	setupSnapshotDirs(t, homeDir, []int64{1000, 2000})
 
 	mock := newMockS3Uploader()
-	uploader := NewSnapshotUploader(homeDir, 0, mockUploaderFactory(mock))
+	uploader := NewSnapshotUploader(homeDir, "my-bucket", "eu-central-1", "testchain", 0, mockUploaderFactory(mock))
 
-	err := uploader.Upload(context.Background(), SnapshotUploadRequest{
-		Bucket: "my-bucket",
-		Prefix: "state-sync",
-		Region: "eu-central-1",
-	})
+	err := uploader.Upload(context.Background())
 	if err != nil {
 		t.Fatalf("Upload() error = %v", err)
 	}

--- a/sidecar/tasks/typed_handler_integration_test.go
+++ b/sidecar/tasks/typed_handler_integration_test.go
@@ -204,7 +204,7 @@ func TestDeserialize_ConfigReload(t *testing.T) {
 // TestDeserialize_SnapshotUpload verifies that the snapshot-upload handler
 // correctly deserializes simple string fields from the wire format.
 func TestDeserialize_SnapshotUpload(t *testing.T) {
-	handler := NewSnapshotUploader(t.TempDir(), 0, nil).Handler()
+	handler := NewSnapshotUploader(t.TempDir(), "b", "r", "c", 0, nil).Handler()
 
 	params := map[string]any{
 		"bucket": "",


### PR DESCRIPTION
## Summary
Move snapshot upload S3 coordinates from task params to sidecar environment, matching the snapshot restore and genesis conventions.

- `SnapshotUploadRequest`: remove Bucket/Prefix/Region (now empty)
- `NewSnapshotUploader`: takes bucket/region/chainID from env at construction
- Upload prefix derived as `{chainID}/` from `SEI_CHAIN_ID`
- Client `SnapshotUploadTask` stripped to empty struct

## Companion PR
- sei-k8s-controller: pending

## Test plan
- [x] Build clean
- [x] Client tests pass
- [x] Full sidecar test suite (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)