### PR TITLE
feat: add dnsEndpoints peer discovery source

### DIFF
--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -149,8 +149,9 @@ func ConfigureGenesisTaskFromParams(_ map[string]interface{}) ConfigureGenesisTa
 type PeerSourceType string
 
 const (
-	PeerSourceEC2Tags PeerSourceType = "ec2Tags"
-	PeerSourceStatic  PeerSourceType = "static"
+	PeerSourceEC2Tags      PeerSourceType = "ec2Tags"
+	PeerSourceStatic       PeerSourceType = "static"
+	PeerSourceDNSEndpoints PeerSourceType = "dnsEndpoints"
 )
 
 // PeerSource is a single peer discovery source.
@@ -159,6 +160,7 @@ type PeerSource struct {
 	Region    string
 	Tags      map[string]string
 	Addresses []string
+	Endpoints []string
 }
 
 // DiscoverPeersTask resolves peers from one or more sources.
@@ -186,6 +188,10 @@ func (t DiscoverPeersTask) Validate() error {
 			if len(src.Addresses) == 0 {
 				return fmt.Errorf("discover-peers: source[%d] static missing required field Addresses", i)
 			}
+		case PeerSourceDNSEndpoints:
+			if len(src.Endpoints) == 0 {
+				return fmt.Errorf("discover-peers: source[%d] dnsEndpoints missing required field Endpoints", i)
+			}
 		default:
 			return fmt.Errorf("discover-peers: source[%d] unknown type %q", i, src.Type)
 		}
@@ -211,6 +217,12 @@ func (t DiscoverPeersTask) ToTaskRequest() TaskRequest {
 				addrs[j] = a
 			}
 			m["addresses"] = addrs
+		case PeerSourceDNSEndpoints:
+			eps := make([]interface{}, len(src.Endpoints))
+			for j, e := range src.Endpoints {
+				eps[j] = e
+			}
+			m["endpoints"] = eps
 		}
 		sources[i] = m
 	}
@@ -256,6 +268,15 @@ func DiscoverPeersTaskFromParams(params map[string]interface{}) (DiscoverPeersTa
 				for _, a := range rawAddrs {
 					if s, ok := a.(string); ok {
 						src.Addresses = append(src.Addresses, s)
+					}
+				}
+			}
+		case PeerSourceDNSEndpoints:
+			if rawEps, ok := m["endpoints"].([]interface{}); ok {
+				src.Endpoints = make([]string, 0, len(rawEps))
+				for _, e := range rawEps {
+					if s, ok := e.(string); ok {
+						src.Endpoints = append(src.Endpoints, s)
 					}
 				}
 			}

--- a/sidecar/tasks/peers.go
+++ b/sidecar/tasks/peers.go
@@ -61,6 +61,14 @@ type StaticSource struct {
 	Addresses []string
 }
 
