### PR TITLE
fix: export-state memory and gentx error handling

### DIFF
--- a/sidecar/tasks/assemble_genesis_fork.go
+++ b/sidecar/tasks/assemble_genesis_fork.go
@@ -372,11 +372,11 @@ func (a *GenesisForkAssembler) addMissingGenesisAccounts(accountBalance string) 
 	for _, gf := range gentxFiles {
 		data, err := os.ReadFile(gf)
 		if err != nil {
-			continue
+			return fmt.Errorf("assemble-genesis-fork: reading gentx %s: %w", filepath.Base(gf), err)
 		}
 		tx, err := txCfg.TxJSONDecoder()(data)
 		if err != nil {
-			continue
+			return fmt.Errorf("assemble-genesis-fork: decoding gentx %s: %w", filepath.Base(gf), err)
 		}
 		for _, msg := range tx.GetMsgs() {
 			delegator := extractDelegatorAddress(msg)
@@ -385,7 +385,7 @@ func (a *GenesisForkAssembler) addMissingGenesisAccounts(accountBalance string) 
 			}
 			addr, err := sdk.AccAddressFromBech32(delegator)
 			if err != nil {
-				continue
+				return fmt.Errorf("assemble-genesis-fork: parsing delegator address in %s: %w", filepath.Base(gf), err)
 			}
 			if accs.Contains(addr) {
 				continue

--- a/sidecar/tasks/export_state.go
+++ b/sidecar/tasks/export_state.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -69,25 +68,8 @@ func (e *StateExporter) Handler() engine.TaskHandler {
 			args = append(args, "--height", strconv.FormatInt(req.Height, 10))
 		}
 
-		stateExportLog.Info("running seid export", "height", req.Height)
-		cmd := exec.CommandContext(ctx, "seid", args...)
-		output, err := cmd.Output()
-		if err != nil {
-			return fmt.Errorf("export-state: seid export failed: %w", err)
-		}
-
-		s3Key := req.S3Key
-		if s3Key == "" {
-			s3Key = req.ChainID + "/exported-state.json"
-		}
-
-		uploader, err := e.s3UploaderFactory(ctx, req.S3Region)
-		if err != nil {
-			return fmt.Errorf("export-state: building S3 uploader: %w", err)
-		}
-
-		// Write to temp file first to avoid holding multi-GB in memory
-		// during the S3 multipart upload.
+		// Write seid export output directly to a temp file to avoid
+		// holding multi-GB chain state in memory.
 		tmpDir := filepath.Join(e.homeDir, "tmp")
 		if err := os.MkdirAll(tmpDir, 0o755); err != nil {
 			return fmt.Errorf("export-state: creating tmp dir: %w", err)
@@ -99,17 +81,43 @@ func (e *StateExporter) Handler() engine.TaskHandler {
 		tmpPath := tmpFile.Name()
 		defer func() { _ = os.Remove(tmpPath) }()
 
-		if _, err := tmpFile.Write(output); err != nil {
+		stateExportLog.Info("running seid export", "height", req.Height)
+		cmd := exec.CommandContext(ctx, "seid", args...)
+		cmd.Stdout = tmpFile
+		if err := cmd.Run(); err != nil {
 			_ = tmpFile.Close()
-			return fmt.Errorf("export-state: writing temp file: %w", err)
+			return fmt.Errorf("export-state: seid export failed: %w", err)
 		}
+
+		stat, err := tmpFile.Stat()
+		if err != nil {
+			_ = tmpFile.Close()
+			return fmt.Errorf("export-state: stat temp file: %w", err)
+		}
+		exportSize := stat.Size()
 		_ = tmpFile.Close()
 
-		stateExportLog.Info("uploading exported state", "bucket", req.S3Bucket, "key", s3Key, "bytes", len(output))
+		s3Key := req.S3Key
+		if s3Key == "" {
+			s3Key = req.ChainID + "/exported-state.json"
+		}
+
+		uploader, err := e.s3UploaderFactory(ctx, req.S3Region)
+		if err != nil {
+			return fmt.Errorf("export-state: building S3 uploader: %w", err)
+		}
+
+		uploadFile, err := os.Open(tmpPath)
+		if err != nil {
+			return fmt.Errorf("export-state: reopening temp file: %w", err)
+		}
+		defer func() { _ = uploadFile.Close() }()
+
+		stateExportLog.Info("uploading exported state", "bucket", req.S3Bucket, "key", s3Key, "bytes", exportSize)
 		_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 			Bucket:      aws.String(req.S3Bucket),
 			Key:         aws.String(s3Key),
-			Body:        bytes.NewReader(output),
+			Body:        uploadFile,
 			ContentType: aws.String("application/json"),
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary

- **export_state.go**: Stream `seid export` stdout directly to a temp file instead of capturing multi-GB output in memory via `cmd.Output()`. The S3 upload now reads from disk. Prevents OOM on production chain exports.
- **assemble_genesis_fork.go**: `addMissingGenesisAccounts` now returns errors for unreadable/unparseable gentx files instead of silently skipping them. Makes failures visible at the point of failure rather than surfacing as confusing errors in `collectGentxs`.

## Test plan

- [x] All existing fork assembler tests pass
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)