### PR TITLE
feat(internal): cluster-cli foundation packages

### DIFF
--- a/internal/clioutput/envelope.go
+++ b/internal/clioutput/envelope.go
@@ -1,0 +1,123 @@
+// Package clioutput defines the JSON output envelope for cluster-facing
+// seictl subcommands and the exit-code / category enums that are part of
+// the public CLI contract.
+//
+// The shape here is the v2 MCP tool contract per docs/design/cluster-cli.md
+// — bumping Version is a breaking change for the sei-platform-engineer skill.
+package clioutput
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+const EnvelopeVersion = "v1"
+
+const (
+	ExitSuccess  = 0
+	ExitUsage    = 2
+	ExitNotFound = 3
+	ExitCluster  = 4
+	ExitRBAC     = 5
+	ExitBench    = 10
+	ExitOnboard  = 20
+	ExitIdentity = 40
+)
+
+const (
+	CatImagePolicy     = "image-policy"
+	CatImageResolution = "image-resolution"
+	CatValidation      = "validation"
+	CatNamespacePolicy = "namespace-policy"
+	CatApplyFailed     = "apply-failed"
+	CatNameCollision   = "name-collision"
+	CatFinalizerStuck  = "finalizer-stuck"
+	CatTemplateRender  = "template-render"
+
+	CatAliasInvalid        = "alias-invalid"
+	CatPlatformRepoMissing = "platform-repo-missing"
+	CatWorkingTreeDirty    = "working-tree-dirty"
+	CatGHUnauthenticated   = "gh-unauthenticated"
+	CatPRCreateFailed      = "pr-create-failed"
+	CatAWSCreateFailed     = "aws-create-failed"
+
+	CatMalformed       = "malformed"
+	CatMissing         = "missing"
+	CatKubeconfigParse = "kubeconfig-parse"
+	CatPermsLoose      = "perms-loose"
+)
+
+type Envelope struct {
+	Kind    string          `json:"kind"`
+	Version string          `json:"version"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Error   *ErrorBody      `json:"error,omitempty"`
+}
+
+type ErrorBody struct {
+	Code     int    `json:"code"`
+	Category string `json:"category"`
+	Message  string `json:"message"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+// Error is the CLI-side typed failure. Carries enough to populate ErrorBody
+// and choose the process exit code. Implements error.
+type Error struct {
+	Code     int
+	Category string
+	Message  string
+	Detail   string
+}
+
+func (e *Error) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("%s: %s (%s)", e.Category, e.Message, e.Detail)
+	}
+	return fmt.Sprintf("%s: %s", e.Category, e.Message)
+}
+
+func New(code int, category, message string) *Error {
+	return &Error{Code: code, Category: category, Message: message}
+}
+
+func Newf(code int, category, format string, args ...any) *Error {
+	return &Error{Code: code, Category: category, Message: fmt.Sprintf(format, args...)}
+}
+
+func (e *Error) WithDetail(detail string) *Error {
+	e.Detail = detail
+	return e
+}
+
+// Emit writes a success envelope to w. data is marshalled into the
+// envelope's Data field.
+func Emit(w io.Writer, kind string, data any) error {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshalling %s data: %w", kind, err)
+	}
+	env := Envelope{Kind: kind, Version: EnvelopeVersion, Data: raw}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
+}
+
+// EmitError writes an error envelope to w. Returns marshal errors only;
+// callers should not propagate those back to the user.
+func EmitError(w io.Writer, kind string, e *Error) error {
+	env := Envelope{
+		Kind:    kind,
+		Version: EnvelopeVersion,
+		Error: &ErrorBody{
+			Code:     e.Code,
+			Category: e.Category,
+			Message:  e.Message,
+			Detail:   e.Detail,
+		},
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
+}

--- a/internal/clioutput/envelope_test.go
+++ b/internal/clioutput/envelope_test.go
@@ -1,0 +1,138 @@
+package clioutput
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEmit_Success(t *testing.T) {
+	type sample struct {
+		Foo string `json:"foo"`
+		Bar int    `json:"bar"`
+	}
+
+	var buf bytes.Buffer
+	if err := Emit(&buf, "test.kind", sample{Foo: "hello", Bar: 42}); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Kind != "test.kind" {
+		t.Errorf("kind: got %q, want %q", env.Kind, "test.kind")
+	}
+	if env.Version != EnvelopeVersion {
+		t.Errorf("version: got %q, want %q", env.Version, EnvelopeVersion)
+	}
+	if env.Error != nil {
+		t.Errorf("error body should be nil on success, got %+v", env.Error)
+	}
+	var got sample
+	if err := json.Unmarshal(env.Data, &got); err != nil {
+		t.Fatalf("data unmarshal: %v", err)
+	}
+	if got.Foo != "hello" || got.Bar != 42 {
+		t.Errorf("data round-trip: got %+v, want {hello 42}", got)
+	}
+}
+
+func TestEmitError_Round_Trip(t *testing.T) {
+	var buf bytes.Buffer
+	cliErr := New(ExitBench, CatImagePolicy, "image registry not allowed").WithDetail("got: docker.io/foo")
+	if err := EmitError(&buf, "bench.up.result", cliErr); err != nil {
+		t.Fatalf("EmitError returned error: %v", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Kind != "bench.up.result" {
+		t.Errorf("kind: got %q", env.Kind)
+	}
+	if env.Error == nil {
+		t.Fatalf("error body should be populated")
+	}
+	if env.Error.Code != ExitBench {
+		t.Errorf("code: got %d, want %d", env.Error.Code, ExitBench)
+	}
+	if env.Error.Category != CatImagePolicy {
+		t.Errorf("category: got %q", env.Error.Category)
+	}
+	if env.Error.Message != "image registry not allowed" {
+		t.Errorf("message: got %q", env.Error.Message)
+	}
+	if env.Error.Detail != "got: docker.io/foo" {
+		t.Errorf("detail: got %q", env.Error.Detail)
+	}
+	if len(env.Data) != 0 {
+		t.Errorf("data should be empty on failure, got %s", env.Data)
+	}
+}
+
+func TestError_ErrorString(t *testing.T) {
+	tests := map[string]struct {
+		err  *Error
+		want string
+	}{
+		"no detail": {
+			err:  New(ExitIdentity, CatMissing, "engineer.json not found"),
+			want: "missing: engineer.json not found",
+		},
+		"with detail": {
+			err:  New(ExitBench, CatImagePolicy, "registry not allowed").WithDetail("got: docker.io"),
+			want: "image-policy: registry not allowed (got: docker.io)",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewf(t *testing.T) {
+	e := Newf(ExitOnboard, CatAliasInvalid, "alias %q failed regex", "BAD")
+	if !strings.Contains(e.Message, `"BAD"`) {
+		t.Errorf("Newf did not format args: %q", e.Message)
+	}
+	if e.Code != ExitOnboard {
+		t.Errorf("code: got %d", e.Code)
+	}
+}
+
+func TestExitCodes_Stable(t *testing.T) {
+	// Exit codes are part of the CLI contract per LLD §Exit codes.
+	// This test pins them so accidental renumbering fails loudly.
+	want := map[string]int{
+		"ExitSuccess":  0,
+		"ExitUsage":    2,
+		"ExitNotFound": 3,
+		"ExitCluster":  4,
+		"ExitRBAC":     5,
+		"ExitBench":    10,
+		"ExitOnboard":  20,
+		"ExitIdentity": 40,
+	}
+	got := map[string]int{
+		"ExitSuccess":  ExitSuccess,
+		"ExitUsage":    ExitUsage,
+		"ExitNotFound": ExitNotFound,
+		"ExitCluster":  ExitCluster,
+		"ExitRBAC":     ExitRBAC,
+		"ExitBench":    ExitBench,
+		"ExitOnboard":  ExitOnboard,
+		"ExitIdentity": ExitIdentity,
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s: got %d, want %d", k, got[k], v)
+		}
+	}
+}

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,0 +1,119 @@
+// Package identity manages ~/.seictl/engineer.json — the engineer's
+// alias and display name used to scope cluster-facing seictl commands.
+//
+// Per docs/design/cluster-cli.md §Identity file:
+//   - File mode 0600, parent dir 0700.
+//   - Read refuses to proceed if perms are loose.
+//   - Two fields: alias, name.
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+const (
+	FileMode os.FileMode = 0o600
+	DirMode  os.FileMode = 0o700
+)
+
+type Engineer struct {
+	Alias string `json:"alias"`
+	Name  string `json:"name"`
+}
+
+// DefaultPath returns ~/.seictl/engineer.json.
+func DefaultPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".seictl", "engineer.json"), nil
+}
+
+// Read returns the engineer record at path. Refuses if the file has any
+// group or world permission bits set.
+func Read(path string) (*Engineer, *clioutput.Error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMissing,
+				"engineer identity not found at %s; run `seictl onboard --alias <alias>`", path)
+		}
+		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"stat %s: %v", path, err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatPermsLoose,
+			"engineer identity file %s has loose permissions %#o; expected 0600", path, mode)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"read %s: %v", path, err)
+	}
+	var e Engineer
+	if err := json.Unmarshal(raw, &e); err != nil {
+		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"parse %s: %v", path, err)
+	}
+	if e.Alias == "" {
+		return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"engineer identity is missing required field: alias").WithDetail(path)
+	}
+	return &e, nil
+}
+
+// Write atomically writes the engineer record to path with mode 0600 and
+// ensures the parent directory is 0700. Refuses if an existing parent
+// directory has loose perms — silently tightening would mask a security
+// concern.
+func Write(path string, e Engineer) *clioutput.Error {
+	if e.Alias == "" {
+		return clioutput.New(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"alias is required")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, DirMode); err != nil {
+		return clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"create %s: %v", dir, err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"stat %s: %v", dir, err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		return clioutput.Newf(clioutput.ExitIdentity, clioutput.CatPermsLoose,
+			"directory %s has loose permissions %#o; tighten to 0700 and re-run", dir, mode)
+	}
+
+	raw, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"marshal engineer: %v", err)
+	}
+	raw = append(raw, '\n')
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, raw, FileMode); err != nil {
+		return clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"write %s: %v", tmp, err)
+	}
+	if err := os.Chmod(tmp, FileMode); err != nil {
+		_ = os.Remove(tmp)
+		return clioutput.Newf(clioutput.ExitIdentity, clioutput.CatPermsLoose,
+			"set %s mode %#o: %v", tmp, FileMode, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMalformed,
+			"rename %s -> %s: %v", tmp, path, err)
+	}
+	return nil
+}

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -1,0 +1,163 @@
+package identity
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+func TestWrite_RoundTrip(t *testing.T) {
+	// t.TempDir() returns a directory with mode 0755; Write refuses loose
+	// parents, so write into a fresh subdir it can create with 0700.
+	path := filepath.Join(t.TempDir(), "seictl", "engineer.json")
+
+	if err := Write(path, Engineer{Alias: "bdc", Name: "Brandon"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Alias != "bdc" || got.Name != "Brandon" {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatalf("stat: %v", statErr)
+	}
+	if mode := info.Mode().Perm(); mode != FileMode {
+		t.Errorf("file mode: got %#o, want %#o", mode, FileMode)
+	}
+}
+
+func TestWrite_CreatesParentDirWithStrictMode(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "nested", "engineer.json")
+
+	if err := Write(path, Engineer{Alias: "bdc", Name: "Brandon"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	dirInfo, statErr := os.Stat(filepath.Dir(path))
+	if statErr != nil {
+		t.Fatalf("stat dir: %v", statErr)
+	}
+	if mode := dirInfo.Mode().Perm(); mode != DirMode {
+		t.Errorf("dir mode: got %#o, want %#o", mode, DirMode)
+	}
+}
+
+func TestWrite_RefusesLooseParentDir(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "loose")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "engineer.json")
+
+	cliErr := Write(path, Engineer{Alias: "bdc", Name: "Brandon"})
+	if cliErr == nil {
+		t.Fatalf("expected refusal, got nil")
+	}
+	if cliErr.Category != clioutput.CatPermsLoose {
+		t.Errorf("category: got %q, want %q", cliErr.Category, clioutput.CatPermsLoose)
+	}
+}
+
+func TestWrite_RejectsEmptyAlias(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "engineer.json")
+
+	cliErr := Write(path, Engineer{Alias: "", Name: "Anon"})
+	if cliErr == nil || cliErr.Category != clioutput.CatMalformed {
+		t.Errorf("expected malformed error, got %+v", cliErr)
+	}
+}
+
+func TestRead_Missing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.json")
+	_, cliErr := Read(path)
+	if cliErr == nil {
+		t.Fatalf("expected error for missing file")
+	}
+	if cliErr.Code != clioutput.ExitIdentity {
+		t.Errorf("code: got %d, want %d", cliErr.Code, clioutput.ExitIdentity)
+	}
+	if cliErr.Category != clioutput.CatMissing {
+		t.Errorf("category: got %q, want %q", cliErr.Category, clioutput.CatMissing)
+	}
+}
+
+func TestRead_Malformed(t *testing.T) {
+	dir := tightTempDir(t)
+	path := filepath.Join(dir, "engineer.json")
+	if err := os.WriteFile(path, []byte("not-json"), FileMode); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, cliErr := Read(path)
+	if cliErr == nil || cliErr.Category != clioutput.CatMalformed {
+		t.Errorf("expected malformed, got %+v", cliErr)
+	}
+}
+
+func TestRead_MissingAliasField(t *testing.T) {
+	dir := tightTempDir(t)
+	path := filepath.Join(dir, "engineer.json")
+	body, _ := json.Marshal(Engineer{Name: "Anon"})
+	if err := os.WriteFile(path, body, FileMode); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, cliErr := Read(path)
+	if cliErr == nil || cliErr.Category != clioutput.CatMalformed {
+		t.Errorf("expected malformed, got %+v", cliErr)
+	}
+}
+
+func TestRead_RefusesLoosePerms(t *testing.T) {
+	dir := tightTempDir(t)
+	path := filepath.Join(dir, "engineer.json")
+	body, _ := json.Marshal(Engineer{Alias: "bdc", Name: "Brandon"})
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, cliErr := Read(path)
+	if cliErr == nil {
+		t.Fatalf("expected perms-loose error")
+	}
+	if cliErr.Category != clioutput.CatPermsLoose {
+		t.Errorf("category: got %q, want %q", cliErr.Category, clioutput.CatPermsLoose)
+	}
+}
+
+// tightTempDir returns a fresh subdirectory with mode 0700 — needed because
+// t.TempDir() returns the system default 0755, which Read rejects as loose.
+func tightTempDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "seictl")
+	if err := os.Mkdir(dir, DirMode); err != nil {
+		t.Fatalf("mkdir tight: %v", err)
+	}
+	return dir
+}
+
+func TestDefaultPath_PointsUnderHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir available")
+	}
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join(home, ".seictl", "engineer.json")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,144 @@
+// Package validate centralises input validation for cluster-facing
+// seictl commands. Every side-effecting subcommand calls these helpers
+// before any kubeconfig, AWS, or filesystem mutation.
+//
+// The regex shapes and the deny-list match docs/design/cluster-cli.md
+// §Input validation. Image validation is policy-only — it does not
+// resolve references to digests; that lives in internal/aws.
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+const (
+	AllowedRegistry   = "189176372795.dkr.ecr.us-east-2.amazonaws.com"
+	AllowedRepoPrefix = "sei/"
+
+	BenchSizeSmall  = "s"
+	BenchSizeMedium = "m"
+	BenchSizeLarge  = "l"
+
+	BenchDurationMin = 1
+	BenchDurationMax = 240
+
+	maxK8sLabel = 63
+)
+
+var (
+	aliasRe     = regexp.MustCompile(`^[a-z]([a-z0-9-]{0,28}[a-z0-9])?$`)
+	nameRe      = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$`)
+	namespaceRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+	aliasDenyList = map[string]struct{}{
+		"kube-system":     {},
+		"kube-public":     {},
+		"kube-node-lease": {},
+		"default":         {},
+		"autobake":        {},
+		"flux-system":     {},
+		"istio-system":    {},
+		"tide-agents":     {},
+	}
+)
+
+func Alias(s string) *clioutput.Error {
+	if !aliasRe.MatchString(s) {
+		return clioutput.Newf(clioutput.ExitOnboard, clioutput.CatAliasInvalid,
+			"alias %q does not match %s", s, aliasRe)
+	}
+	if _, denied := aliasDenyList[s]; denied {
+		return clioutput.Newf(clioutput.ExitOnboard, clioutput.CatAliasInvalid,
+			"alias %q is reserved", s)
+	}
+	return nil
+}
+
+// Name validates a benchmark name and enforces the combined
+// `bench-<alias>-<name>` chain-id stays within K8s' 63-char label cap.
+func Name(alias, name string) *clioutput.Error {
+	if !nameRe.MatchString(name) {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
+			"name %q does not match %s", name, nameRe)
+	}
+	chainID := fmt.Sprintf("bench-%s-%s", alias, name)
+	if len(chainID) > maxK8sLabel {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
+			"combined chain-id %q is %d chars, max %d", chainID, len(chainID), maxK8sLabel)
+	}
+	return nil
+}
+
+func Size(s string) *clioutput.Error {
+	switch s {
+	case BenchSizeSmall, BenchSizeMedium, BenchSizeLarge:
+		return nil
+	}
+	return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
+		"size %q is not one of s|m|l", s)
+}
+
+func DurationMinutes(n int) *clioutput.Error {
+	if n < BenchDurationMin || n > BenchDurationMax {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
+			"duration %d minutes is out of range [%d, %d]", n, BenchDurationMin, BenchDurationMax)
+	}
+	return nil
+}
+
+// Namespace enforces RFC-1123 label shape. If alias is non-empty, also
+// enforces the side-effecting-verb policy that the namespace equals
+// `eng-<alias>`. Pass empty alias for read-only verbs.
+func Namespace(ns, alias string) *clioutput.Error {
+	if len(ns) > maxK8sLabel || !namespaceRe.MatchString(ns) {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatNamespacePolicy,
+			"namespace %q is not a valid RFC-1123 label", ns)
+	}
+	if alias != "" {
+		want := "eng-" + alias
+		if ns != want {
+			return clioutput.Newf(clioutput.ExitBench, clioutput.CatNamespacePolicy,
+				"namespace must equal %q for engineer %q (got %q)", want, alias, ns)
+		}
+	}
+	return nil
+}
+
+// Image enforces the v1 registry policy: ECR-only, sei/* prefix, must
+// carry a tag or a digest. Digest resolution is handled later in
+// internal/aws — this is a pure shape and policy gate.
+func Image(ref string) *clioutput.Error {
+	if ref == "" {
+		return clioutput.New(clioutput.ExitBench, clioutput.CatImagePolicy,
+			"image is required")
+	}
+	slash := strings.IndexByte(ref, '/')
+	if slash < 0 {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+			"image %q is missing registry hostname", ref)
+	}
+	host := ref[:slash]
+	if host != AllowedRegistry {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+			"image registry must be %s (got %s)", AllowedRegistry, host)
+	}
+	rest := ref[slash+1:]
+	if !strings.HasPrefix(rest, AllowedRepoPrefix) {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+			"image repo must start with %q (got %q)", AllowedRepoPrefix, rest)
+	}
+	repoTail := rest[len(AllowedRepoPrefix):]
+	if repoTail == "" {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+			"image %q is missing repo name after %q", ref, AllowedRepoPrefix)
+	}
+	if !strings.ContainsAny(repoTail, ":@") {
+		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+			"image %q must specify a tag or digest", ref)
+	}
+	return nil
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,165 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+func TestAlias(t *testing.T) {
+	tests := map[string]struct {
+		in       string
+		wantErr  bool
+		category string
+	}{
+		"single letter":         {in: "a"},
+		"alphanumeric":          {in: "bdc"},
+		"with digits":           {in: "abc123"},
+		"with hyphen":           {in: "ab-cd"},
+		"max length 30":         {in: strings.Repeat("a", 30)},
+		"empty":                 {in: "", wantErr: true, category: clioutput.CatAliasInvalid},
+		"starts with digit":     {in: "1abc", wantErr: true, category: clioutput.CatAliasInvalid},
+		"starts with hyphen":    {in: "-abc", wantErr: true, category: clioutput.CatAliasInvalid},
+		"ends with hyphen":      {in: "abc-", wantErr: true, category: clioutput.CatAliasInvalid},
+		"underscore":            {in: "ab_c", wantErr: true, category: clioutput.CatAliasInvalid},
+		"uppercase":             {in: "BAD", wantErr: true, category: clioutput.CatAliasInvalid},
+		"too long":              {in: strings.Repeat("a", 31), wantErr: true, category: clioutput.CatAliasInvalid},
+		"reserved kube-system":  {in: "kube-system", wantErr: true, category: clioutput.CatAliasInvalid},
+		"reserved default":      {in: "default", wantErr: true, category: clioutput.CatAliasInvalid},
+		"reserved autobake":     {in: "autobake", wantErr: true, category: clioutput.CatAliasInvalid},
+		"reserved flux-system":  {in: "flux-system", wantErr: true, category: clioutput.CatAliasInvalid},
+		"reserved istio-system": {in: "istio-system", wantErr: true, category: clioutput.CatAliasInvalid},
+		"reserved tide-agents":  {in: "tide-agents", wantErr: true, category: clioutput.CatAliasInvalid},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Alias(tc.in)
+			if (got != nil) != tc.wantErr {
+				t.Errorf("Alias(%q) err=%v, wantErr=%v", tc.in, got, tc.wantErr)
+			}
+			if tc.wantErr && got != nil && got.Category != tc.category {
+				t.Errorf("category: got %q, want %q", got.Category, tc.category)
+			}
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	tests := map[string]struct {
+		alias, name string
+		wantErr     bool
+	}{
+		// Name regex caps `name` at 40 chars; the combined-too-long path
+		// is only reachable when `alias` is also long.
+		"basic":              {alias: "bdc", name: "demo"},
+		"name with digits":   {alias: "bdc", name: "v2-demo"},
+		"max name 40":        {alias: "bdc", name: strings.Repeat("a", 40)},
+		"name 41 fails":      {alias: "bdc", name: strings.Repeat("a", 41), wantErr: true},
+		"combined too long":  {alias: strings.Repeat("a", 30), name: strings.Repeat("b", 30), wantErr: true},
+		"name uppercase":     {alias: "bdc", name: "Demo", wantErr: true},
+		"name starts with -": {alias: "bdc", name: "-demo", wantErr: true},
+		"name ends with -":   {alias: "bdc", name: "demo-", wantErr: true},
+		"name empty":         {alias: "bdc", name: "", wantErr: true},
+	}
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			got := Name(tc.alias, tc.name)
+			if (got != nil) != tc.wantErr {
+				t.Errorf("Name(%q,%q) err=%v, wantErr=%v", tc.alias, tc.name, got, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSize(t *testing.T) {
+	for _, ok := range []string{"s", "m", "l"} {
+		if err := Size(ok); err != nil {
+			t.Errorf("Size(%q) unexpected err: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "x", "S", "small", "xl"} {
+		if err := Size(bad); err == nil {
+			t.Errorf("Size(%q) should fail", bad)
+		}
+	}
+}
+
+func TestDurationMinutes(t *testing.T) {
+	tests := map[string]struct {
+		n       int
+		wantErr bool
+	}{
+		"min":      {n: 1},
+		"max":      {n: 240},
+		"middle":   {n: 60},
+		"zero":     {n: 0, wantErr: true},
+		"negative": {n: -1, wantErr: true},
+		"over max": {n: 241, wantErr: true},
+		"way over": {n: 10000, wantErr: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := DurationMinutes(tc.n)
+			if (got != nil) != tc.wantErr {
+				t.Errorf("DurationMinutes(%d) err=%v, wantErr=%v", tc.n, got, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNamespace(t *testing.T) {
+	tests := map[string]struct {
+		ns, alias string
+		wantErr   bool
+		category  string
+	}{
+		"matches alias":      {ns: "eng-bdc", alias: "bdc"},
+		"read-only no alias": {ns: "eng-bdc", alias: ""},
+		"alias mismatch":     {ns: "eng-other", alias: "bdc", wantErr: true, category: clioutput.CatNamespacePolicy},
+		"too long":           {ns: strings.Repeat("a", 64), alias: "", wantErr: true, category: clioutput.CatNamespacePolicy},
+		"uppercase":          {ns: "Bad", alias: "", wantErr: true, category: clioutput.CatNamespacePolicy},
+		"underscore":         {ns: "bad_ns", alias: "", wantErr: true, category: clioutput.CatNamespacePolicy},
+		"starts with hyphen": {ns: "-bad", alias: "", wantErr: true, category: clioutput.CatNamespacePolicy},
+		"empty":              {ns: "", alias: "", wantErr: true, category: clioutput.CatNamespacePolicy},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Namespace(tc.ns, tc.alias)
+			if (got != nil) != tc.wantErr {
+				t.Errorf("Namespace(%q,%q) err=%v, wantErr=%v", tc.ns, tc.alias, got, tc.wantErr)
+			}
+			if tc.wantErr && got != nil && got.Category != tc.category {
+				t.Errorf("category: got %q, want %q", got.Category, tc.category)
+			}
+		})
+	}
+}
+
+func TestImage(t *testing.T) {
+	good := AllowedRegistry + "/" + AllowedRepoPrefix
+	tests := map[string]struct {
+		ref     string
+		wantErr bool
+	}{
+		"with tag":           {ref: good + "sei-chain:v1.2.3"},
+		"with digest":        {ref: good + "sei-chain@sha256:" + strings.Repeat("a", 64)},
+		"empty":              {ref: "", wantErr: true},
+		"no slash":           {ref: "sei-chain:v1", wantErr: true},
+		"wrong registry":     {ref: "docker.io/sei/sei-chain:v1", wantErr: true},
+		"missing sei prefix": {ref: AllowedRegistry + "/other/foo:v1", wantErr: true},
+		"empty repo":         {ref: AllowedRegistry + "/sei/", wantErr: true},
+		"no tag or digest":   {ref: good + "sei-chain", wantErr: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Image(tc.ref)
+			if (got != nil) != tc.wantErr {
+				t.Errorf("Image(%q) err=%v, wantErr=%v", tc.ref, got, tc.wantErr)
+			}
+			if got != nil && got.Category != clioutput.CatImagePolicy {
+				t.Errorf("category: got %q, want %q", got.Category, clioutput.CatImagePolicy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Vertical slice 1 of the cluster-cli LLD (#65) — the three leaf packages every cluster-facing command will depend on. No kube client, AWS client, or command wiring yet; this is pure foundation.

- `internal/clioutput` — `Envelope`, `ErrorBody`, exit-code constants, category enums, `Emit` / `EmitError` writers. The JSON shape here is the **v2 MCP tool contract** for the `sei-platform-engineer` skill (sei-protocol/Tide#8); bumping `EnvelopeVersion` is a breaking change.
- `internal/identity` — `~/.seictl/engineer.json` read/write. Mode 0600 enforced; loose-perms file rejected with `category: perms-loose` per LLD §Identity file. Parent dir created with 0700 when absent; refuses if existing parent is loose rather than silently tightening.
- `internal/validate` — alias / name / size / duration / namespace / image policy validators per LLD §Input validation. Image policy is shape-only (registry hostname + `sei/` prefix + tag-or-digest); digest resolution lives in `internal/aws` (deferred slice).

## What's deferred

- `internal/kube`, `internal/render`, `internal/aws` — wired in subsequent slices once command files need them.
- Image digest resolution — pushed to the AWS slice; validate is a pure-shape gate.
- Command files (`context.go`, `bench.go`, `onboard.go`) and `main.go` registration — slice 2 starts with `seictl context` since that locks the kube-client wiring with the smallest surface.

## Test plan

- [x] `go test ./internal/clioutput/... ./internal/identity/... ./internal/validate/...` passes
- [x] `gofmt -s -l internal/` clean
- [x] `go vet` clean on the three packages
- [x] Exit-code stability test pins the LLD §Exit codes matrix
- [x] Identity round-trip + loose-perms refusal + atomic write verified
- [x] Image policy: empty / wrong-registry / missing `sei/` prefix / tag-less all rejected with `category: image-policy`

> Note: `make test` reveals a pre-existing flake in `sidecar/tasks/typed_handler_integration_test.go` (`TestDeserialize_SnapshotUpload` 9-min hang) on `main`; unrelated to this PR.

## References

- LLD: `docs/design/cluster-cli.md` (#65)
- Skill: sei-protocol/Tide#8 (sei-platform-engineer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)