+// DNSEndpointsSource discovers peers by querying a list of DNS endpoints
+// for their Tendermint node IDs. The controller resolves Kubernetes
+// SeiNodes to stable pod DNS names; this source handles the RPC query.
+type DNSEndpointsSource struct {
+	Endpoints   []string
+	QueryNodeID NodeIDQuerier
+}
+
 // DiscoverPeersRequest holds the typed parameters for the discover-peers task.
 type DiscoverPeersRequest struct {
 	Sources []PeerSourceEntry `json:"sources"`
@@ -72,6 +80,7 @@ type PeerSourceEntry struct {
 	Region    string            `json:"region,omitempty"`
 	Tags      map[string]string `json:"tags,omitempty"`
 	Addresses []string          `json:"addresses,omitempty"`
+	Endpoints []string          `json:"endpoints,omitempty"`
 }
 
 // PeerDiscoverer resolves peers from multiple sources and writes them to a file.
@@ -144,6 +153,30 @@ func (s *StaticSource) Discover(_ context.Context) ([]string, error) {
 	result := make([]string, len(s.Addresses))
 	copy(result, s.Addresses)
 	return result, nil
+}
+
+// Discover queries each DNS endpoint's Tendermint RPC for its node ID
+// and returns peer addresses in id@host:port format.
+func (s *DNSEndpointsSource) Discover(ctx context.Context) ([]string, error) {
+	querier := s.QueryNodeID
+	if querier == nil {
+		querier = defaultQueryNodeID
+	}
+
+	var peers []string
+	for _, endpoint := range s.Endpoints {
+		nodeID, err := querier(ctx, endpoint+":26657")
+		if err != nil {
+			peerLog.Info("skipping unreachable DNS endpoint", "endpoint", endpoint, "error", err)
+			continue
+		}
+		peers = append(peers, fmt.Sprintf("%s@%s:%s", nodeID, endpoint, p2pPort))
+	}
+
+	if len(peers) == 0 {
+		return nil, fmt.Errorf("no reachable peers found via dnsEndpoints (%d endpoints tried)", len(s.Endpoints))
+	}
+	return peers, nil
 }
 
 // NewPeerDiscoverer creates a discoverer targeting the given home directory.
@@ -237,6 +270,14 @@ func (d *PeerDiscoverer) buildSources(configs []PeerSourceEntry) ([]PeerSource, 
 				return nil, fmt.Errorf("source[%d]: static source has empty addresses", i)
 			}
 			sources = append(sources, &StaticSource{Addresses: cfg.Addresses})
+		case "dnsEndpoints":
+			if len(cfg.Endpoints) == 0 {
+				return nil, fmt.Errorf("source[%d]: dnsEndpoints source has empty endpoints", i)
+			}
+			sources = append(sources, &DNSEndpointsSource{
+				Endpoints:   cfg.Endpoints,
+				QueryNodeID: d.queryNodeID,
+			})
 		default:
 			return nil, fmt.Errorf("source[%d]: unknown type %q", i, cfg.Type)
 		}

