### PR TITLE
feat: align bench S3 path with harbor-validation-results schema

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -21,7 +21,11 @@ import (
 )
 
 const (
-	benchS3Bucket = "harbor-sei-autobake-results"
+	// benchS3Bucket and benchJob mirror the platform's shared
+	// validation-results scheme: s3://<bucket>/<namespace>/<job>/<run>/...
+	// IAM scoping happens on the namespace prefix.
+	benchS3Bucket = "harbor-validation-results"
+	benchJob      = "evm-transfer"
 
 	// defaultSeiloadImage is operator-vendored, not engineer input, so
 	// it bypasses the registry policy applied to --image.
@@ -131,7 +135,7 @@ func runBenchUp(ctx context.Context, in benchUpInput, out io.Writer, deps benchD
 
 	chainID := fmt.Sprintf("bench-%s-%s", eng.Alias, in.Name)
 	digestShort := shortDigest(digest)
-	s3URI := fmt.Sprintf("s3://%s/%s/%s/%s/report.log", benchS3Bucket, chainID, digestShort, chainID)
+	s3URI := fmt.Sprintf("s3://%s/%s/%s/%s/report.log", benchS3Bucket, namespace, benchJob, in.Name)
 	sizeProfile := benchSizes[in.Size]
 
 	manifests, err := renderManifests(eng.Alias, in.Name, namespace, chainID, seidImage,

--- a/cluster/bench_test.go
+++ b/cluster/bench_test.go
@@ -79,8 +79,8 @@ func TestRunBenchUp(t *testing.T) {
 		if !data.DryRun {
 			t.Errorf("dryRun should be true")
 		}
-		// Per LLD §`bench up`: `s3://harbor-sei-autobake-results/<chain-id>/<image-sha-12>/<chain-id>/report.log`
-		want := "s3://harbor-sei-autobake-results/bench-bdc-demo/1234567890ab/bench-bdc-demo/report.log"
+		// Schema: s3://harbor-validation-results/<namespace>/<job>/<run>/...
+		want := "s3://harbor-validation-results/eng-bdc/evm-transfer/demo/report.log"
 		if data.ResultsS3URI != want {
 			t.Errorf("s3 uri: got %q, want %q", data.ResultsS3URI, want)
 		}

--- a/docs/design/cluster-cli.md
+++ b/docs/design/cluster-cli.md
@@ -215,7 +215,7 @@ Sizes:
 
 Chain ID convention: `bench-<alias>-<name>` (engineer benchmarks); RPC SND is `bench-<alias>-<name>-rpc`. Distinguishes from autobake's nightly `autobake-<run-id>`.
 
-S3 results URI: `s3://harbor-sei-autobake-results/<chain-id>/<image-sha-12>/<chain-id>/report.log`. Same bucket as nightly autobake; chain-ID prefix partitions.
+S3 results URI: `s3://harbor-validation-results/<namespace>/<job>/<run>/report.log`. Shared bucket per the platform's validation-results schema; namespace prefix is the per-engineer IAM scope. For engineer benches the segments resolve to `eng-<alias>/evm-transfer/<name>/`.
 
 ### `seictl bench down`
 
@@ -366,7 +366,7 @@ Single source of truth in `internal/validate/`. Commands call `validate.Alias(s)
 
 `seictl onboard --apply` creates resources directly via AWS SDK:
 
-1. **IAM policy** `harbor-bench-seiload-eng-<alias>` — per-engineer scoped to `s3://harbor-sei-autobake-results/bench-<alias>-*/`. Shared policies are explicitly rejected as a security risk that doesn't scale.
+1. **IAM policy** `harbor-bench-seiload-eng-<alias>` — per-engineer scoped to the shared validation-results bucket under the engineer's namespace prefix: `s3:ListBucket` with `s3:prefix=["eng-<alias>/*"]` and `s3:PutObject` on `arn:aws:s3:::harbor-validation-results/eng-<alias>/*`. Mirrors the platform's nightly policy (`harbor-nightly-seiload`); shared policies are explicitly rejected as a security risk that doesn't scale.
 2. **Pod Identity association** via `eks:CreatePodIdentityAssociation` for `(cluster=harbor, namespace=eng-<alias>, service_account=bench-seiload, role_arn=<policy-attached-role>)`
 
 Engineer's SSO role currently has admin permissions (sufficient to create the above). When SSO permissions get scoped down, the LLD revisits.


### PR DESCRIPTION
## Summary

Tracks sei-protocol/platform#229 — the shared `harbor-validation-results` bucket with `<namespace>/<job>/<run>/` partitioning. Engineer benches plug into the same scheme; IAM scopes per namespace prefix, matching our locked per-engineer-IAM stance.

## Mapping

| Segment | Engineer bench |
|---|---|
| `<namespace>` | `eng-<alias>` |
| `<job>` | `evm-transfer` (only profile vendored today) |
| `<run>` | the engineer's `--name` flag |

## Before / After

```diff
- s3://harbor-sei-autobake-results/bench-bdc-demo/<sha-12>/bench-bdc-demo/report.log
+ s3://harbor-validation-results/eng-bdc/evm-transfer/demo/report.log
```

The image digest is no longer in the S3 path. The 90-day bucket lifecycle handles cleanup; engineers don't partition by image when they iterate; image SHA still rides on every rendered manifest as `sei.io/image-sha`.

## Changes

- `cluster/bench.go`: bucket constant + new `benchJob = "evm-transfer"` constant; S3 URI format uses `(namespace, job, name)` instead of `(chain-id, digest, chain-id)`.
- `cluster/bench_test.go`: assertion updated.
- `docs/design/cluster-cli.md` §`bench up` + §IAM via AWS SDK: schema references aligned. The IAM policy doc now mirrors the platform's nightly policy shape — `s3:ListBucket` scoped via `s3:prefix=["eng-<alias>/*"]` + `s3:PutObject` on the prefixed ARN.

## Test plan

- [x] `go test ./cluster/...` green
- [x] Manual smoke: `seictl bench up --name demo --size s` emits  
  `s3://harbor-validation-results/eng-bdc/evm-transfer/demo/report.log`
- [x] `gofmt -s -l` clean

## What this enables for slice 4 (`onboard --apply`)

The IAM policy generation can now be a near-mechanical translation of `platform/terraform/aws/189176372795/eu-central-1/harbor/nightly.tf`'s `aws_iam_policy.nightly_seiload`, with `nightly` swapped for `eng-<alias>`. Same shape, same prefix discipline, just per-engineer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)