### PR TITLE
fix: variable shadowing in snapshot restore swallowed resolve errors

### DIFF
--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -100,16 +100,25 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 
 	var snapshotKey string
 	if targetHeight > 0 {
-		lister, err := r.listerFactory(ctx, r.region)
-		if err != nil {
-			return fmt.Errorf("building S3 lister: %w", err)
+		lister, listerErr := r.listerFactory(ctx, r.region)
+		if listerErr != nil {
+			return fmt.Errorf("building S3 lister: %w", listerErr)
 		}
-		snapshotKey, err = resolveKeyForHeight(ctx, lister, r.bucket, prefix, targetHeight)
+		var resolveErr error
+		snapshotKey, resolveErr = resolveKeyForHeight(ctx, lister, r.bucket, prefix, targetHeight)
+		if resolveErr != nil {
+			return resolveErr
+		}
 	} else {
-		snapshotKey, err = resolveLatestKey(ctx, client, r.bucket, prefix)
+		var resolveErr error
+		snapshotKey, resolveErr = resolveLatestKey(ctx, client, r.bucket, prefix)
+		if resolveErr != nil {
+			return resolveErr
+		}
 	}
-	if err != nil {
-		return err
+
+	if snapshotKey == "" {
+		return fmt.Errorf("snapshot-restore: resolved snapshot key is empty for %s in s3://%s/%s", r.chainID, r.bucket, prefix)
 	}
 
 	tmpDir := filepath.Join(r.homeDir, "tmp")

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
@@ -332,6 +333,9 @@ func TestSnapshotRestoreTargetHeightNoMatch(t *testing.T) {
 	err := restorer.Restore(context.Background(), 50000000)
 	if err == nil {
 		t.Fatal("expected error when no snapshot found at or below target height")
+	}
+	if !strings.Contains(err.Error(), "no snapshot found") {
+		t.Fatalf("expected 'no snapshot found' error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Classic Go variable shadowing bug: `:=` on `lister, err` inside the `if targetHeight > 0` block created a block-scoped `err` that shadowed the outer one. When `resolveKeyForHeight` returned an error (e.g., empty S3 bucket), the error was silently discarded and the download proceeded with an empty key, producing a confusing `"input member Key must not be empty"` AWS SDK error instead of `"no snapshot found at or below height N"`.

## Changes

- Replace shared-err-across-branches pattern with explicit error variables and immediate returns
- Add defensive empty-key guard before download (before tmpdir/tmpfile creation)
- Strengthen `TestSnapshotRestoreTargetHeightNoMatch` to assert the specific error message

## Test plan

- [x] All 11 snapshot restore tests pass
- [x] `TestSnapshotRestoreTargetHeightNoMatch` now asserts `"no snapshot found"` in error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)