--- a/sidecar/tasks/peers.go
+++ b/sidecar/tasks/peers.go
@@ -165,7 +165,7 @@ func (s *DNSEndpointsSource) Discover(ctx context.Context) ([]string, error) {
 
 	var peers []string
 	for _, endpoint := range s.Endpoints {
-		nodeID, err := querier(ctx, endpoint+":26657")
+		nodeID, err := querier(ctx, endpoint)
 		if err != nil {
 			peerLog.Info("skipping unreachable DNS endpoint", "endpoint", endpoint, "error", err)
 			continue

--- a/sidecar/tasks/peers_test.go
+++ b/sidecar/tasks/peers_test.go
@@ -197,8 +197,8 @@ func TestStaticSource_EmptyAddresses_ReturnsError(t *testing.T) {
 
 func TestDNSEndpointsSource_Discover(t *testing.T) {
 	nodeIDs := map[string]string{
-		"node-0-0.node-0.default.svc.cluster.local:26657": "abc123",
-		"node-1-0.node-1.default.svc.cluster.local:26657": "def456",
+		"node-0-0.node-0.default.svc.cluster.local": "abc123",
+		"node-1-0.node-1.default.svc.cluster.local": "def456",
 	}
 	querier := func(_ context.Context, host string) (string, error) {
 		id, ok := nodeIDs[host]
@@ -233,7 +233,7 @@ func TestDNSEndpointsSource_Discover(t *testing.T) {
 
 func TestDNSEndpointsSource_SkipsUnreachable(t *testing.T) {
 	querier := func(_ context.Context, host string) (string, error) {
-		if host == "bad-0.bad.default.svc.cluster.local:26657" {
+		if host == "bad-0.bad.default.svc.cluster.local" {
 			return "", fmt.Errorf("connection refused")
 		}
 		return "good-id", nil

--- a/sidecar/tasks/peers_test.go
+++ b/sidecar/tasks/peers_test.go
@@ -195,6 +195,111 @@ func TestStaticSource_EmptyAddresses_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestDNSEndpointsSource_Discover(t *testing.T) {
+	nodeIDs := map[string]string{
+		"node-0-0.node-0.default.svc.cluster.local:26657": "abc123",
+		"node-1-0.node-1.default.svc.cluster.local:26657": "def456",
+	}
+	querier := func(_ context.Context, host string) (string, error) {
+		id, ok := nodeIDs[host]
+		if !ok {
+			return "", fmt.Errorf("unreachable: %s", host)
+		}
+		return id, nil
+	}
+
+	src := &DNSEndpointsSource{
+		Endpoints: []string{
+			"node-0-0.node-0.default.svc.cluster.local",
+			"node-1-0.node-1.default.svc.cluster.local",
+		},
+		QueryNodeID: querier,
+	}
+
+	peers, err := src.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d: %v", len(peers), peers)
+	}
+	if peers[0] != "abc123@node-0-0.node-0.default.svc.cluster.local:26656" {
+		t.Errorf("peer[0] = %q", peers[0])
+	}
+	if peers[1] != "def456@node-1-0.node-1.default.svc.cluster.local:26656" {
+		t.Errorf("peer[1] = %q", peers[1])
+	}
+}
+
+func TestDNSEndpointsSource_SkipsUnreachable(t *testing.T) {
+	querier := func(_ context.Context, host string) (string, error) {
+		if host == "bad-0.bad.default.svc.cluster.local:26657" {
+			return "", fmt.Errorf("connection refused")
+		}
+		return "good-id", nil
+	}
+
+	src := &DNSEndpointsSource{
+		Endpoints: []string{
+			"bad-0.bad.default.svc.cluster.local",
+			"good-0.good.default.svc.cluster.local",
+		},
+		QueryNodeID: querier,
+	}
+
+	peers, err := src.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 reachable peer, got %d: %v", len(peers), peers)
+	}
+	if peers[0] != "good-id@good-0.good.default.svc.cluster.local:26656" {
+		t.Errorf("peer[0] = %q", peers[0])
+	}
+}
+
+func TestDNSEndpointsSource_AllUnreachable_ReturnsError(t *testing.T) {
+	querier := func(_ context.Context, _ string) (string, error) {
+		return "", fmt.Errorf("connection refused")
+	}
+
+	src := &DNSEndpointsSource{
+		Endpoints:   []string{"a-0.a.default.svc.cluster.local", "b-0.b.default.svc.cluster.local"},
+		QueryNodeID: querier,
+	}
+
+	_, err := src.Discover(context.Background())
+	if err == nil {
+		t.Fatal("expected error when all endpoints unreachable")
+	}
+}
+
+func TestHandler_SourcesParam_DNSEndpoints(t *testing.T) {
+	homeDir := t.TempDir()
+	ensureConfigDir(t, homeDir)
+	discoverer := NewPeerDiscoverer(homeDir, nil, staticNodeIDQuerier("k8s-node"))
+	handler := discoverer.Handler()
+
+	err := handler(context.Background(), map[string]any{
+		"sources": []any{
+			map[string]any{
+				"type":      "dnsEndpoints",
+				"endpoints": []any{"peer-0-0.peer-0.default.svc.cluster.local"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Handler failed: %v", err)
+	}
+
+	got := readPeersFromConfigTOML(t, homeDir)
+	want := "k8s-node@peer-0-0.peer-0.default.svc.cluster.local:26656"
+	if got != want {
+		t.Fatalf("peers = %q, want %q", got, want)
+	}
+}
+
 func TestDiscoverFromSources_Deduplication(t *testing.T) {
 	src1 := &StaticSource{Addresses: []string{"abc@1.2.3.4:26656", "def@5.6.7.8:26656"}}
 	src2 := &StaticSource{Addresses: []string{"def@5.6.7.8:26656", "ghi@9.10.11.12:26656"}}


### PR DESCRIPTION
## Summary

Add `DNSEndpointsSource` to the discover-peers handler. The controller resolves Kubernetes SeiNode label selectors to stable pod DNS names and passes them as `dnsEndpoints` sources. The sidecar queries each endpoint's Tendermint RPC for the node ID and builds peer addresses.

Named `dnsEndpoints` (not `kubernetesLabel`) so the sidecar stays infrastructure-agnostic — it receives DNS hostnames and makes HTTP calls, no Kubernetes API access needed.

Companion controller PR: sei-protocol/sei-k8s-controller#47

## Changes

- `DNSEndpointsSource` with `Discover()` that queries each endpoint's `:26657/status` for node ID
- `Endpoints` field added to `PeerSourceEntry`
- `dnsEndpoints` case wired into `buildSources` dispatcher
- `PeerSourceDNSEndpoints` constant and full client support (Validate, ToTaskRequest, FromParams)

## Test plan

- [x] `go vet` passes
- [x] `go build` passes
- [x] Unit test for `DNSEndpointsSource.Discover` with mock querier

🤖 Generated with [Claude Code](https://claude.com/claude-code)