### PR TITLE
feat: bench up --dry-run

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/sei-protocol/seictl/internal/aws"
+	"github.com/sei-protocol/seictl/internal/clioutput"
+	"github.com/sei-protocol/seictl/internal/identity"
+	"github.com/sei-protocol/seictl/internal/render"
+	"github.com/sei-protocol/seictl/internal/validate"
+	"github.com/sei-protocol/seictl/templates"
+)
+
+const (
+	benchUpResultKind = "bench.up.result"
+	benchS3Bucket     = "harbor-sei-autobake-results"
+
+	// Vendored seiload image. Slice 3b will resolve to a digest at apply
+	// time; v1 dry-run emits the tag for visibility, fails-closed against
+	// non-ECR registries via internal/validate.Image.
+	defaultSeiloadImage = "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/seiload:latest"
+)
+
+var benchSizes = map[string]struct {
+	Validators int
+	RPC        int
+}{
+	"s": {Validators: 4, RPC: 1},
+	"m": {Validators: 10, RPC: 2},
+	"l": {Validators: 21, RPC: 4},
+}
+
+type benchUpResult struct {
+	ChainID      string               `json:"chainId"`
+	Name         string               `json:"name"`
+	Namespace    string               `json:"namespace"`
+	ImageRef     string               `json:"imageRef"`
+	ImageDigest  string               `json:"imageDigest"`
+	Size         string               `json:"size"`
+	Validators   int                  `json:"validators"`
+	RPCNodes     int                  `json:"rpcNodes"`
+	Duration     string               `json:"duration"`
+	ResultsS3URI string               `json:"resultsS3Uri"`
+	DryRun       bool                 `json:"dryRun"`
+	Manifests    []render.ManifestRef `json:"manifests"`
+	AppliedAt    *time.Time           `json:"appliedAt,omitempty"`
+}
+
+type benchUpInput struct {
+	Image    string
+	Name     string
+	Size     string
+	Duration int
+}
+
+type benchDeps struct {
+	resolveDigest func(context.Context, string) (string, *clioutput.Error)
+	identityPath  func() (string, error)
+}
+
+var defaultBenchDeps = benchDeps{
+	resolveDigest: aws.ResolveDigest,
+	identityPath:  identity.DefaultPath,
+}
+
+var benchCmd = cli.Command{
+	Name:  "bench",
+	Usage: "Manage benchmark workloads on the harbor cluster",
+	Commands: []*cli.Command{
+		{
+			Name:  "up",
+			Usage: "Render (slice 3a) or apply (slice 3b) a benchmark workload",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "image", Required: true, Usage: "ECR image ref to bench"},
+				&cli.StringFlag{Name: "name", Required: true, Usage: "Bench name (forms part of chain-id)"},
+				&cli.StringFlag{Name: "size", Value: "s", Usage: "s|m|l"},
+				&cli.IntFlag{Name: "duration", Value: 30, Usage: "Bench duration in minutes (1-240)"},
+			},
+			Action: func(ctx context.Context, command *cli.Command) error {
+				return runBenchUp(ctx, benchUpInput{
+					Image:    command.String("image"),
+					Name:     command.String("name"),
+					Size:     command.String("size"),
+					Duration: int(command.Int("duration")),
+				}, os.Stdout, defaultBenchDeps)
+			},
+		},
+	},
+}
+
+func runBenchUp(ctx context.Context, in benchUpInput, out io.Writer, deps benchDeps) error {
+	eng, idErr := loadEngineer(deps.identityPath)
+	if idErr != nil {
+		return failBenchUp(out, idErr)
+	}
+
+	if e := validate.Image(in.Image); e != nil {
+		return failBenchUp(out, e)
+	}
+	if e := validate.Name(eng.Alias, in.Name); e != nil {
+		return failBenchUp(out, e)
+	}
+	if e := validate.Size(in.Size); e != nil {
+		return failBenchUp(out, e)
+	}
+	if e := validate.DurationMinutes(in.Duration); e != nil {
+		return failBenchUp(out, e)
+	}
+
+	namespace := "eng-" + eng.Alias
+	if e := validate.Namespace(namespace, eng.Alias); e != nil {
+		return failBenchUp(out, e)
+	}
+
+	digest, dErr := deps.resolveDigest(ctx, in.Image)
+	if dErr != nil {
+		return failBenchUp(out, dErr)
+	}
+	seidImage := digestPinned(in.Image, digest)
+	if err := aws.AssertECRDigestRef(seidImage); err != nil {
+		return failBenchUp(out, clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+			"%v", err))
+	}
+
+	chainID := fmt.Sprintf("bench-%s-%s", eng.Alias, in.Name)
+	digestShort := shortDigest(digest)
+	s3URI := fmt.Sprintf("s3://%s/%s/%s/%s/report.log", benchS3Bucket, chainID, digestShort, chainID)
+	sizeProfile := benchSizes[in.Size]
+
+	manifests, err := renderManifests(eng.Alias, in.Name, namespace, chainID, seidImage,
+		digestShort, sizeProfile.Validators, sizeProfile.RPC, in.Duration)
+	if err != nil {
+		return failBenchUp(out, err)
+	}
+
+	res := benchUpResult{
+		ChainID:      chainID,
+		Name:         in.Name,
+		Namespace:    namespace,
+		ImageRef:     in.Image,
+		ImageDigest:  digest,
+		Size:         in.Size,
+		Validators:   sizeProfile.Validators,
+		RPCNodes:     sizeProfile.RPC,
+		Duration:     fmt.Sprintf("%dm", in.Duration),
+		ResultsS3URI: s3URI,
+		DryRun:       true,
+		Manifests:    manifests,
+	}
+	if err := clioutput.Emit(out, benchUpResultKind, res); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+func loadEngineer(pathFn func() (string, error)) (*identity.Engineer, *clioutput.Error) {
+	path, err := pathFn()
+	if err != nil {
+		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatMissing,
+			"resolve identity path: %v", err)
+	}
+	return identity.Read(path)
+}
+
+// renderManifests builds the four-document YAML stream the bench
+// produces (validator SND, RPC SND, seiload Job, profile ConfigMap)
+// and extracts a ManifestRef per document.
+func renderManifests(alias, name, namespace, chainID, seidImage, digestShort string,
+	validators, rpcCount, durationMin int) ([]render.ManifestRef, *clioutput.Error) {
+	vars := map[string]string{
+		"CHAIN_ID":             chainID,
+		"NAMESPACE":            namespace,
+		"ENGINEER_ALIAS":       alias,
+		"BENCH_NAME":           name,
+		"SEID_IMAGE":           seidImage,
+		"SEILOAD_IMAGE":        defaultSeiloadImage,
+		"IMAGE_DIGEST_SHORT":   digestShort,
+		"VALIDATOR_COUNT":      strconv.Itoa(validators),
+		"RPC_COUNT":            strconv.Itoa(rpcCount),
+		"JOB_DEADLINE_SECONDS": strconv.Itoa(durationMin * 60),
+	}
+
+	sndYAML, e := renderEmbedded("snd.yaml", vars)
+	if e != nil {
+		return nil, e
+	}
+	jobYAML, e := renderEmbedded("seiload-job.yaml", vars)
+	if e != nil {
+		return nil, e
+	}
+
+	profileBody, e := renderEmbedded("seiload-profile.json", map[string]string{
+		"CHAIN_ID":      chainID,
+		"RPC_ENDPOINTS": rpcEndpointsJSON(chainID, namespace, rpcCount),
+	})
+	if e != nil {
+		return nil, e
+	}
+
+	cmVars := make(map[string]string, len(vars)+1)
+	for k, v := range vars {
+		cmVars[k] = v
+	}
+	cmVars["PROFILE_BODY_INDENTED"] = render.Indent(strings.TrimRight(string(profileBody), "\n"), "    ")
+	cmYAML, e := renderEmbedded("profile-cm.yaml", cmVars)
+	if e != nil {
+		return nil, e
+	}
+
+	stream := bytes.Join([][]byte{sndYAML, jobYAML, cmYAML}, []byte("\n---\n"))
+	var refs []render.ManifestRef
+	for _, doc := range render.SplitYAML(stream) {
+		ref, err := render.ExtractRef(doc)
+		if err != nil {
+			return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatTemplateRender,
+				"extract manifest ref: %v", err)
+		}
+		ref.Action = "create"
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+func renderEmbedded(name string, vars map[string]string) ([]byte, *clioutput.Error) {
+	raw, err := templates.FS.ReadFile(name)
+	if err != nil {
+		return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatTemplateRender,
+			"read embedded template %s: %v", name, err)
+	}
+	return render.Render(raw, vars)
+}
+
+func failBenchUp(out io.Writer, e *clioutput.Error) error {
+	_ = clioutput.EmitError(out, benchUpResultKind, e)
+	return cli.Exit("", e.Code)
+}
+
+// digestPinned strips any tag or digest from ref and re-pins to the
+// given digest, producing host/repo@sha256:....
+func digestPinned(ref, digest string) string {
+	slash := strings.IndexByte(ref, '/')
+	host := ref[:slash]
+	rest := ref[slash+1:]
+	if at := strings.IndexByte(rest, '@'); at >= 0 {
+		rest = rest[:at]
+	} else if colon := strings.IndexByte(rest, ':'); colon >= 0 {
+		rest = rest[:colon]
+	}
+	return host + "/" + rest + "@" + digest
+}
+
+// shortDigest returns the first 12 hex characters of a sha256 digest,
+// matching the autobake S3 path partition convention.
+func shortDigest(d string) string {
+	i := strings.IndexByte(d, ':')
+	if i < 0 || len(d) < i+1+12 {
+		return d
+	}
+	return d[i+1 : i+1+12]
+}
+
+// rpcEndpointsJSON renders the JSON-array body for the seiload profile's
+// `endpoints` field. RPC service DNS resolves at apply time; dry-run
+// emits the predictable cluster-local form.
+func rpcEndpointsJSON(chainID, namespace string, rpcCount int) string {
+	var sb strings.Builder
+	for i := 0; i < rpcCount; i++ {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("%q",
+			fmt.Sprintf("http://%s-rpc.%s.svc.cluster.local:8545", chainID, namespace)))
+	}
+	return sb.String()
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+	"github.com/sei-protocol/seictl/internal/identity"
+)
+
+const benchTestDigest = "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd"
+
+func writeEngineerFile(t *testing.T, alias string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "seictl")
+	path := filepath.Join(root, "engineer.json")
+	if err := identity.Write(path, identity.Engineer{Alias: alias, Name: "Test"}); err != nil {
+		t.Fatalf("seed identity: %+v", err)
+	}
+	return path
+}
+
+func stubBenchDeps(t *testing.T, alias string) benchDeps {
+	t.Helper()
+	path := writeEngineerFile(t, alias)
+	return benchDeps{
+		resolveDigest: func(context.Context, string) (string, *clioutput.Error) {
+			return benchTestDigest, nil
+		},
+		identityPath: func() (string, error) { return path, nil },
+	}
+}
+
+func TestRunBenchUp(t *testing.T) {
+	t.Run("dry-run emits BenchUpResult envelope for size s", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1.2.3",
+			Name:     "demo",
+			Size:     "s",
+			Duration: 5,
+		}, &buf, stubBenchDeps(t, "bdc"))
+		if err != nil {
+			t.Fatalf("runBenchUp: %v\nbody=%s", err, buf.String())
+		}
+
+		var env clioutput.Envelope
+		if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+			t.Fatalf("envelope unmarshal: %v\n%s", err, buf.String())
+		}
+		if env.Kind != benchUpResultKind || env.Version != "v1" {
+			t.Errorf("envelope: kind=%q version=%q", env.Kind, env.Version)
+		}
+		if env.Error != nil {
+			t.Fatalf("error body should be nil; got %+v\nbody=%s", env.Error, buf.String())
+		}
+		var data benchUpResult
+		if err := json.Unmarshal(env.Data, &data); err != nil {
+			t.Fatalf("data unmarshal: %v", err)
+		}
+
+		if data.ChainID != "bench-bdc-demo" {
+			t.Errorf("chainId: %q", data.ChainID)
+		}
+		if data.Namespace != "eng-bdc" {
+			t.Errorf("namespace: %q", data.Namespace)
+		}
+		if data.ImageDigest != benchTestDigest {
+			t.Errorf("digest: %q", data.ImageDigest)
+		}
+		if data.Validators != 4 || data.RPCNodes != 1 {
+			t.Errorf("size profile s: validators=%d rpc=%d", data.Validators, data.RPCNodes)
+		}
+		if !data.DryRun {
+			t.Errorf("dryRun should be true")
+		}
+		// Per LLD §`bench up`: `s3://harbor-sei-autobake-results/<chain-id>/<image-sha-12>/<chain-id>/report.log`
+		want := "s3://harbor-sei-autobake-results/bench-bdc-demo/1234567890ab/bench-bdc-demo/report.log"
+		if data.ResultsS3URI != want {
+			t.Errorf("s3 uri: got %q, want %q", data.ResultsS3URI, want)
+		}
+		if len(data.Manifests) != 4 {
+			t.Fatalf("expected 4 manifests (validator SND, rpc SND, seiload Job, profile CM); got %d", len(data.Manifests))
+		}
+
+		// Spot-check kinds and namespacing — every manifest must live in eng-bdc.
+		seenKinds := map[string]bool{}
+		for _, m := range data.Manifests {
+			seenKinds[m.Kind] = true
+			if m.Namespace != "eng-bdc" {
+				t.Errorf("manifest %s/%s namespace: got %q, want eng-bdc", m.Kind, m.Name, m.Namespace)
+			}
+			if m.Action != "create" {
+				t.Errorf("dry-run action: got %q", m.Action)
+			}
+		}
+		if !seenKinds["SeiNodeDeployment"] || !seenKinds["Job"] || !seenKinds["ConfigMap"] {
+			t.Errorf("expected kinds {SeiNodeDeployment,Job,ConfigMap}; got %v", seenKinds)
+		}
+	})
+
+	t.Run("size m yields 10 validators / 2 rpc", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Name:     "load",
+			Size:     "m",
+			Duration: 30,
+		}, &buf, stubBenchDeps(t, "bdc"))
+		if err != nil {
+			t.Fatalf("runBenchUp: %v", err)
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data benchUpResult
+		_ = json.Unmarshal(env.Data, &data)
+		if data.Validators != 10 || data.RPCNodes != 2 {
+			t.Errorf("size m: %d / %d", data.Validators, data.RPCNodes)
+		}
+	})
+
+	t.Run("rejects non-ECR image", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "docker.io/sei/sei-chain:v1",
+			Name:     "demo",
+			Size:     "s",
+			Duration: 30,
+		}, &buf, stubBenchDeps(t, "bdc"))
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		exitCoder, ok := err.(interface{ ExitCode() int })
+		if !ok || exitCoder.ExitCode() != clioutput.ExitBench {
+			t.Errorf("exit code: %v", err)
+		}
+		if !strings.Contains(buf.String(), "image-policy") {
+			t.Errorf("expected image-policy category; got %s", buf.String())
+		}
+	})
+
+	t.Run("rejects bad size", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Name:     "demo",
+			Size:     "xl",
+			Duration: 30,
+		}, &buf, stubBenchDeps(t, "bdc"))
+		if err == nil || !strings.Contains(buf.String(), "validation") {
+			t.Errorf("expected validation error; got err=%v body=%s", err, buf.String())
+		}
+	})
+
+	t.Run("propagates digest-resolution errors", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		deps := benchDeps{
+			resolveDigest: func(context.Context, string) (string, *clioutput.Error) {
+				return "", clioutput.New(clioutput.ExitBench, clioutput.CatImageResolution, "ecr unavailable")
+			},
+			identityPath: func() (string, error) { return path, nil },
+		}
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Name:     "demo",
+			Size:     "s",
+			Duration: 5,
+		}, &buf, deps)
+		if err == nil || !strings.Contains(buf.String(), "image-resolution") {
+			t.Errorf("expected image-resolution error; got %s", buf.String())
+		}
+	})
+
+	t.Run("missing identity surfaces typed error", func(t *testing.T) {
+		deps := benchDeps{
+			resolveDigest: func(context.Context, string) (string, *clioutput.Error) {
+				return benchTestDigest, nil
+			},
+			identityPath: func() (string, error) { return "", errors.New("home unset") },
+		}
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Name:     "demo",
+			Size:     "s",
+			Duration: 5,
+		}, &buf, deps)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(buf.String(), `"category": "missing"`) {
+			t.Errorf("expected missing identity error; got %s", buf.String())
+		}
+	})
+}
+
+func TestDigestPinned(t *testing.T) {
+	tests := map[string]struct {
+		ref, digest, want string
+	}{
+		"tag": {
+			ref:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			digest: benchTestDigest,
+			want:   "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain@" + benchTestDigest,
+		},
+		"already digested": {
+			ref:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain@sha256:" + strings.Repeat("a", 64),
+			digest: benchTestDigest,
+			want:   "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain@" + benchTestDigest,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := digestPinned(tc.ref, tc.digest); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShortDigest(t *testing.T) {
+	if got := shortDigest("sha256:1234567890abcdef1234567890abcdef"); got != "1234567890ab" {
+		t.Errorf("got %q", got)
+	}
+	if got := shortDigest("not-a-digest"); got != "not-a-digest" {
+		t.Errorf("non-prefixed pass-through: %q", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/sei-protocol/seictl
 go 1.25.6
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.4
+	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.293.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9
-	github.com/aws/smithy-go v1.24.2
+	github.com/aws/smithy-go v1.25.0
 	github.com/ethereum/go-ethereum v1.16.8
 	github.com/google/uuid v1.6.0
 	github.com/leanovate/gopter v0.2.11
@@ -54,10 +54,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.293.0
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9
 	github.com/aws/smithy-go v1.25.0
@@ -20,6 +21,7 @@ require (
 	github.com/sei-protocol/sei-config v0.0.12
 	github.com/sei-protocol/seilog v0.0.3
 	github.com/urfave/cli/v3 v3.6.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/client-go v0.35.0
 	modernc.org/sqlite v1.18.1
 )
@@ -58,7 +60,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 // indirect
@@ -222,7 +223,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.35.0 // indirect
 	k8s.io/component-base v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -702,6 +702,8 @@ github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZw
 github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
 github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
 github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
+github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.18.45/go.mod h1:ZwDUgFnQgsazQTnWfeLWk5GjeqTQTL8lMkoE1UXzxdE=
@@ -718,9 +720,13 @@ github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10/go.mod h1:KwaiUF
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43/go.mod h1:auo+PiyLl0n1l8A0e8RIeR8tOzYPfZZH/JNlrJ8igTQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37/go.mod h1:Qe+2KtKml+FEsQF/DHmDV+xjtche/hwoF75EG4UlHW8=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.45/go.mod h1:lD5M20o09/LCuQ2mE62Mb/iSdSlCNuj6H5ci7tW7OsE=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
@@ -728,6 +734,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21 h1:SwGMTMLIlvDNyhMteQ6r8IJSBPl
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21/go.mod h1:UUxgWxofmOdAMuqEsSppbDtGKLfR04HGsD0HXzvhI1k=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.293.0 h1:dgdIaG/GCiXMo16HAdFwpjt9Vn34bD2WVH5SiZdwzUc=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.293.0/go.mod h1:2dMnUs1QzlGzsm46i9oBHAxVHQp7b6qF7PljWcgVEVE=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1 h1:G/O4muLF2pe1UJBKEyF7J+kdokEEqFJjm42cU68FqH4=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1/go.mod h1:KBzTxiBlQ2bB5XT367+t18i3Qe7NZDRyGKxdzN43aOw=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7/go.mod h1:x0nZssQ3qZSnIcePWLvcoFisRXJzcTVvYpAAdYX8+GI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 h1:qtJZ70afD3ISKWnoX3xB0J2otEqu3LqicRcDBqsj0hQ=
@@ -754,6 +762,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle
 github.com/aws/smithy-go v1.15.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
+github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/immutable v0.4.3 h1:GYHcksoJ9K6HyAUpGxwZURrbTkXA0Dh4otXGqbhdrjA=

--- a/go.sum
+++ b/go.sum
@@ -700,8 +700,6 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
-github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
-github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
 github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
@@ -718,13 +716,9 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20/go.mod h1:z/MVwUARehy6GAg
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10 h1:2KCL4TmeiNvpPedtC4Bey5jvjRLD74WUYqGeHJ//aco=
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10/go.mod h1:KwaiUFVO7pG8Z9F5bMGvvrRibdSDaAu8HtlKGKkjZSA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43/go.mod h1:auo+PiyLl0n1l8A0e8RIeR8tOzYPfZZH/JNlrJ8igTQ=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37/go.mod h1:Qe+2KtKml+FEsQF/DHmDV+xjtche/hwoF75EG4UlHW8=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.45/go.mod h1:lD5M20o09/LCuQ2mE62Mb/iSdSlCNuj6H5ci7tW7OsE=
@@ -760,8 +754,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.23.2/go.mod h1:Eows6e1uQEsc4ZaHANmsP
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 h1:Cng+OOwCHmFljXIxpEVXAGMnBia8MSU6Ch5i9PgBkcU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle+gyCwTlizzW5ycgWnvIxkk=
 github.com/aws/smithy-go v1.15.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
-github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
 github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=

--- a/internal/aws/ecr.go
+++ b/internal/aws/ecr.go
@@ -1,0 +1,108 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	awscfg "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+// ResolveDigest converts an ECR image reference (registry/repo:tag) into
+// its sha256 digest. References already pinned to a digest are returned
+// as-is without an ECR round-trip.
+//
+// The registry hostname is parsed for AWS account + region — the
+// registry policy in internal/validate constrains it to a single
+// account, but the hostname remains the source of truth so a future
+// per-engineer-ECR rollout doesn't require touching this code.
+func ResolveDigest(ctx context.Context, ref string) (string, *clioutput.Error) {
+	host, repo, tag, digest, parseErr := parseImageRef(ref)
+	if parseErr != nil {
+		return "", parseErr
+	}
+	if digest != "" {
+		return digest, nil
+	}
+
+	account, region, err := parseECRHost(host)
+	if err != nil {
+		return "", err
+	}
+
+	cfg, awsErr := awscfg.LoadDefaultConfig(ctx, awscfg.WithRegion(region))
+	if awsErr != nil {
+		return "", clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+			"load AWS config: %v", awsErr)
+	}
+	out, awsErr := ecr.NewFromConfig(cfg).DescribeImages(ctx, &ecr.DescribeImagesInput{
+		RegistryId:     awssdk.String(account),
+		RepositoryName: awssdk.String(repo),
+		ImageIds:       []types.ImageIdentifier{{ImageTag: awssdk.String(tag)}},
+	})
+	if awsErr != nil {
+		return "", clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+			"ecr describe-images %s:%s: %v", repo, tag, awsErr)
+	}
+	if len(out.ImageDetails) == 0 || out.ImageDetails[0].ImageDigest == nil {
+		return "", clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+			"ecr returned no digest for %s:%s", repo, tag)
+	}
+	return awssdk.ToString(out.ImageDetails[0].ImageDigest), nil
+}
+
+// parseImageRef splits a fully-qualified ECR ref into host, repo, tag,
+// digest. Exactly one of (tag, digest) is populated. Caller must have
+// already validated the registry policy via internal/validate.Image.
+func parseImageRef(ref string) (host, repo, tag, digest string, err *clioutput.Error) {
+	slash := strings.IndexByte(ref, '/')
+	if slash < 0 {
+		return "", "", "", "", clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+			"image %q is missing registry hostname", ref)
+	}
+	host = ref[:slash]
+	rest := ref[slash+1:]
+	if at := strings.IndexByte(rest, '@'); at >= 0 {
+		digest = rest[at+1:]
+		if !strings.HasPrefix(digest, "sha256:") {
+			return "", "", "", "", clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+				"digest %q must be sha256:...", digest)
+		}
+		return host, rest[:at], "", digest, nil
+	}
+	if colon := strings.IndexByte(rest, ':'); colon >= 0 {
+		return host, rest[:colon], rest[colon+1:], "", nil
+	}
+	return "", "", "", "", clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+		"image %q must specify a tag or digest", ref)
+}
+
+// parseECRHost extracts the AWS account and region from
+// `<account>.dkr.ecr.<region>.amazonaws.com`.
+func parseECRHost(host string) (account, region string, err *clioutput.Error) {
+	parts := strings.Split(host, ".")
+	if len(parts) != 6 || parts[1] != "dkr" || parts[2] != "ecr" || parts[4] != "amazonaws" || parts[5] != "com" {
+		return "", "", clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution,
+			"hostname %q is not an ECR endpoint", host)
+	}
+	return parts[0], parts[3], nil
+}
+
+// AssertECRDigestRef returns an actionable error if ref is not a
+// digest-pinned ECR reference. Used at render time to guarantee
+// manifests never carry a tag.
+func AssertECRDigestRef(ref string) error {
+	_, _, _, digest, err := parseImageRef(ref)
+	if err != nil {
+		return fmt.Errorf("image %q is not a valid ECR ref: %s", ref, err.Message)
+	}
+	if digest == "" {
+		return fmt.Errorf("image %q must be digest-pinned (got tag)", ref)
+	}
+	return nil
+}

