### PR TITLE
chore: bump Go 1.25.6 → 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.25 as BUILD
+FROM docker.io/golang:1.26 as BUILD
 
 WORKDIR /go/src/seictl
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sei-protocol/seictl
 
-go 1.25.6
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6


### PR DESCRIPTION
## Summary

Removes the self-imposed Go 1.25 ceiling that was blocking newer K8s libraries:
- `sigs.k8s.io/controller-runtime` v0.23.x → requires Go 1.26+
- `k8s.io/cli-runtime` v0.36.x → requires Go 1.26+

The 1.25.6 pin originated in slice 2 as a "stay on what's known-working" choice when first adding k8s deps. There's no proven need to keep it.

## Changes

```diff
-go 1.25.6
+go 1.26.0
```

```diff
-FROM docker.io/golang:1.25 as BUILD
+FROM docker.io/golang:1.26 as BUILD
```

CI uses `go-version-file: go.mod`, so it picks the new version automatically. No workflow edits needed.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cluster/...` green
- [x] `go mod tidy` no-op on dep tree (only directive line changed)

## Unblocks

Slice 3b follow-up: refactor `cluster/internal/kube/apply.go` to use `k8s.io/cli-runtime/pkg/resource.Builder`. Drops the YAML/REST mapper plumbing, keeps the seictl-specific orchestration (namespace pre-flight, generation-based action attribution, JSON envelope, apply order discipline). Coral round on #73 raised the question whether we were reinventing kubectl apply — the Builder switch is the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)