### PR TITLE
fix: bump sei-config to v0.0.12 (genesis params fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7
-	github.com/sei-protocol/sei-config v0.0.9
+	github.com/sei-protocol/sei-config v0.0.12
 	github.com/sei-protocol/seilog v0.0.3
 	github.com/urfave/cli/v3 v3.6.1
 	modernc.org/sqlite v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -1820,8 +1820,8 @@ github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQp
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:kW+yxMoSm4RvpP5VT5lFfSa+dqnOE9ZpapE2qNIJwvc=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
-github.com/sei-protocol/sei-config v0.0.9 h1:ELCpE0XnsTvgjOfWe1fWU43vqqFGL2tnlWuF9U1A2l8=
-github.com/sei-protocol/sei-config v0.0.9/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.12 h1:pv0IIM8c4sKPoNOvUEIx0OAp+X+coDlBibHUPbBZGxI=
+github.com/sei-protocol/sei-config v0.0.12/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082/go.mod h1:V0fNURAjS6A8+sA1VllegjNeSobay3oRUW5VFZd04bA=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=


### PR DESCRIPTION
## Summary

- Bumps sei-config from v0.0.9 to v0.0.12
- Picks up the genesis params fix for all three networks (sei-protocol/sei-config#5)

## Context

The `configure-genesis` sidecar task writes the embedded genesis from sei-config. Without the params module populated, seid v6.4.1 panics during `InitGenesis` with "cosmos gas multiplier numerator can not be 0". This blocks archive nodes from block syncing from genesis.

## Test plan
- [x] CI passes
- [x] Archive node cold start from genesis no longer panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)