### PR TITLE
feat: sidecar Prometheus metrics, RPC connection pooling, cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/leanovate/gopter v0.2.11
 	github.com/oapi-codegen/runtime v1.2.0
 	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/prometheus/client_golang v1.23.2
 	github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7
 	github.com/sei-protocol/sei-config v0.0.9
 	github.com/sei-protocol/seilog v0.0.3
@@ -150,7 +151,6 @@ require (
 	github.com/petermattis/goid v0.0.0-20260113132338-7c7de50cc741 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect

--- a/sidecar/engine/engine.go
+++ b/sidecar/engine/engine.go
@@ -131,6 +131,7 @@ func (e *Engine) Submit(task Task) (string, error) {
 	}
 
 	log.Info("task submitted", "type", task.Type, "id", id, "run", run)
+	taskSubmissions.WithLabelValues(string(task.Type)).Inc()
 	e.runTask(id, task.Type, handler, task.Params, now, run)
 
 	return id, nil
@@ -167,10 +168,15 @@ func (e *Engine) runTask(id string, taskType TaskType, handler TaskHandler, para
 func (e *Engine) execute(ctx context.Context, taskType TaskType, handler TaskHandler, params map[string]any) error {
 	start := time.Now()
 	if err := handler(ctx, params); err != nil {
-		log.Error("task failed", "type", taskType, "elapsed", time.Since(start).Round(time.Millisecond), "err", err)
+		elapsed := time.Since(start)
+		log.Error("task failed", "type", taskType, "elapsed", elapsed.Round(time.Millisecond), "err", err)
+		taskDuration.WithLabelValues(string(taskType), "failed").Observe(elapsed.Seconds())
+		taskFailures.WithLabelValues(string(taskType)).Inc()
 		return err
 	}
-	log.Info("task completed", "type", taskType, "elapsed", time.Since(start).Round(time.Millisecond))
+	elapsed := time.Since(start)
+	log.Info("task completed", "type", taskType, "elapsed", elapsed.Round(time.Millisecond))
+	taskDuration.WithLabelValues(string(taskType), "completed").Observe(elapsed.Seconds())
 	if taskType == TaskMarkReady {
 		e.ready.Store(true)
 	}

--- a/sidecar/engine/metrics.go
+++ b/sidecar/engine/metrics.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// taskDuration records the execution duration of each task in seconds.
+	taskDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "seictl_task_duration_seconds",
+			Help:    "Duration of task execution in seconds.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"type", "status"},
+	)
+
+	// taskSubmissions counts the total number of task submissions.
+	taskSubmissions = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "seictl_task_submissions_total",
+			Help: "Total number of tasks submitted.",
+		},
+		[]string{"type"},
+	)
+
+	// taskFailures counts the total number of task failures.
+	taskFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "seictl_task_failures_total",
+			Help: "Total number of tasks that failed.",
+		},
+		[]string{"type"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(taskDuration)
+	prometheus.MustRegister(taskSubmissions)
+	prometheus.MustRegister(taskFailures)
+}

--- a/sidecar/engine/metrics.go
+++ b/sidecar/engine/metrics.go
@@ -5,11 +5,12 @@ import (
 )
 
 var (
-	// taskDuration records the execution duration of each task in seconds.
+	// taskDuration records the wall-clock execution time of the task handler
+	// (measured inside the goroutine, not submission latency).
 	taskDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "seictl_task_duration_seconds",
-			Help:    "Duration of task execution in seconds.",
+			Name:    "seictl_task_execution_duration_seconds",
+			Help:    "Wall-clock execution time of task handlers in seconds (measured inside the goroutine, not submission latency).",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"type", "status"},

--- a/sidecar/server/server.go
+++ b/sidecar/server/server.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/sei-protocol/seictl/sidecar/engine"
 )
 
@@ -55,6 +57,7 @@ func NewServer(addr string, eng *engine.Engine, homeDir string) *Server {
 	s.mux.HandleFunc("GET /v0/healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /v0/livez", s.handleLivez)
 	s.mux.HandleFunc("GET /v0/status", s.handleStatus)
+	s.mux.Handle("GET /v0/metrics", promhttp.Handler())
 	s.mux.HandleFunc("GET /v0/node-id", s.handleNodeID)
 	s.mux.HandleFunc("POST /v0/tasks", s.handlePostTask)
 	s.mux.HandleFunc("GET /v0/tasks", s.handleListTasks)

--- a/sidecar/shadow/comparator.go
+++ b/sidecar/shadow/comparator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/sei-protocol/seictl/sidecar/rpc"
 	"github.com/sei-protocol/seilog"
 )
 
