### PR TITLE
Add report list and extend report divergence with --env/--height

### DIFF
--- a/report.go
+++ b/report.go
@@ -1,17 +1,14 @@
 package main
 
 import (
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/urfave/cli/v3"
 
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
 	"github.com/sei-protocol/seictl/sidecar/shadow"
 )
 
@@ -20,6 +17,7 @@ var reportCmd = cli.Command{
 	Usage: "Analyze shadow chain comparison data",
 	Commands: []*cli.Command{
 		&reportDivergenceCmd,
+		&reportListCmd,
 	},
 }
 
@@ -28,19 +26,33 @@ var reportDivergenceCmd = cli.Command{
 	Usage: "Fetch and render a divergence report from S3",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:     "bucket",
-			Usage:    "S3 bucket containing the report",
-			Required: true,
+			Name:  "env",
+			Usage: "Environment shorthand (expands to '{env}-sei-shadow-results')",
 		},
 		&cli.StringFlag{
-			Name:     "key",
-			Usage:    "S3 object key (e.g. shadow-results/pacific-1/divergence-198740042.report.json.gz)",
-			Required: true,
+			Name:    "bucket",
+			Sources: cli.EnvVars("SEI_RESULT_EXPORT_BUCKET"),
+			Usage:   "S3 bucket containing the report",
 		},
 		&cli.StringFlag{
-			Name:  "region",
-			Usage: "AWS region",
-			Value: "eu-central-1",
+			Name:  "key",
+			Usage: "S3 object key (e.g. shadow-results/divergence-198740042.report.json.gz)",
+		},
+		&cli.IntFlag{
+			Name:  "height",
+			Usage: "Block height of the divergence report (alternative to --key)",
+		},
+		&cli.StringFlag{
+			Name:    "prefix",
+			Sources: cli.EnvVars("SEI_RESULT_EXPORT_PREFIX"),
+			Usage:   "S3 key prefix (used with --height to compute key)",
+			Value:   "shadow-results/",
+		},
+		&cli.StringFlag{
+			Name:    "region",
+			Sources: cli.EnvVars("SEI_RESULT_EXPORT_REGION"),
+			Usage:   "AWS region",
+			Value:   "eu-central-1",
 		},
 		&cli.BoolFlag{
 			Name:  "json",
@@ -51,17 +63,48 @@ var reportDivergenceCmd = cli.Command{
 }
 
 func runReportDivergence(ctx context.Context, cmd *cli.Command) error {
+	if cmd.IsSet("key") && cmd.IsSet("height") {
+		return fmt.Errorf("--key and --height are mutually exclusive")
+	}
+
 	bucket := cmd.String("bucket")
 	key := cmd.String("key")
 	region := cmd.String("region")
-	outputJSON := cmd.Bool("json")
+	prefix := cmd.String("prefix")
 
-	report, err := downloadDivergenceReport(ctx, bucket, key, region)
+	// When --env or --height is used, resolve to bucket/key.
+	if cmd.IsSet("env") || cmd.IsSet("height") {
+		resolved, resolvedPrefix, resolvedRegion, err := resolveS3Ref(
+			cmd.String("env"), bucket, prefix, region,
+		)
+		if err != nil {
+			return err
+		}
+		bucket = resolved
+		region = resolvedRegion
+		if cmd.IsSet("height") {
+			key = fmt.Sprintf("%sdivergence-%d.report.json.gz", resolvedPrefix, cmd.Int("height"))
+		}
+	}
+
+	if bucket == "" {
+		return fmt.Errorf("one of --env or --bucket is required")
+	}
+	if key == "" {
+		return fmt.Errorf("one of --key or --height is required")
+	}
+
+	downloader, err := seis3.DefaultDownloaderFactory(ctx, region)
 	if err != nil {
 		return err
 	}
 
-	if outputJSON {
+	report, err := shadow.FetchReport(ctx, downloader, bucket, key)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Bool("json") {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(report)
@@ -71,40 +114,26 @@ func runReportDivergence(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func downloadDivergenceReport(ctx context.Context, bucket, key, region string) (*shadow.DivergenceReport, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
-	if err != nil {
-		return nil, fmt.Errorf("loading AWS config: %w", err)
+// resolveS3Ref converts --env/--bucket/--prefix/--region flags to concrete values.
+func resolveS3Ref(env, bucket, prefix, region string) (string, string, string, error) {
+	switch {
+	case env != "" && bucket != "":
+		return "", "", "", fmt.Errorf("--env and --bucket are mutually exclusive")
+	case env != "":
+		bucket = env + "-sei-shadow-results"
+	case bucket != "":
+		// use as-is
+	default:
+		return "", "", "", fmt.Errorf("one of --env or --bucket is required")
 	}
-
-	client := s3.NewFromConfig(cfg)
-	resp, err := client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: &bucket,
-		Key:    &key,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("downloading s3://%s/%s: %w", bucket, key, err)
+	if prefix == "" {
+		prefix = "shadow-results/"
 	}
-	defer resp.Body.Close()
-
-	var reader io.Reader = resp.Body
-	if isGzipped(key) {
-		gz, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("decompressing report: %w", err)
-		}
-		defer gz.Close()
-		reader = gz
+	if prefix[len(prefix)-1] != '/' {
+		prefix += "/"
 	}
-
-	var report shadow.DivergenceReport
-	if err := json.NewDecoder(reader).Decode(&report); err != nil {
-		return nil, fmt.Errorf("decoding report: %w", err)
+	if region == "" {
+		region = "eu-central-1"
 	}
-
-	return &report, nil
-}
-
-func isGzipped(key string) bool {
-	return len(key) > 3 && key[len(key)-3:] == ".gz"
+	return bucket, prefix, region, nil
 }

--- a/report_list.go
+++ b/report_list.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/urfave/cli/v3"
+
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+)
+
+var (
+	comparePageRe      = regexp.MustCompile(`(\d+)-(\d+)\.compare\.ndjson\.gz$`)
+	divergenceReportRe = regexp.MustCompile(`divergence-(\d+)\.report\.json\.gz$`)
+)
+
+var reportListCmd = cli.Command{
+	Name:  "list",
+	Usage: "List available shadow comparison data in S3",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "env",
+			Usage: "Environment shorthand (expands to '{env}-sei-shadow-results')",
+		},
+		&cli.StringFlag{
+			Name:    "bucket",
+			Sources: cli.EnvVars("SEI_RESULT_EXPORT_BUCKET"),
+			Usage:   "S3 bucket name",
+		},
+		&cli.StringFlag{
+			Name:    "prefix",
+			Sources: cli.EnvVars("SEI_RESULT_EXPORT_PREFIX"),
+			Usage:   "S3 key prefix",
+			Value:   "shadow-results/",
+		},
+		&cli.StringFlag{
+			Name:    "region",
+			Sources: cli.EnvVars("SEI_RESULT_EXPORT_REGION"),
+			Usage:   "AWS region",
+			Value:   "eu-central-1",
+		},
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "Output raw JSON instead of table",
+		},
+	},
+	Action: runReportList,
+}
+
+type listOutput struct {
+	Pages             []pageEntry       `json:"pages"`
+	DivergenceReports []divergenceEntry `json:"divergenceReports"`
+	TotalBlocks       int64             `json:"totalBlocks"`
+}
+
+type pageEntry struct {
+	Key         string `json:"key"`
+	StartHeight int64  `json:"startHeight"`
+	EndHeight   int64  `json:"endHeight"`
+	Blocks      int    `json:"blocks"`
+}
+
+type divergenceEntry struct {
+	Key    string `json:"key"`
+	Height int64  `json:"height"`
+}
+
+func runReportList(ctx context.Context, cmd *cli.Command) error {
+	bucket, prefix, region, err := resolveS3Ref(
+		cmd.String("env"), cmd.String("bucket"), cmd.String("prefix"), cmd.String("region"),
+	)
+	if err != nil {
+		return err
+	}
+
+	lister, err := seis3.DefaultObjectListerFactory(ctx, region)
+	if err != nil {
+		return err
+	}
+
+	// List all objects under prefix.
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(prefix),
+	}
+
+	var pages []pageEntry
+	var reports []divergenceEntry
+
+	for {
+		resp, err := lister.ListObjectsV2(ctx, input)
+		if err != nil {
+			return fmt.Errorf("listing s3://%s/%s: %w", bucket, prefix, err)
+		}
+		for _, obj := range resp.Contents {
+			key := aws.ToString(obj.Key)
+			if m := comparePageRe.FindStringSubmatch(key); len(m) >= 3 {
+				start, _ := strconv.ParseInt(m[1], 10, 64)
+				end, _ := strconv.ParseInt(m[2], 10, 64)
+				pages = append(pages, pageEntry{
+					Key: key, StartHeight: start, EndHeight: end,
+					Blocks: int(end - start + 1),
+				})
+			} else if m := divergenceReportRe.FindStringSubmatch(key); len(m) >= 2 {
+				height, _ := strconv.ParseInt(m[1], 10, 64)
+				reports = append(reports, divergenceEntry{Key: key, Height: height})
+			}
+		}
+		if !aws.ToBool(resp.IsTruncated) {
+			break
+		}
+		input.ContinuationToken = resp.NextContinuationToken
+	}
+
+	sort.Slice(pages, func(i, j int) bool { return pages[i].StartHeight < pages[j].StartHeight })
+	sort.Slice(reports, func(i, j int) bool { return reports[i].Height < reports[j].Height })
+
+	var totalBlocks int64
+	for _, p := range pages {
+		totalBlocks += int64(p.Blocks)
+	}
+
+	out := listOutput{
+		Pages:             pages,
+		DivergenceReports: reports,
+		TotalBlocks:       totalBlocks,
+	}
+	if out.Pages == nil {
+		out.Pages = []pageEntry{}
+	}
+	if out.DivergenceReports == nil {
+		out.DivergenceReports = []divergenceEntry{}
+	}
+
+	if cmd.Bool("json") {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	// Human-readable output.
+	fmt.Fprintf(os.Stderr, "%d comparison page(s), %d divergence report(s), %d blocks covered\n\n",
+		len(pages), len(reports), totalBlocks)
+
+	if len(pages) == 0 && len(reports) == 0 {
+		fmt.Fprintln(os.Stderr, "no data found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "TYPE\tHEIGHT RANGE\tBLOCKS")
+	for _, p := range pages {
+		fmt.Fprintf(w, "page\t%d - %d\t%d\n", p.StartHeight, p.EndHeight, p.Blocks)
+	}
+	for _, r := range reports {
+		fmt.Fprintf(w, "divergence\t%d\t-\n", r.Height)
+	}
+	w.Flush()
+	return nil
+}

--- a/report_list_test.go
+++ b/report_list_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestComparePageRe(t *testing.T) {
+	tests := []struct {
+		key       string
+		wantStart int64
+		wantEnd   int64
+		wantMatch bool
+	}{
+		{
+			key:       "shadow-results/198000000-198000099.compare.ndjson.gz",
+			wantStart: 198000000,
+			wantEnd:   198000099,
+			wantMatch: true,
+		},
+		{
+			key:       "prefix/100-199.compare.ndjson.gz",
+			wantStart: 100,
+			wantEnd:   199,
+			wantMatch: true,
+		},
+		{
+			key:       "deep/nested/prefix/1-50.compare.ndjson.gz",
+			wantStart: 1,
+			wantEnd:   50,
+			wantMatch: true,
+		},
+		{
+			// Raw export page — must NOT match.
+			key:       "shadow-results/198000000-198000099.ndjson.gz",
+			wantMatch: false,
+		},
+		{
+			// Divergence report — must NOT match.
+			key:       "shadow-results/divergence-198032451.report.json.gz",
+			wantMatch: false,
+		},
+		{
+			// Unrelated file.
+			key:       "shadow-results/checkpoint.json",
+			wantMatch: false,
+		},
+		{
+			// Empty key.
+			key:       "",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			m := comparePageRe.FindStringSubmatch(tt.key)
+			if !tt.wantMatch {
+				if len(m) >= 3 {
+					t.Fatalf("expected no match for %q, got %v", tt.key, m)
+				}
+				return
+			}
+			if len(m) < 3 {
+				t.Fatalf("expected match for %q, got nil", tt.key)
+			}
+			// m[1] and m[2] parsed by strconv in the real code; verify they're numeric.
+			if m[1] == "" || m[2] == "" {
+				t.Fatalf("empty capture groups for %q", tt.key)
+			}
+		})
+	}
+}
+
+func TestDivergenceReportRe(t *testing.T) {
+	tests := []struct {
+		key        string
+		wantHeight string
+		wantMatch  bool
+	}{
+		{
+			key:        "shadow-results/divergence-198032451.report.json.gz",
+			wantHeight: "198032451",
+			wantMatch:  true,
+		},
+		{
+			key:        "prefix/divergence-1.report.json.gz",
+			wantHeight: "1",
+			wantMatch:  true,
+		},
+		{
+			// Comparison page — must NOT match.
+			key:       "shadow-results/198000000-198000099.compare.ndjson.gz",
+			wantMatch: false,
+		},
+		{
+			// Raw export page — must NOT match.
+			key:       "shadow-results/198000000-198000099.ndjson.gz",
+			wantMatch: false,
+		},
+		{
+			key:       "",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			m := divergenceReportRe.FindStringSubmatch(tt.key)
+			if !tt.wantMatch {
+				if len(m) >= 2 {
+					t.Fatalf("expected no match for %q, got %v", tt.key, m)
+				}
+				return
+			}
+			if len(m) < 2 {
+				t.Fatalf("expected match for %q, got nil", tt.key)
+			}
+			if m[1] != tt.wantHeight {
+				t.Errorf("height = %q, want %q", m[1], tt.wantHeight)
+			}
+		})
+	}
+}

--- a/report_test.go
+++ b/report_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestResolveS3Ref(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		bucket     string
+		prefix     string
+		region     string
+		wantBucket string
+		wantPrefix string
+		wantRegion string
+		wantErr    bool
+	}{
+		{
+			name:       "env expands to bucket name",
+			env:        "prod",
+			wantBucket: "prod-sei-shadow-results",
+			wantPrefix: "shadow-results/",
+			wantRegion: "eu-central-1",
+		},
+		{
+			name:       "bucket passed directly",
+			bucket:     "my-custom-bucket",
+			wantBucket: "my-custom-bucket",
+			wantPrefix: "shadow-results/",
+			wantRegion: "eu-central-1",
+		},
+		{
+			name:    "env and bucket are mutually exclusive",
+			env:     "prod",
+			bucket:  "my-bucket",
+			wantErr: true,
+		},
+		{
+			name:    "neither env nor bucket",
+			wantErr: true,
+		},
+		{
+			name:       "custom prefix gets trailing slash",
+			env:        "dev",
+			prefix:     "custom-prefix",
+			wantBucket: "dev-sei-shadow-results",
+			wantPrefix: "custom-prefix/",
+			wantRegion: "eu-central-1",
+		},
+		{
+			name:       "custom prefix with trailing slash unchanged",
+			env:        "dev",
+			prefix:     "custom-prefix/",
+			wantBucket: "dev-sei-shadow-results",
+			wantPrefix: "custom-prefix/",
+			wantRegion: "eu-central-1",
+		},
+		{
+			name:       "custom region",
+			env:        "prod",
+			region:     "us-east-2",
+			wantBucket: "prod-sei-shadow-results",
+			wantPrefix: "shadow-results/",
+			wantRegion: "us-east-2",
+		},
+		{
+			name:       "empty prefix defaults",
+			env:        "staging",
+			prefix:     "",
+			wantBucket: "staging-sei-shadow-results",
+			wantPrefix: "shadow-results/",
+			wantRegion: "eu-central-1",
+		},
+		{
+			name:       "empty region defaults",
+			env:        "prod",
+			region:     "",
+			wantBucket: "prod-sei-shadow-results",
+			wantPrefix: "shadow-results/",
+			wantRegion: "eu-central-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, prefix, region, err := resolveS3Ref(tt.env, tt.bucket, tt.prefix, tt.region)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if bucket != tt.wantBucket {
+				t.Errorf("bucket = %q, want %q", bucket, tt.wantBucket)
+			}
+			if prefix != tt.wantPrefix {
+				t.Errorf("prefix = %q, want %q", prefix, tt.wantPrefix)
+			}
+			if region != tt.wantRegion {
+				t.Errorf("region = %q, want %q", region, tt.wantRegion)
+			}
+		})
+	}
+}

--- a/sidecar/s3/client.go
+++ b/sidecar/s3/client.go
@@ -63,6 +63,25 @@ func DefaultObjectListerFactory(ctx context.Context, region string) (ObjectListe
 	return s3.NewFromConfig(cfg), nil
 }
 
+// Downloader abstracts S3 GetObject for streaming reads. Unlike
+// TransferClient (which writes to io.WriterAt), Downloader returns
+// a streaming io.ReadCloser body suitable for gzip decompression.
+type Downloader interface {
+	GetObject(ctx context.Context, input *s3.GetObjectInput, opts ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+// DownloaderFactory builds a Downloader for a given region.
+type DownloaderFactory func(ctx context.Context, region string) (Downloader, error)
+
+// DefaultDownloaderFactory creates a real S3 client for streaming downloads.
+func DefaultDownloaderFactory(ctx context.Context, region string) (Downloader, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return s3.NewFromConfig(cfg), nil
+}
+
 // WriteAtBuffer is a goroutine-safe in-memory io.WriterAt, used for
 // downloading small S3 objects (e.g. latest.txt) via DownloadObject.
 type WriteAtBuffer struct {

--- a/sidecar/shadow/fetch.go
+++ b/sidecar/shadow/fetch.go
@@ -1,0 +1,43 @@
+package shadow
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+)
+
+// FetchReport downloads and decodes a DivergenceReport from S3.
+func FetchReport(ctx context.Context, downloader seis3.Downloader, bucket, key string) (*DivergenceReport, error) {
+	resp, err := downloader.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("downloading s3://%s/%s: %w", bucket, key, err)
+	}
+	defer resp.Body.Close()
+
+	var reader io.Reader = resp.Body
+	if strings.HasSuffix(key, ".gz") {
+		gz, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("decompressing report: %w", err)
+		}
+		defer gz.Close()
+		reader = gz
+	}
+
+	var report DivergenceReport
+	if err := json.NewDecoder(reader).Decode(&report); err != nil {
+		return nil, fmt.Errorf("decoding report: %w", err)
+	}
+
+	return &report, nil
+}

--- a/sidecar/shadow/fetch_test.go
+++ b/sidecar/shadow/fetch_test.go
@@ -1,0 +1,243 @@
+package shadow
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+type mockDownloader struct {
+	objects map[string][]byte
+	err     error
+}
+
+func (m *mockDownloader) GetObject(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	key := aws.ToString(input.Key)
+	data, ok := m.objects[key]
+	if !ok {
+		return nil, &s3types.NoSuchKey{}
+	}
+	return &s3.GetObjectOutput{
+		Body: io.NopCloser(bytes.NewReader(data)),
+	}, nil
+}
+
+func gzipJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if err := json.NewEncoder(gw).Encode(v); err != nil {
+		t.Fatalf("encoding JSON: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("closing gzip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func rawJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("encoding JSON: %v", err)
+	}
+	return data
+}
+
+func TestFetchReport_GzippedReport(t *testing.T) {
+	report := DivergenceReport{
+		Height:    198032451,
+		Timestamp: "2026-04-02T00:00:00Z",
+		Comparison: CompareResult{
+			Height: 198032451,
+			Match:  false,
+			Layer0: Layer0Result{
+				AppHashMatch:         false,
+				LastResultsHashMatch: true,
+				GasUsedMatch:         true,
+				ShadowAppHash:        "aaa",
+				CanonicalAppHash:     "bbb",
+			},
+		},
+	}
+
+	dl := &mockDownloader{objects: map[string][]byte{
+		"shadow-results/divergence-198032451.report.json.gz": gzipJSON(t, report),
+	}}
+
+	got, err := FetchReport(context.Background(), dl, "bucket", "shadow-results/divergence-198032451.report.json.gz")
+	if err != nil {
+		t.Fatalf("FetchReport: %v", err)
+	}
+
+	if got.Height != 198032451 {
+		t.Errorf("Height = %d, want 198032451", got.Height)
+	}
+	if got.Timestamp != "2026-04-02T00:00:00Z" {
+		t.Errorf("Timestamp = %q, want 2026-04-02T00:00:00Z", got.Timestamp)
+	}
+	if got.Comparison.Match {
+		t.Error("expected divergent comparison")
+	}
+	if got.Comparison.Layer0.AppHashMatch {
+		t.Error("expected AppHash mismatch")
+	}
+	if got.Comparison.Layer0.ShadowAppHash != "aaa" {
+		t.Errorf("ShadowAppHash = %q, want aaa", got.Comparison.Layer0.ShadowAppHash)
+	}
+}
+
+func TestFetchReport_UncompressedReport(t *testing.T) {
+	report := DivergenceReport{
+		Height:    100,
+		Timestamp: "2026-04-02T00:00:00Z",
+		Comparison: CompareResult{
+			Height: 100,
+			Match:  true,
+			Layer0: Layer0Result{AppHashMatch: true, LastResultsHashMatch: true, GasUsedMatch: true},
+		},
+	}
+
+	dl := &mockDownloader{objects: map[string][]byte{
+		"reports/divergence-100.report.json": rawJSON(t, report),
+	}}
+
+	got, err := FetchReport(context.Background(), dl, "bucket", "reports/divergence-100.report.json")
+	if err != nil {
+		t.Fatalf("FetchReport: %v", err)
+	}
+	if got.Height != 100 {
+		t.Errorf("Height = %d, want 100", got.Height)
+	}
+}
+
+func TestFetchReport_S3NotFound(t *testing.T) {
+	dl := &mockDownloader{objects: map[string][]byte{}}
+
+	_, err := FetchReport(context.Background(), dl, "bucket", "nonexistent-key.json.gz")
+	if err == nil {
+		t.Fatal("expected error for missing key")
+	}
+}
+
+func TestFetchReport_CorruptGzip(t *testing.T) {
+	dl := &mockDownloader{objects: map[string][]byte{
+		"corrupt.json.gz": {0x00, 0x01, 0x02, 0x03},
+	}}
+
+	_, err := FetchReport(context.Background(), dl, "bucket", "corrupt.json.gz")
+	if err == nil {
+		t.Fatal("expected error for corrupt gzip data")
+	}
+}
+
+func TestFetchReport_InvalidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Write([]byte("not valid json"))
+	gw.Close()
+
+	dl := &mockDownloader{objects: map[string][]byte{
+		"bad.json.gz": buf.Bytes(),
+	}}
+
+	_, err := FetchReport(context.Background(), dl, "bucket", "bad.json.gz")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestFetchReport_WithLayer1Data(t *testing.T) {
+	layer := 0
+	report := DivergenceReport{
+		Height:    42,
+		Timestamp: "2026-04-02T00:00:00Z",
+		Comparison: CompareResult{
+			Height:          42,
+			Match:           false,
+			DivergenceLayer: &layer,
+			Layer0: Layer0Result{
+				AppHashMatch:         false,
+				LastResultsHashMatch: true,
+				GasUsedMatch:         true,
+				ShadowAppHash:        "shadow",
+				CanonicalAppHash:     "canonical",
+			},
+			Layer1: &Layer1Result{
+				TotalTxs:     5,
+				TxCountMatch: true,
+				Divergences: []TxDivergence{
+					{
+						TxIndex: 2,
+						Fields: []FieldDivergence{
+							{Field: "code", Shadow: 0, Canonical: 1},
+							{Field: "gasUsed", Shadow: "100000", Canonical: "120000"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dl := &mockDownloader{objects: map[string][]byte{
+		"divergence-42.report.json.gz": gzipJSON(t, report),
+	}}
+
+	got, err := FetchReport(context.Background(), dl, "bucket", "divergence-42.report.json.gz")
+	if err != nil {
+		t.Fatalf("FetchReport: %v", err)
+	}
+
+	if got.Comparison.Layer1 == nil {
+		t.Fatal("expected Layer1 data")
+	}
+	if got.Comparison.Layer1.TotalTxs != 5 {
+		t.Errorf("TotalTxs = %d, want 5", got.Comparison.Layer1.TotalTxs)
+	}
+	if len(got.Comparison.Layer1.Divergences) != 1 {
+		t.Fatalf("expected 1 tx divergence, got %d", len(got.Comparison.Layer1.Divergences))
+	}
+	div := got.Comparison.Layer1.Divergences[0]
+	if div.TxIndex != 2 {
+		t.Errorf("TxIndex = %d, want 2", div.TxIndex)
+	}
+	if len(div.Fields) != 2 {
+		t.Errorf("expected 2 field divergences, got %d", len(div.Fields))
+	}
+}
+
+func TestFetchReport_WithChainSnapshots(t *testing.T) {
+	report := DivergenceReport{
+		Height:    99,
+		Timestamp: "2026-04-02T00:00:00Z",
+		Comparison: CompareResult{Height: 99, Match: false, Layer0: Layer0Result{AppHashMatch: false}},
+		Shadow:     ChainSnapshot{Block: json.RawMessage(`{"shadow":"block"}`), BlockResults: json.RawMessage(`{"shadow":"results"}`)},
+		Canonical:  ChainSnapshot{Block: json.RawMessage(`{"canonical":"block"}`), BlockResults: json.RawMessage(`{"canonical":"results"}`)},
+	}
+
+	dl := &mockDownloader{objects: map[string][]byte{
+		"report.json.gz": gzipJSON(t, report),
+	}}
+
+	got, err := FetchReport(context.Background(), dl, "bucket", "report.json.gz")
+	if err != nil {
+		t.Fatalf("FetchReport: %v", err)
+	}
+
+	if len(got.Shadow.Block) == 0 {
+		t.Error("expected non-empty Shadow.Block")
+	}
+	if len(got.Canonical.Block) == 0 {
+		t.Error("expected non-empty Canonical.Block")
+	}
+}

--- a/sidecar/shadow/fetch_test.go
+++ b/sidecar/shadow/fetch_test.go
@@ -218,8 +218,8 @@ func TestFetchReport_WithLayer1Data(t *testing.T) {
 
 func TestFetchReport_WithChainSnapshots(t *testing.T) {
 	report := DivergenceReport{
-		Height:    99,
-		Timestamp: "2026-04-02T00:00:00Z",
+		Height:     99,
+		Timestamp:  "2026-04-02T00:00:00Z",
 		Comparison: CompareResult{Height: 99, Match: false, Layer0: Layer0Result{AppHashMatch: false}},
 		Shadow:     ChainSnapshot{Block: json.RawMessage(`{"shadow":"block"}`), BlockResults: json.RawMessage(`{"shadow":"results"}`)},
 		Canonical:  ChainSnapshot{Block: json.RawMessage(`{"canonical":"block"}`), BlockResults: json.RawMessage(`{"canonical":"results"}`)},


### PR DESCRIPTION
## Summary
- Adds `seictl report list` to inventory shadow comparison data in S3
- Extends `seictl report divergence` with `--env`/`--height` convenience flags
- Both commands support `--json` for agent consumption

## What this does

**`report list --env prod`** — shows what comparison pages and divergence reports exist:
```
3 comparison page(s), 1 divergence report(s), 300 blocks covered

TYPE         HEIGHT RANGE              BLOCKS
page         198000000 - 198000099     100
page         198000100 - 198000199     100
page         198000200 - 198000242     43
divergence   198000242                 -
```

**`report divergence --env prod --height 198000242`** — fetches the divergence report without needing to know the S3 key. Equivalent to `--bucket prod-sei-shadow-results --key shadow-results/divergence-198000242.report.json.gz`.

## Why this scope

The shadow replayer crashes on app hash divergence, producing a handful of matching pages + exactly 1 divergence report. The investigation workflow is: "did it diverge?" → "show me the report." These two commands serve that workflow. Statistical analysis (summary, search, trends) was evaluated and cut per YAGNI — the data shape doesn't support it.

## Changes
- `report.go` — extended divergence command, `resolveS3Ref()` helper, registered `list`
- `report_list.go` — new `report list` command with S3 listing + key parsing
- `sidecar/shadow/fetch.go` — extracted `FetchReport()` for testability
- `sidecar/s3/client.go` — new `Downloader` interface for streaming S3 reads

No new dependencies. No sidecar/task engine/OpenAPI changes.

## Test plan
- [ ] `seictl report list --env prod` returns inventory
- [ ] `seictl report list --env prod --json` returns structured JSON
- [ ] `seictl report divergence --env prod --height N` fetches and renders report
- [ ] `seictl report divergence --env prod --height N --json` returns raw JSON
- [ ] `--key` and `--height` are mutually exclusive (error)
- [ ] `--env` and `--bucket` are mutually exclusive (error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)