### PR TITLE
refactor: K8s-aligned envelope (apiVersion + kind)

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	benchUpResultKind = "bench.up.result"
-	benchS3Bucket     = "harbor-sei-autobake-results"
+	benchS3Bucket = "harbor-sei-autobake-results"
 
 	// Vendored seiload image. Slice 3b will resolve to a digest at apply
 	// time; v1 dry-run emits the tag for visibility, fails-closed against
@@ -156,7 +155,7 @@ func runBenchUp(ctx context.Context, in benchUpInput, out io.Writer, deps benchD
 		DryRun:       true,
 		Manifests:    manifests,
 	}
-	if err := clioutput.Emit(out, benchUpResultKind, res); err != nil {
+	if err := clioutput.Emit(out, clioutput.KindBenchUpResult, res); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return cli.Exit("", 1)
 	}
@@ -241,7 +240,7 @@ func renderEmbedded(name string, vars map[string]string) ([]byte, *clioutput.Err
 }
 
 func failBenchUp(out io.Writer, e *clioutput.Error) error {
-	_ = clioutput.EmitError(out, benchUpResultKind, e)
+	_ = clioutput.EmitError(out, clioutput.KindBenchUpResult, e)
 	return cli.Exit("", e.Code)
 }
 

--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -23,9 +23,8 @@ import (
 const (
 	benchS3Bucket = "harbor-sei-autobake-results"
 
-	// Vendored seiload image. Slice 3b will resolve to a digest at apply
-	// time; v1 dry-run emits the tag for visibility, fails-closed against
-	// non-ECR registries via internal/validate.Image.
+	// defaultSeiloadImage is operator-vendored, not engineer input, so
+	// it bypasses the registry policy applied to --image.
 	defaultSeiloadImage = "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/seiload:latest"
 )
 
@@ -77,7 +76,7 @@ var BenchCmd = cli.Command{
 	Commands: []*cli.Command{
 		{
 			Name:  "up",
-			Usage: "Render (slice 3a) or apply (slice 3b) a benchmark workload",
+			Usage: "Render or apply a benchmark workload",
 			Flags: []cli.Flag{
 				&cli.StringFlag{Name: "image", Required: true, Usage: "ECR image ref to bench"},
 				&cli.StringFlag{Name: "name", Required: true, Usage: "Bench name (forms part of chain-id)"},
@@ -171,9 +170,8 @@ func loadEngineer(pathFn func() (string, error)) (*identity.Engineer, *clioutput
 	return identity.Read(path)
 }
 
-// renderManifests builds the four-document YAML stream the bench
-// produces (validator SND, RPC SND, seiload Job, profile ConfigMap)
-// and extracts a ManifestRef per document.
+// renderManifests produces the four-doc YAML bundle (validator SND,
+// RPC SND, seiload Job, profile ConfigMap) and a ManifestRef list.
 func renderManifests(alias, name, namespace, chainID, seidImage, digestShort string,
 	validators, rpcCount, durationMin int) ([]render.ManifestRef, *clioutput.Error) {
 	vars := map[string]string{
@@ -244,8 +242,8 @@ func failBenchUp(out io.Writer, e *clioutput.Error) error {
 	return cli.Exit("", e.Code)
 }
 
-// digestPinned strips any tag or digest from ref and re-pins to the
-// given digest, producing host/repo@sha256:....
+// digestPinned re-pins ref to the given digest, replacing any prior
+// tag or digest. Result form: host/repo@sha256:...
 func digestPinned(ref, digest string) string {
 	slash := strings.IndexByte(ref, '/')
 	host := ref[:slash]
@@ -258,8 +256,8 @@ func digestPinned(ref, digest string) string {
 	return host + "/" + rest + "@" + digest
 }
 
-// shortDigest returns the first 12 hex characters of a sha256 digest,
-// matching the autobake S3 path partition convention.
+// shortDigest returns the first 12 hex chars of a sha256 digest;
+// matches the autobake S3 path partition.
 func shortDigest(d string) string {
 	i := strings.IndexByte(d, ':')
 	if i < 0 || len(d) < i+1+12 {
@@ -268,9 +266,8 @@ func shortDigest(d string) string {
 	return d[i+1 : i+1+12]
 }
 
-// rpcEndpointsJSON renders the JSON-array body for the seiload profile's
-// `endpoints` field. RPC service DNS resolves at apply time; dry-run
-// emits the predictable cluster-local form.
+// rpcEndpointsJSON formats the seiload profile's `endpoints` array
+// using the RPC SND's cluster-local service DNS.
 func rpcEndpointsJSON(chainID, namespace string, rpcCount int) string {
 	var sb strings.Builder
 	for i := 0; i < rpcCount; i++ {

--- a/cluster/bench_test.go
+++ b/cluster/bench_test.go
@@ -53,8 +53,8 @@ func TestRunBenchUp(t *testing.T) {
 		if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 			t.Fatalf("envelope unmarshal: %v\n%s", err, buf.String())
 		}
-		if env.Kind != benchUpResultKind || env.Version != "v1" {
-			t.Errorf("envelope: kind=%q version=%q", env.Kind, env.Version)
+		if env.Kind != clioutput.KindBenchUpResult || env.APIVersion != clioutput.APIVersion {
+			t.Errorf("envelope: kind=%q apiVersion=%q", env.Kind, env.APIVersion)
 		}
 		if env.Error != nil {
 			t.Fatalf("error body should be nil; got %+v\nbody=%s", env.Error, buf.String())

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -14,8 +14,6 @@ import (
 	"github.com/sei-protocol/seictl/cluster/internal/kube"
 )
 
-const contextResultKind = "context.result"
-
 type contextResult struct {
 	KubeContext     string             `json:"kubeContext"`
 	Cluster         string             `json:"cluster"`
@@ -54,7 +52,7 @@ var ContextCmd = cli.Command{
 func runContext(ctx context.Context, kubeconfig, kubeContext string, out io.Writer, deps contextDeps) error {
 	kc, kerr := kube.New(kube.Options{Kubeconfig: kubeconfig, Context: kubeContext})
 	if kerr != nil {
-		_ = clioutput.EmitError(out, contextResultKind, kerr)
+		_ = clioutput.EmitError(out, clioutput.KindContextResult, kerr)
 		return cli.Exit("", kerr.Code)
 	}
 
@@ -76,7 +74,7 @@ func runContext(ctx context.Context, kubeconfig, kubeContext string, out io.Writ
 	if path, err := deps.identityPath(); err == nil {
 		eng, idErr := identity.Read(path)
 		if idErr != nil && idErr.Category != clioutput.CatMissing {
-			_ = clioutput.EmitError(out, contextResultKind, idErr)
+			_ = clioutput.EmitError(out, clioutput.KindContextResult, idErr)
 			return cli.Exit("", idErr.Code)
 		}
 		if eng != nil {
@@ -84,7 +82,7 @@ func runContext(ctx context.Context, kubeconfig, kubeContext string, out io.Writ
 		}
 	}
 
-	if err := clioutput.Emit(out, contextResultKind, res); err != nil {
+	if err := clioutput.Emit(out, clioutput.KindContextResult, res); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return cli.Exit("", 1)
 	}

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -25,8 +25,7 @@ type contextResult struct {
 	Engineer        *identity.Engineer `json:"engineer,omitempty"`
 }
 
-// contextDeps lets tests stub the AWS and identity reads. Production
-// wiring uses aws.GetCaller and identity.Read against the user's home dir.
+// contextDeps lets tests stub the AWS and identity reads.
 type contextDeps struct {
 	getCaller    func(context.Context) (*aws.Caller, *clioutput.Error)
 	identityPath func() (string, error)

--- a/cluster/context_test.go
+++ b/cluster/context_test.go
@@ -67,8 +67,8 @@ func TestRunContext(t *testing.T) {
 		if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 			t.Fatalf("unmarshal: %v", err)
 		}
-		if env.Kind != "context.result" || env.Version != "v1" {
-			t.Errorf("envelope: kind=%q version=%q", env.Kind, env.Version)
+		if env.Kind != clioutput.KindContextResult || env.APIVersion != clioutput.APIVersion {
+			t.Errorf("envelope: kind=%q apiVersion=%q", env.Kind, env.APIVersion)
 		}
 		var data contextResult
 		if err := json.Unmarshal(env.Data, &data); err != nil {

--- a/cluster/internal/aws/caller.go
+++ b/cluster/internal/aws/caller.go
@@ -1,6 +1,5 @@
 // Package aws holds AWS-side helpers used by cluster-facing seictl
-// commands. ECR digest resolution and IAM/Pod-Identity helpers land
-// alongside the slice that first needs them.
+// commands.
 package aws
 
 import (

--- a/cluster/internal/aws/ecr.go
+++ b/cluster/internal/aws/ecr.go
@@ -14,13 +14,11 @@ import (
 )
 
 // ResolveDigest converts an ECR image reference (registry/repo:tag) into
-// its sha256 digest. References already pinned to a digest are returned
-// as-is without an ECR round-trip.
+// its sha256 digest. Already-digested refs are returned as-is without an
+// ECR round-trip.
 //
-// The registry hostname is parsed for AWS account + region — the
-// registry policy in internal/validate constrains it to a single
-// account, but the hostname remains the source of truth so a future
-// per-engineer-ECR rollout doesn't require touching this code.
+// Account + region come from the hostname rather than constants so the
+// resolver works for any ECR registry the validate-layer policy admits.
 func ResolveDigest(ctx context.Context, ref string) (string, *clioutput.Error) {
 	host, repo, tag, digest, parseErr := parseImageRef(ref)
 	if parseErr != nil {

--- a/cluster/internal/clioutput/envelope.go
+++ b/cluster/internal/clioutput/envelope.go
@@ -2,8 +2,16 @@
 // seictl subcommands and the exit-code / category enums that are part of
 // the public CLI contract.
 //
-// The shape here is the v2 MCP tool contract per docs/design/cluster-cli.md
-// — bumping Version is a breaking change for the sei-platform-engineer skill.
+// The envelope mirrors Kubernetes `metav1.TypeMeta` (apiVersion + kind)
+// so the Sei platform engineer audience reads results in the same shape
+// they read CRDs. The same shape becomes the v2 MCP tool contract.
+//
+// Two-way doors:
+//   - Adding new kinds → additive, never breaks consumers.
+//   - Adding new fields to a kind → JSON consumers ignore unknown fields.
+//   - Adding new error categories → already non-breaking.
+//   - Breaking schema change → ship `seictl.sei.io/v2` alongside v1
+//     (the standard K8s API-versioning migration).
 package clioutput
 
 import (
@@ -12,7 +20,18 @@ import (
 	"io"
 )
 
-const EnvelopeVersion = "v1"
+// APIVersion is the stable group/version string emitted on every envelope.
+// Bumping the major version is a breaking change for the
+// sei-platform-engineer skill; do it by adding `seictl.sei.io/v2`
+// alongside, not by mutating v1.
+const APIVersion = "seictl.sei.io/v1"
+
+// Kinds emitted by cluster-facing verbs. New verbs add a constant here
+// rather than open-coding the string at the call site.
+const (
+	KindContextResult = "ContextResult"
+	KindBenchUpResult = "BenchUpResult"
+)
 
 const (
 	ExitSuccess  = 0
@@ -50,10 +69,10 @@ const (
 )
 
 type Envelope struct {
-	Kind    string          `json:"kind"`
-	Version string          `json:"version"`
-	Data    json.RawMessage `json:"data,omitempty"`
-	Error   *ErrorBody      `json:"error,omitempty"`
+	APIVersion string          `json:"apiVersion"`
+	Kind       string          `json:"kind"`
+	Data       json.RawMessage `json:"data,omitempty"`
+	Error      *ErrorBody      `json:"error,omitempty"`
 }
 
 type ErrorBody struct {
@@ -99,7 +118,7 @@ func Emit(w io.Writer, kind string, data any) error {
 	if err != nil {
 		return fmt.Errorf("marshalling %s data: %w", kind, err)
 	}
-	env := Envelope{Kind: kind, Version: EnvelopeVersion, Data: raw}
+	env := Envelope{APIVersion: APIVersion, Kind: kind, Data: raw}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(env)
@@ -109,8 +128,8 @@ func Emit(w io.Writer, kind string, data any) error {
 // callers should not propagate those back to the user.
 func EmitError(w io.Writer, kind string, e *Error) error {
 	env := Envelope{
-		Kind:    kind,
-		Version: EnvelopeVersion,
+		APIVersion: APIVersion,
+		Kind:       kind,
 		Error: &ErrorBody{
 			Code:     e.Code,
 			Category: e.Category,

--- a/cluster/internal/clioutput/envelope.go
+++ b/cluster/internal/clioutput/envelope.go
@@ -1,17 +1,7 @@
 // Package clioutput defines the JSON output envelope for cluster-facing
 // seictl subcommands and the exit-code / category enums that are part of
-// the public CLI contract.
-//
-// The envelope mirrors Kubernetes `metav1.TypeMeta` (apiVersion + kind)
-// so the Sei platform engineer audience reads results in the same shape
-// they read CRDs. The same shape becomes the v2 MCP tool contract.
-//
-// Two-way doors:
-//   - Adding new kinds → additive, never breaks consumers.
-//   - Adding new fields to a kind → JSON consumers ignore unknown fields.
-//   - Adding new error categories → already non-breaking.
-//   - Breaking schema change → ship `seictl.sei.io/v2` alongside v1
-//     (the standard K8s API-versioning migration).
+// the public CLI contract. The envelope mirrors Kubernetes
+// `metav1.TypeMeta` (apiVersion + kind).
 package clioutput
 
 import (

--- a/cluster/internal/clioutput/envelope.go
+++ b/cluster/internal/clioutput/envelope.go
@@ -21,9 +21,8 @@ import (
 )
 
 // APIVersion is the stable group/version string emitted on every envelope.
-// Bumping the major version is a breaking change for the
-// sei-platform-engineer skill; do it by adding `seictl.sei.io/v2`
-// alongside, not by mutating v1.
+// Breaking changes ship as `seictl.sei.io/v2` alongside v1, not as
+// mutations to v1.
 const APIVersion = "seictl.sei.io/v1"
 
 // Kinds emitted by cluster-facing verbs. New verbs add a constant here

--- a/cluster/internal/clioutput/envelope_test.go
+++ b/cluster/internal/clioutput/envelope_test.go
@@ -111,10 +111,6 @@ func TestNewf(t *testing.T) {
 }
 
 func TestEnvelopeContract_Stable(t *testing.T) {
-	// APIVersion and Kind constants are part of the public contract
-	// for the sei-platform-engineer skill / future MCP layer. Pin them
-	// so accidental renames fail loudly. Bumping is a breaking change
-	// — ship `seictl.sei.io/v2` alongside, don't mutate v1.
 	if APIVersion != "seictl.sei.io/v1" {
 		t.Errorf("APIVersion: got %q, want %q", APIVersion, "seictl.sei.io/v1")
 	}

--- a/cluster/internal/clioutput/envelope_test.go
+++ b/cluster/internal/clioutput/envelope_test.go
@@ -14,7 +14,7 @@ func TestEmit_Success(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := Emit(&buf, "test.kind", sample{Foo: "hello", Bar: 42}); err != nil {
+	if err := Emit(&buf, "TestKind", sample{Foo: "hello", Bar: 42}); err != nil {
 		t.Fatalf("Emit returned error: %v", err)
 	}
 
@@ -22,11 +22,11 @@ func TestEmit_Success(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if env.Kind != "test.kind" {
-		t.Errorf("kind: got %q, want %q", env.Kind, "test.kind")
+	if env.Kind != "TestKind" {
+		t.Errorf("kind: got %q, want %q", env.Kind, "TestKind")
 	}
-	if env.Version != EnvelopeVersion {
-		t.Errorf("version: got %q, want %q", env.Version, EnvelopeVersion)
+	if env.APIVersion != APIVersion {
+		t.Errorf("apiVersion: got %q, want %q", env.APIVersion, APIVersion)
 	}
 	if env.Error != nil {
 		t.Errorf("error body should be nil on success, got %+v", env.Error)
@@ -43,7 +43,7 @@ func TestEmit_Success(t *testing.T) {
 func TestEmitError_Round_Trip(t *testing.T) {
 	var buf bytes.Buffer
 	cliErr := New(ExitBench, CatImagePolicy, "image registry not allowed").WithDetail("got: docker.io/foo")
-	if err := EmitError(&buf, "bench.up.result", cliErr); err != nil {
+	if err := EmitError(&buf, KindBenchUpResult, cliErr); err != nil {
 		t.Fatalf("EmitError returned error: %v", err)
 	}
 
@@ -51,8 +51,11 @@ func TestEmitError_Round_Trip(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if env.Kind != "bench.up.result" {
+	if env.Kind != KindBenchUpResult {
 		t.Errorf("kind: got %q", env.Kind)
+	}
+	if env.APIVersion != APIVersion {
+		t.Errorf("apiVersion: got %q", env.APIVersion)
 	}
 	if env.Error == nil {
 		t.Fatalf("error body should be populated")
@@ -104,6 +107,29 @@ func TestNewf(t *testing.T) {
 	}
 	if e.Code != ExitOnboard {
 		t.Errorf("code: got %d", e.Code)
+	}
+}
+
+func TestEnvelopeContract_Stable(t *testing.T) {
+	// APIVersion and Kind constants are part of the public contract
+	// for the sei-platform-engineer skill / future MCP layer. Pin them
+	// so accidental renames fail loudly. Bumping is a breaking change
+	// — ship `seictl.sei.io/v2` alongside, don't mutate v1.
+	if APIVersion != "seictl.sei.io/v1" {
+		t.Errorf("APIVersion: got %q, want %q", APIVersion, "seictl.sei.io/v1")
+	}
+	want := map[string]string{
+		"KindContextResult": "ContextResult",
+		"KindBenchUpResult": "BenchUpResult",
+	}
+	got := map[string]string{
+		"KindContextResult": KindContextResult,
+		"KindBenchUpResult": KindBenchUpResult,
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s: got %q, want %q", k, got[k], v)
+		}
 	}
 }
 

--- a/cluster/internal/kube/client.go
+++ b/cluster/internal/kube/client.go
@@ -1,6 +1,5 @@
 // Package kube wraps kubeconfig loading for cluster-facing seictl
-// commands. The controller-runtime client and rest.Config are added
-// in the slice that first needs them.
+// commands.
 package kube
 
 import (

--- a/cluster/internal/render/render.go
+++ b/cluster/internal/render/render.go
@@ -108,8 +108,7 @@ func isCommentOnly(doc []byte) bool {
 }
 
 // ExtractRef pulls Kind / metadata.name / metadata.namespace from a
-// rendered Kubernetes manifest. Action is left to the caller (dry-run
-// reports "create"; --apply distinguishes create/update/unchanged).
+// rendered Kubernetes manifest. Action is filled in by the caller.
 func ExtractRef(doc []byte) (ManifestRef, error) {
 	var m struct {
 		Kind     string `yaml:"kind"`

--- a/cluster/internal/validate/validate.go
+++ b/cluster/internal/validate/validate.go
@@ -108,9 +108,8 @@ func Namespace(ns, alias string) *clioutput.Error {
 	return nil
 }
 
-// Image enforces the v1 registry policy: ECR-only, sei/* prefix, must
-// carry a tag or a digest. Digest resolution is handled later in
-// internal/aws — this is a pure shape and policy gate.
+// Image enforces the registry policy (ECR-only, sei/* prefix, tag or
+// digest required). Digest resolution lives in internal/aws.
 func Image(ref string) *clioutput.Error {
 	if ref == "" {
 		return clioutput.New(clioutput.ExitBench, clioutput.CatImagePolicy,


### PR DESCRIPTION
## Summary

Aligns the cluster-facing JSON envelope with the Kubernetes `metav1.TypeMeta` shape the platform-engineer audience reads daily — same shape the eventual workload CRD will use, same shape the v2 MCP tool layer will route on.

**Before:**
```json
{
  "kind": "context.result",
  "version": "v1",
  "data": { ... }
}
```

**After:**
```json
{
  "apiVersion": "seictl.sei.io/v1",
  "kind": "ContextResult",
  "data": { ... }
}
```

## Why this shape

- **Conventional**: matches K8s `metav1.TypeMeta` exactly (field names, JSON tags, group/version format).
- **Idiomatic**: PascalCase kinds, camelCase JSON, group `seictl.sei.io` parallel to the controller's `sei.io/v1alpha1` CRD group.
- **MCP-ready**: `apiVersion + kind` is the discriminator the future MCP tool layer routes on.

## Two-way doors (none added)

| Change | Breaking? | Mitigation |
|---|---|---|
| Add new kind | No | Just add a `Kind*` constant |
| Add new field to a kind | No | JSON consumers ignore unknown |
| Add new error category | No | Already established as additive |
| Schema-break a kind | Yes | Ship `seictl.sei.io/v2` alongside v1 (K8s API versioning) |

The `data \| error` union stays at envelope level (not K8s `Status` subresource) because for an MCP tool result the consumer wants a **stable kind whether the call succeeded or failed** — `kind=BenchUpResult` always means "bench-up response, look at data or error". JSON-RPC 2.0 picked the same union shape for the same reason.

## Changes

- `clioutput.Envelope`: `Version` → `APIVersion`. JSON tag `apiVersion`.
- New constants: `APIVersion = "seictl.sei.io/v1"`, `KindContextResult`, `KindBenchUpResult`.
- Per-verb string literals (`"context.result"`, `"bench.up.result"`) gone — callers use constants.
- `TestEnvelopeContract_Stable` pins the public values so accidental rename fails loudly.

## Test plan

- [x] `go test ./cluster/...` green
- [x] Manual smoke `seictl context`: emits `apiVersion: seictl.sei.io/v1`, `kind: ContextResult`
- [x] Manual smoke `seictl bench up` success: emits `kind: BenchUpResult`, `data` populated
- [x] Manual smoke `seictl bench up` rejection (docker.io): emits `kind: BenchUpResult`, `error` populated, exit 10

No consumer is live yet (skill hasn't graduated to MCP), so this is a clean break, not a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)