@@ -12,16 +13,16 @@ var log = seilog.NewLogger("seictl", "shadow")
 // Comparator performs block-by-block comparison between a shadow node and
 // a canonical chain node via their RPC endpoints.
 type Comparator struct {
-	shadowRPC    string
-	canonicalRPC string
+	shadowClient    *rpc.Client
+	canonicalClient *rpc.Client
 }
 
 // NewComparator creates a Comparator that queries shadowRPC for the local
 // shadow node and canonicalRPC for the reference chain.
 func NewComparator(shadowRPC, canonicalRPC string) *Comparator {
 	return &Comparator{
-		shadowRPC:    shadowRPC,
-		canonicalRPC: canonicalRPC,
+		shadowClient:    rpc.NewClient(shadowRPC, nil),
+		canonicalClient: rpc.NewClient(canonicalRPC, nil),
 	}
 }
 

--- a/sidecar/shadow/layer0.go
+++ b/sidecar/shadow/layer0.go
@@ -11,11 +11,11 @@ import (
 // compareLayer0 fetches the block header from both chains at the given
 // height and compares AppHash, LastResultsHash, and total gas used.
 func (c *Comparator) compareLayer0(ctx context.Context, height int64) (*Layer0Result, error) {
-	shadowBlock, err := queryBlock(ctx, c.shadowRPC, height)
+	shadowBlock, err := queryBlock(ctx, c.shadowClient, height)
 	if err != nil {
 		return nil, fmt.Errorf("querying shadow block at height %d: %w", height, err)
 	}
-	canonicalBlock, err := queryBlock(ctx, c.canonicalRPC, height)
+	canonicalBlock, err := queryBlock(ctx, c.canonicalClient, height)
 	if err != nil {
 		return nil, fmt.Errorf("querying canonical block at height %d: %w", height, err)
 	}
@@ -52,9 +52,8 @@ func (c *Comparator) compareLayer0(ctx context.Context, height int64) (*Layer0Re
 
 // queryBlock fetches the block at the given height from a CometBFT RPC endpoint
 // and returns the header fields needed for comparison.
-func queryBlock(ctx context.Context, rpcEndpoint string, height int64) (*rpc.BlockResult, error) {
-	c := rpc.NewClient(rpcEndpoint, nil)
-	raw, err := c.Get(ctx, fmt.Sprintf("/block?height=%d", height))
+func queryBlock(ctx context.Context, client *rpc.Client, height int64) (*rpc.BlockResult, error) {
+	raw, err := client.Get(ctx, fmt.Sprintf("/block?height=%d", height))
 	if err != nil {
 		return nil, err
 	}

--- a/sidecar/shadow/layer1.go
+++ b/sidecar/shadow/layer1.go
@@ -12,11 +12,11 @@ import (
 // compareLayer1 fetches block_results from both chains and compares
 // individual transaction receipts to identify which transactions diverged.
 func (c *Comparator) compareLayer1(ctx context.Context, height int64) (*Layer1Result, error) {
-	shadowResults, err := queryBlockResults(ctx, c.shadowRPC, height)
+	shadowResults, err := queryBlockResults(ctx, c.shadowClient, height)
 	if err != nil {
 		return nil, fmt.Errorf("querying shadow block_results at height %d: %w", height, err)
 	}
-	canonicalResults, err := queryBlockResults(ctx, c.canonicalRPC, height)
+	canonicalResults, err := queryBlockResults(ctx, c.canonicalClient, height)
 	if err != nil {
 		return nil, fmt.Errorf("querying canonical block_results at height %d: %w", height, err)
 	}
@@ -105,9 +105,8 @@ func compareTxReceipts(idx int, shadow, canonical rpc.TxResult) *TxDivergence {
 }
 
 // queryBlockResults fetches /block_results at the given height.
-func queryBlockResults(ctx context.Context, rpcEndpoint string, height int64) (*rpc.BlockResultsResult, error) {
-	c := rpc.NewClient(rpcEndpoint, nil)
-	raw, err := c.Get(ctx, fmt.Sprintf("/block_results?height=%d", height))
+func queryBlockResults(ctx context.Context, client *rpc.Client, height int64) (*rpc.BlockResultsResult, error) {
+	raw, err := client.Get(ctx, fmt.Sprintf("/block_results?height=%d", height))
 	if err != nil {
 		return nil, err
 	}

--- a/sidecar/shadow/report.go
+++ b/sidecar/shadow/report.go
@@ -12,12 +12,12 @@ import (
 // given height. It pairs the comparison result with the full raw RPC
 // responses from both chains so engineers can diagnose offline.
 func (c *Comparator) BuildDivergenceReport(ctx context.Context, height int64, comparison CompareResult) (*DivergenceReport, error) {
-	shadowSnap, err := captureChainSnapshot(ctx, c.shadowRPC, height)
+	shadowSnap, err := captureChainSnapshot(ctx, c.shadowClient, height)
 	if err != nil {
 		return nil, fmt.Errorf("capturing shadow snapshot at height %d: %w", height, err)
 	}
 
-	canonicalSnap, err := captureChainSnapshot(ctx, c.canonicalRPC, height)
+	canonicalSnap, err := captureChainSnapshot(ctx, c.canonicalClient, height)
 	if err != nil {
 		return nil, fmt.Errorf("capturing canonical snapshot at height %d: %w", height, err)
 	}
@@ -31,13 +31,13 @@ func (c *Comparator) BuildDivergenceReport(ctx context.Context, height int64, co
 	}, nil
 }
 
-func captureChainSnapshot(ctx context.Context, rpcEndpoint string, height int64) (*ChainSnapshot, error) {
-	block, err := fetchRawBlock(ctx, rpcEndpoint, height)
+func captureChainSnapshot(ctx context.Context, client *rpc.Client, height int64) (*ChainSnapshot, error) {
+	block, err := fetchRawBlock(ctx, client, height)
 	if err != nil {
 		return nil, err
 	}
 
-	blockResults, err := fetchRawBlockResults(ctx, rpcEndpoint, height)
+	blockResults, err := fetchRawBlockResults(ctx, client, height)
 	if err != nil {
 		return nil, err
 	}
@@ -48,10 +48,10 @@ func captureChainSnapshot(ctx context.Context, rpcEndpoint string, height int64)
 	}, nil
 }
 
-func fetchRawBlock(ctx context.Context, rpcEndpoint string, height int64) ([]byte, error) {
-	return rpc.NewClient(rpcEndpoint, nil).GetRaw(ctx, fmt.Sprintf("/block?height=%d", height))
+func fetchRawBlock(ctx context.Context, client *rpc.Client, height int64) ([]byte, error) {
+	return client.GetRaw(ctx, fmt.Sprintf("/block?height=%d", height))
 }
 
-func fetchRawBlockResults(ctx context.Context, rpcEndpoint string, height int64) ([]byte, error) {
-	return rpc.NewClient(rpcEndpoint, nil).GetRaw(ctx, fmt.Sprintf("/block_results?height=%d", height))
+func fetchRawBlockResults(ctx context.Context, client *rpc.Client, height int64) ([]byte, error) {
+	return client.GetRaw(ctx, fmt.Sprintf("/block_results?height=%d", height))
 }

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -24,9 +24,8 @@ import (
 var exportLog = seilog.NewLogger("seictl", "task", "result-export")
 
 const (
-	exportStateFile  = ".sei-sidecar-last-export.json"
-	defaultPageSize  = 1000
-	exportRPCTimeout = 10 * time.Second
+	exportStateFile = ".sei-sidecar-last-export.json"
+	defaultPageSize = 1000
 )
 
 var defaultRPCEndpoint = fmt.Sprintf("http://localhost:%d", seiconfig.PortRPC)
@@ -105,6 +104,7 @@ func (e *ResultExporter) Export(ctx context.Context, cfg ResultExportRequest) er
 		return fmt.Errorf("building S3 uploader: %w", err)
 	}
 
+	rpcClient := rpc.NewClient(cfg.RPCEndpoint, nil)
 	prefix := normalizePrefix(cfg.Prefix)
 
 	availableBlocks := latestHeight - startHeight + 1
@@ -126,7 +126,7 @@ func (e *ResultExporter) Export(ctx context.Context, cfg ResultExportRequest) er
 			"end", pageEnd,
 			"bucket", cfg.Bucket)
 
-		if err := e.exportPage(ctx, cfg.RPCEndpoint, uploader, cfg.Bucket, cfg.Region, prefix, pageStart, pageEnd); err != nil {
+		if err := e.exportPage(ctx, rpcClient, uploader, cfg.Bucket, cfg.Region, prefix, pageStart, pageEnd); err != nil {
 			return fmt.Errorf("exporting page %d-%d: %w", pageStart, pageEnd, err)
 		}
 
@@ -150,7 +150,7 @@ func (e *ResultExporter) Export(ctx context.Context, cfg ResultExportRequest) er
 // NDJSON file to S3.
 func (e *ResultExporter) exportPage(
 	ctx context.Context,
-	rpcEndpoint string,
+	client *rpc.Client,
 	uploader seis3.Uploader,
 	bucket, region, prefix string,
 	start, end int64,
@@ -161,7 +161,7 @@ func (e *ResultExporter) exportPage(
 
 	collectErr := make(chan error, 1)
 	go func() {
-		collectErr <- e.collectResults(ctx, rpcEndpoint, pw, start, end)
+		collectErr <- e.collectResults(ctx, client, pw, start, end)
 	}()
 
 	_, uploadErr := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
@@ -185,7 +185,7 @@ func (e *ResultExporter) exportPage(
 // collectResults queries block_results for each height and writes gzipped
 // NDJSON to wc. Each line is a JSON object with height, time, and the raw
 // block_results response.
-func (e *ResultExporter) collectResults(ctx context.Context, rpcEndpoint string, wc io.WriteCloser, start, end int64) (retErr error) {
+func (e *ResultExporter) collectResults(ctx context.Context, client *rpc.Client, wc io.WriteCloser, start, end int64) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			wc.(*io.PipeWriter).CloseWithError(retErr)
@@ -206,7 +206,7 @@ func (e *ResultExporter) collectResults(ctx context.Context, rpcEndpoint string,
 			return err
 		}
 
-		result, err := queryBlockResults(ctx, rpcEndpoint, h)
+		result, err := queryBlockResults(ctx, client, h)
 		if err != nil {
 			return fmt.Errorf("querying block_results at height %d: %w", h, err)
 		}
@@ -232,20 +232,10 @@ func (e *ResultExporter) collectResults(ctx context.Context, rpcEndpoint string,
 }
 
 func queryLatestHeight(ctx context.Context, rpcEndpoint string) (int64, error) {
-	c := rpc.NewClient(rpcEndpoint, nil)
-	raw, err := c.Get(ctx, "/status")
+	c := rpc.NewStatusClient(rpcEndpoint, nil)
+	h, err := c.LatestHeight(ctx)
 	if err != nil {
 		return 0, err
-	}
-
-	var result rpc.StatusResult
-	if err := json.Unmarshal(raw, &result); err != nil {
-		return 0, fmt.Errorf("decoding /status response: %w", err)
-	}
-
-	h, err := strconv.ParseInt(result.SyncInfo.LatestBlockHeight, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parsing latest_block_height %q: %w", result.SyncInfo.LatestBlockHeight, err)
 	}
 	if h <= 0 {
 		return 0, fmt.Errorf("latest_block_height is %d, node may still be syncing", h)
@@ -253,9 +243,8 @@ func queryLatestHeight(ctx context.Context, rpcEndpoint string) (int64, error) {
 	return h, nil
 }
 
-func queryBlockResults(ctx context.Context, rpcEndpoint string, height int64) (json.RawMessage, error) {
-	c := rpc.NewClient(rpcEndpoint, nil)
-	body, err := c.GetRaw(ctx, fmt.Sprintf("/block_results?height=%d", height))
+func queryBlockResults(ctx context.Context, client *rpc.Client, height int64) (json.RawMessage, error) {
+	body, err := client.GetRaw(ctx, fmt.Sprintf("/block_results?height=%d", height))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Prod hardening: sidecar observability and performance improvements.

### Changes

- **Prometheus metrics** — `seictl_task_duration_seconds` (histogram), `seictl_task_submissions_total`, `seictl_task_failures_total`. Exposed at `/v0/metrics` via `promhttp.Handler()`.
- **RPC connection pooling** — `Comparator` holds two `*rpc.Client` instances constructed once in `NewComparator`, reused across all block/block_results queries. Eliminates per-request `http.Client` allocation in the comparison hot loop.
- **`queryLatestHeight` consolidated** — replaced standalone function in `result_export.go` with `rpc.NewStatusClient().LatestHeight()`, eliminating duplicate `/status` parsing.
- **`queryBlockResults` pooled** — uses a shared `rpc.Client` instead of constructing per-call.

### Companion to

- sei-k8s-controller#51 (sidecar probes, SubmittedAt, submission logging)

## Test plan

- [x] `go test ./sidecar/rpc/` — pass
- [x] `go test ./sidecar/engine/` — pass
- [x] `go test ./sidecar/shadow/` — pass
- [x] `go test ./sidecar/server/` — pass
- [x] `go test ./sidecar/tasks/` — pass
- [x] `go build ./sidecar/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)