--- a/internal/aws/ecr_test.go
+++ b/internal/aws/ecr_test.go
@@ -1,0 +1,92 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+func TestParseImageRef(t *testing.T) {
+	tests := map[string]struct {
+		ref        string
+		wantHost   string
+		wantRepo   string
+		wantTag    string
+		wantDigest string
+		wantErrCat string
+	}{
+		"with tag": {
+			ref:      "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1.2.3",
+			wantHost: "189176372795.dkr.ecr.us-east-2.amazonaws.com",
+			wantRepo: "sei/sei-chain",
+			wantTag:  "v1.2.3",
+		},
+		"with digest": {
+			ref:        "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain@sha256:" + strings.Repeat("a", 64),
+			wantHost:   "189176372795.dkr.ecr.us-east-2.amazonaws.com",
+			wantRepo:   "sei/sei-chain",
+			wantDigest: "sha256:" + strings.Repeat("a", 64),
+		},
+		"missing slash":     {ref: "sei-chain:v1", wantErrCat: clioutput.CatImageResolution},
+		"no tag or digest":  {ref: "host.example.com/sei/sei-chain", wantErrCat: clioutput.CatImageResolution},
+		"non-sha256 digest": {ref: "host.example.com/sei/sei-chain@md5:abc", wantErrCat: clioutput.CatImageResolution},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			host, repo, tag, digest, err := parseImageRef(tc.ref)
+			if tc.wantErrCat != "" {
+				if err == nil || err.Category != tc.wantErrCat {
+					t.Fatalf("error: got %+v, want category %q", err, tc.wantErrCat)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %+v", err)
+			}
+			if host != tc.wantHost || repo != tc.wantRepo || tag != tc.wantTag || digest != tc.wantDigest {
+				t.Errorf("got (%q,%q,%q,%q)", host, repo, tag, digest)
+			}
+		})
+	}
+}
+
+func TestParseECRHost(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		account, region, err := parseECRHost("189176372795.dkr.ecr.us-east-2.amazonaws.com")
+		if err != nil {
+			t.Fatalf("err: %+v", err)
+		}
+		if account != "189176372795" || region != "us-east-2" {
+			t.Errorf("got %q / %q", account, region)
+		}
+	})
+	t.Run("not ECR", func(t *testing.T) {
+		_, _, err := parseECRHost("docker.io")
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestAssertECRDigestRef(t *testing.T) {
+	good := "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain@sha256:" + strings.Repeat("a", 64)
+	if err := AssertECRDigestRef(good); err != nil {
+		t.Errorf("digest ref should pass: %v", err)
+	}
+	if err := AssertECRDigestRef("189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1"); err == nil {
+		t.Errorf("tag ref must fail")
+	}
+}
+
+func TestResolveDigest_PassThroughDigest(t *testing.T) {
+	// Already digested — must not call ECR.
+	ref := "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain@sha256:" + strings.Repeat("b", 64)
+	got, err := ResolveDigest(nil, ref)
+	if err != nil {
+		t.Fatalf("err: %+v", err)
+	}
+	if got != "sha256:"+strings.Repeat("b", 64) {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -1,0 +1,132 @@
+// Package render handles ${VAR}-style substitution and YAML
+// document splitting for templates rendered by `seictl bench up`.
+//
+// Substitution uses os.Expand and is fail-closed: any unresolved ${VAR}
+// in a template returns CatTemplateRender so the engineer sees the gap
+// rather than an empty-string-laundered manifest.
+package render
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+// Render substitutes ${VAR} occurrences in tmpl with values from vars.
+// Errors with the deduplicated, sorted list of missing keys.
+func Render(tmpl []byte, vars map[string]string) ([]byte, *clioutput.Error) {
+	missing := map[string]struct{}{}
+	out := os.Expand(string(tmpl), func(key string) string {
+		v, ok := vars[key]
+		if !ok {
+			missing[key] = struct{}{}
+		}
+		return v
+	})
+	if len(missing) > 0 {
+		keys := make([]string, 0, len(missing))
+		for k := range missing {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatTemplateRender,
+			"template references undefined vars: %v", keys)
+	}
+	return []byte(out), nil
+}
+
+// Indent left-pads every line of body with prefix. Trailing whitespace
+// and a single trailing newline are preserved as the input had them.
+func Indent(body, prefix string) string {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ManifestRef is the minimal manifest metadata bench up emits per
+// rendered document.
+type ManifestRef struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Action    string `json:"action"`
+}
+
+// SplitYAML returns each non-empty document from a multi-doc YAML
+// stream. The split happens on YAML document boundaries (a `---` line
+// at column zero), preserving each document's original formatting.
+// Comment-only documents (e.g., a provenance preamble at the top of a
+// file before the first `---`) are filtered out — they carry no
+// manifest data and would fail downstream Kind/Name extraction.
+func SplitYAML(data []byte) [][]byte {
+	var (
+		docs    [][]byte
+		current []byte
+	)
+	flush := func() {
+		buf := bytes.TrimSpace(current)
+		if len(buf) > 0 && !isCommentOnly(buf) {
+			docs = append(docs, append([]byte(nil), buf...))
+		}
+		current = current[:0]
+	}
+	for _, line := range bytes.SplitAfter(data, []byte("\n")) {
+		if bytes.Equal(bytes.TrimRight(line, "\r\n"), []byte("---")) {
+			flush()
+			continue
+		}
+		current = append(current, line...)
+	}
+	flush()
+	return docs
+}
+
+func isCommentOnly(doc []byte) bool {
+	for _, line := range bytes.Split(doc, []byte("\n")) {
+		t := bytes.TrimSpace(line)
+		if len(t) == 0 {
+			continue
+		}
+		if t[0] != '#' {
+			return false
+		}
+	}
+	return true
+}
+
+// ExtractRef pulls Kind / metadata.name / metadata.namespace from a
+// rendered Kubernetes manifest. Action is left to the caller (dry-run
+// reports "create"; --apply distinguishes create/update/unchanged).
+func ExtractRef(doc []byte) (ManifestRef, error) {
+	var m struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name      string `yaml:"name"`
+			Namespace string `yaml:"namespace"`
+		} `yaml:"metadata"`
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(doc))
+	if err := dec.Decode(&m); err != nil && !errors.Is(err, io.EOF) {
+		return ManifestRef{}, fmt.Errorf("parse manifest: %w", err)
+	}
+	if m.Kind == "" {
+		return ManifestRef{}, errors.New("manifest missing kind")
+	}
+	if m.Metadata.Name == "" {
+		return ManifestRef{}, errors.New("manifest missing metadata.name")
+	}
+	return ManifestRef{Kind: m.Kind, Name: m.Metadata.Name, Namespace: m.Metadata.Namespace}, nil
+}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -1,0 +1,124 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/internal/clioutput"
+)
+
+func TestRender(t *testing.T) {
+	t.Run("substitutes simple vars", func(t *testing.T) {
+		out, err := Render([]byte("hello ${NAME}, chain=${CHAIN_ID}"),
+			map[string]string{"NAME": "bdc", "CHAIN_ID": "bench-bdc-demo"})
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		if string(out) != "hello bdc, chain=bench-bdc-demo" {
+			t.Errorf("got %q", string(out))
+		}
+	})
+
+	t.Run("fails closed on missing vars", func(t *testing.T) {
+		_, err := Render([]byte("${A} and ${B} and ${A}"), map[string]string{"A": "x"})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if err.Category != clioutput.CatTemplateRender {
+			t.Errorf("category: %q", err.Category)
+		}
+		// Missing var list should be deduped + sorted.
+		if !strings.Contains(err.Message, "[B]") {
+			t.Errorf("expected [B] in message, got %q", err.Message)
+		}
+	})
+
+	t.Run("multiple missing vars are deduped and sorted", func(t *testing.T) {
+		_, err := Render([]byte("${C}${A}${B}${A}"), map[string]string{})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Message, "[A B C]") {
+			t.Errorf("expected sorted dedup list, got %q", err.Message)
+		}
+	})
+}
+
+func TestSplitYAML(t *testing.T) {
+	t.Run("two docs", func(t *testing.T) {
+		input := []byte(`---
+kind: A
+metadata:
+  name: a1
+---
+kind: B
+metadata:
+  name: b1
+`)
+		docs := SplitYAML(input)
+		if len(docs) != 2 {
+			t.Fatalf("docs: got %d, want 2", len(docs))
+		}
+		if !strings.Contains(string(docs[0]), "a1") || !strings.Contains(string(docs[1]), "b1") {
+			t.Errorf("doc contents wrong: %s | %s", docs[0], docs[1])
+		}
+	})
+
+	t.Run("single doc no leading separator", func(t *testing.T) {
+		docs := SplitYAML([]byte("kind: X\nmetadata:\n  name: x1\n"))
+		if len(docs) != 1 {
+			t.Fatalf("docs: got %d, want 1", len(docs))
+		}
+	})
+
+	t.Run("empty docs are skipped", func(t *testing.T) {
+		docs := SplitYAML([]byte("---\n---\nkind: X\nmetadata:\n  name: x1\n---\n"))
+		if len(docs) != 1 {
+			t.Fatalf("docs: got %d, want 1", len(docs))
+		}
+	})
+
+	t.Run("comment-only preamble is dropped", func(t *testing.T) {
+		input := []byte("# Provenance line 1\n# Provenance line 2\n---\nkind: X\nmetadata:\n  name: x1\n")
+		docs := SplitYAML(input)
+		if len(docs) != 1 {
+			t.Fatalf("docs: got %d, want 1", len(docs))
+		}
+		if !strings.Contains(string(docs[0]), "kind: X") {
+			t.Errorf("expected kind doc, got %s", docs[0])
+		}
+	})
+}
+
+func TestExtractRef(t *testing.T) {
+	t.Run("populated", func(t *testing.T) {
+		ref, err := ExtractRef([]byte("kind: SeiNodeDeployment\nmetadata:\n  name: bench-bdc-demo\n  namespace: eng-bdc\n"))
+		if err != nil {
+			t.Fatalf("ExtractRef: %v", err)
+		}
+		if ref.Kind != "SeiNodeDeployment" || ref.Name != "bench-bdc-demo" || ref.Namespace != "eng-bdc" {
+			t.Errorf("ref: %+v", ref)
+		}
+	})
+
+	t.Run("missing kind", func(t *testing.T) {
+		_, err := ExtractRef([]byte("metadata:\n  name: nope\n"))
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		_, err := ExtractRef([]byte("kind: ConfigMap\n"))
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}
+
+func TestIndent(t *testing.T) {
+	out := Indent("a\nb\n\nc", "  ")
+	if out != "  a\n  b\n\n  c" {
+		t.Errorf("got %q", out)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 			&serveCmd,
 			&reportCmd,
 			&contextCmd,
+			&benchCmd,
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -1,0 +1,11 @@
+// Package templates embeds the autobake-derived YAML/JSON templates
+// rendered by `seictl bench up`. Templates are vendored copies of
+// sei-protocol/platform autobake/{templates,profiles}/* with engineer-
+// bench adaptations (per-engineer namespace, seictl labels). Drift is
+// resolved by a deliberate seictl PR per upstream change.
+package templates
+
+import "embed"
+
+//go:embed *.yaml *.json
+var FS embed.FS

--- a/templates/profile-cm.yaml
+++ b/templates/profile-cm.yaml
@@ -1,0 +1,18 @@
+# Wraps the rendered seiload profile as a ConfigMap mounted by the
+# seiload Job. Profile body is rendered separately and inlined verbatim.
+# Vars: CHAIN_ID, NAMESPACE, ENGINEER_ALIAS, BENCH_NAME, PROFILE_BODY
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seiload-profile-${CHAIN_ID}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: seictl
+    app.kubernetes.io/part-of: seictl-bench
+    sei.io/chain-id: ${CHAIN_ID}
+    sei.io/engineer: ${ENGINEER_ALIAS}
+    sei.io/bench-name: ${BENCH_NAME}
+data:
+  profile.json: |
+${PROFILE_BODY_INDENTED}

--- a/templates/seiload-job.yaml
+++ b/templates/seiload-job.yaml
@@ -1,0 +1,76 @@
+# Source: sei-protocol/platform autobake/templates/seiload-job.yaml
+# Embedded at: 2026-04-27
+# Vars: CHAIN_ID, NAMESPACE, ENGINEER_ALIAS, BENCH_NAME, SEILOAD_IMAGE,
+#       IMAGE_DIGEST_SHORT, JOB_DEADLINE_SECONDS
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seiload-${CHAIN_ID}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: seictl
+    app.kubernetes.io/part-of: seictl-bench
+    sei.io/chain-id: ${CHAIN_ID}
+    sei.io/engineer: ${ENGINEER_ALIAS}
+    sei.io/bench-name: ${BENCH_NAME}
+    sei.io/image-sha: ${IMAGE_DIGEST_SHORT}
+    sei.io/component: seiload
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: ${JOB_DEADLINE_SECONDS}
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: seiload
+        app.kubernetes.io/managed-by: seictl
+        app.kubernetes.io/part-of: seictl-bench
+        sei.io/chain-id: ${CHAIN_ID}
+        sei.io/engineer: ${ENGINEER_ALIAS}
+        sei.io/bench-name: ${BENCH_NAME}
+        sei.io/component: seiload
+    spec:
+      serviceAccountName: bench-seiload
+      restartPolicy: Never
+      # Window for the metrics scrape after seiload exits but before the
+      # pod is torn down (PodMonitor scrape interval is 15s).
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: seiload
+          image: ${SEILOAD_IMAGE}
+          args:
+            - --config
+            - /etc/seiload/profile.json
+          ports:
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          env:
+            - name: SEILOAD_RUN_ID
+              value: ${CHAIN_ID}
+            - name: SEILOAD_CHAIN_ID
+              value: ${CHAIN_ID}
+            - name: SEILOAD_COMMIT_ID
+              value: ${IMAGE_DIGEST_SHORT}
+            - name: SEILOAD_WORKLOAD
+              value: seictl-bench
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "20"]
+          volumeMounts:
+            - name: profile
+              mountPath: /etc/seiload
+              readOnly: true
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+      volumes:
+        - name: profile
+          configMap:
+            name: seiload-profile-${CHAIN_ID}

--- a/templates/seiload-profile.json
+++ b/templates/seiload-profile.json
@@ -1,0 +1,30 @@
+{
+  "_provenance": "sei-protocol/platform autobake/profiles/autobake_evm_transfer.json — embedded 2026-04-27",
+  "chainId": 713714,
+  "seiChainId": "${CHAIN_ID}",
+  "endpoints": [${RPC_ENDPOINTS}],
+  "accounts": {
+    "count": 5000,
+    "newAccountRate": 0.0
+  },
+  "scenarios": [
+    {
+      "name": "EVMTransfer",
+      "weight": 1
+    }
+  ],
+  "settings": {
+    "workers": 500,
+    "tps": 0,
+    "statsInterval": "5s",
+    "bufferSize": 1000,
+    "dryRun": false,
+    "debug": false,
+    "trackReceipts": false,
+    "trackBlocks": true,
+    "trackUserLatency": false,
+    "prewarm": false,
+    "rampUp": false,
+    "reportPath": "/dev/stdout"
+  }
+}

--- a/templates/snd.yaml
+++ b/templates/snd.yaml
@@ -1,0 +1,86 @@
+# Source: sei-protocol/platform autobake/templates/seinodedeployment.yaml
+# Embedded at: 2026-04-27
+# Vars: CHAIN_ID, NAMESPACE, ENGINEER_ALIAS, BENCH_NAME, SEID_IMAGE,
+#       IMAGE_DIGEST_SHORT, VALIDATOR_COUNT, RPC_COUNT
+---
+# Validator fleet — runs consensus, owns the genesis ceremony.
+apiVersion: sei.io/v1alpha1
+kind: SeiNodeDeployment
+metadata:
+  name: ${CHAIN_ID}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: seictl
+    app.kubernetes.io/part-of: seictl-bench
+    sei.io/chain-id: ${CHAIN_ID}
+    sei.io/engineer: ${ENGINEER_ALIAS}
+    sei.io/bench-name: ${BENCH_NAME}
+    sei.io/image-sha: ${IMAGE_DIGEST_SHORT}
+    sei.io/role: validator
+spec:
+  replicas: ${VALIDATOR_COUNT}
+  deletionPolicy: Delete
+  updateStrategy:
+    type: InPlace
+  genesis:
+    chainId: ${CHAIN_ID}
+    stakingAmount: "10000000usei"
+  template:
+    metadata:
+      labels:
+        sei.io/chain-id: ${CHAIN_ID}
+        sei.io/engineer: ${ENGINEER_ALIAS}
+        sei.io/bench-name: ${BENCH_NAME}
+        sei.io/role: validator
+    spec:
+      chainId: ${CHAIN_ID}
+      image: ${SEID_IMAGE}
+      entrypoint:
+        command: ["seid"]
+        args: ["start", "--home", "/sei"]
+      peers:
+        - label:
+            selector:
+              sei.io/chain-id: ${CHAIN_ID}
+      validator: {}
+---
+# RPC fleet — block-syncs from validators and serves EVM JSON-RPC to seiload.
+# No genesis block (inherits from the validator SND's ceremony via S3).
+apiVersion: sei.io/v1alpha1
+kind: SeiNodeDeployment
+metadata:
+  name: ${CHAIN_ID}-rpc
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: seictl
+    app.kubernetes.io/part-of: seictl-bench
+    sei.io/chain-id: ${CHAIN_ID}
+    sei.io/engineer: ${ENGINEER_ALIAS}
+    sei.io/bench-name: ${BENCH_NAME}
+    sei.io/image-sha: ${IMAGE_DIGEST_SHORT}
+    sei.io/role: rpc
+spec:
+  replicas: ${RPC_COUNT}
+  deletionPolicy: Delete
+  updateStrategy:
+    type: InPlace
+  template:
+    metadata:
+      labels:
+        sei.io/chain-id: ${CHAIN_ID}
+        sei.io/engineer: ${ENGINEER_ALIAS}
+        sei.io/bench-name: ${BENCH_NAME}
+        sei.io/role: rpc
+    spec:
+      chainId: ${CHAIN_ID}
+      image: ${SEID_IMAGE}
+      entrypoint:
+        command: ["seid"]
+        args: ["start", "--home", "/sei"]
+      peers:
+        - label:
+            selector:
+              sei.io/nodedeployment: ${CHAIN_ID}
+      fullNode: {}
+      overrides:
+        evm.ws_enabled: "true"


### PR DESCRIPTION
## Summary

Slice 3a of the cluster-cli LLD (#65). Engineer can now go from a tagged ECR image to the four-document manifest plan + the `bench.up.result` JSON envelope, with no cluster I/O — purely render + validate + ECR digest resolve + emit.

```
$ seictl bench up --image 189...amazonaws.com/sei/sei-chain:v1.2.3 --name demo --size s
{
  "kind": "bench.up.result",
  "version": "v1",
  "data": {
    "chainId": "bench-bdc-demo",
    "namespace": "eng-bdc",
    "imageDigest": "sha256:...",
    "validators": 4,
    "rpcNodes": 1,
    "resultsS3Uri": "s3://harbor-sei-autobake-results/bench-bdc-demo/<sha-12>/bench-bdc-demo/report.log",
    "dryRun": true,
    "manifests": [
      {"kind": "SeiNodeDeployment", "name": "bench-bdc-demo", "namespace": "eng-bdc", "action": "create"},
      {"kind": "SeiNodeDeployment", "name": "bench-bdc-demo-rpc", "namespace": "eng-bdc", "action": "create"},
      {"kind": "Job",               "name": "seiload-bench-bdc-demo", "namespace": "eng-bdc", "action": "create"},
      {"kind": "ConfigMap",         "name": "seiload-profile-bench-bdc-demo", "namespace": "eng-bdc", "action": "create"}
    ]
  }
}
```

## Why split 3a/3b

Dry-run is the LLD's default. The entire render + ECR + validation pipeline lands testable purely offline before any SSA / controller-runtime code exists. Slice 3b will reintroduce `Client.RESTConfig`, the controller-runtime CR client, and SSA with field manager `seictl-bench`.

## Packages

- **`templates/`** — vendored copies of `sei-protocol/platform` autobake templates with engineer-bench adaptations (per-engineer namespace, `app.kubernetes.io/managed-by=seictl`, `sei.io/engineer=<alias>`, `sei.io/bench-name=<name>` labels). Each file has a provenance header pointing at upstream. Drift is a deliberate seictl PR per upstream change.
- **`internal/render`** — `os.Expand`-based `${VAR}` substitution, fail-closed on undefined vars; YAML doc splitter that filters comment-only preambles; `ManifestRef` extractor (Kind / metadata.{name,namespace}).
- **`internal/aws/ecr`** — `ResolveDigest` via ECR `DescribeImages`. Account + region parsed from the hostname so a future per-engineer-ECR rollout doesn't need code changes. Already-digested refs pass through. `AssertECRDigestRef` is the apply-time guard.

## Top-level

- **`bench.go`** — `seictl bench up` with `--image / --name / --size / --duration`. Validates → resolves digest → renders → emits envelope. `benchDeps` struct enables stub-driven tests of the full pipeline.

## LLD adjustment

The LLD §Embedded templates says "text/template — autobake source files use Helm-style `{{ }}`." The actual autobake templates use shell-style `${VAR}`. Followed reality; will correct the LLD note in a doc PR.

## Test plan

- [x] `internal/render` table-driven: missing-vars dedup+sort, multi-doc split, comment-only filter
- [x] `internal/aws/ecr` table-driven: ref parsing (tag/digest/no-prefix/non-sha256), ECR host parsing, digest pass-through
- [x] `bench_test.go` end-to-end with stub deps: size s/m profiles, image-policy rejection, validation rejection, digest-resolution propagation, missing-identity error
- [x] Manual smoke (digest-pinned image, no ECR call): exit 0, 4 manifests, all in `eng-bdc`
- [x] Manual smoke (docker.io image): exit 10, category `image-policy`
- [x] Manual smoke (size xl): exit 10, category `validation`
- [x] `gofmt -s -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)