### PR TITLE
feat: bench down + bench list

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -99,6 +99,8 @@ var BenchCmd = cli.Command{
 	Name:  "bench",
 	Usage: "Manage benchmark workloads on the harbor cluster",
 	Commands: []*cli.Command{
+		benchDownCmd,
+		benchListCmd,
 		{
 			Name:  "up",
 			Usage: "Render or apply a benchmark workload",

--- a/cluster/bench_down.go
+++ b/cluster/bench_down.go
@@ -1,0 +1,142 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/identity"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+	"github.com/sei-protocol/seictl/cluster/internal/render"
+	"github.com/sei-protocol/seictl/cluster/internal/validate"
+)
+
+// benchDownTargets enumerates the resource types Apply creates.
+// Order matters for cascade reasoning; foreground propagation handles
+// child-cleanup within each kind.
+var benchDownTargets = []string{
+	"seinodedeployments.sei.io",
+	"jobs.batch",
+	"configmaps",
+}
+
+type benchDownResult struct {
+	Name      string               `json:"name"`
+	ChainID   string               `json:"chainId"`
+	Namespace string               `json:"namespace"`
+	Resources []render.ManifestRef `json:"resources"`
+	DeletedAt *time.Time           `json:"deletedAt,omitempty"`
+}
+
+type benchDownInput struct {
+	Name       string
+	Namespace  string
+	Kubeconfig string
+	Context    string
+}
+
+type benchDownDeps struct {
+	identityPath  func() (string, error)
+	newKubeClient func(kube.Options) (*kube.Client, *clioutput.Error)
+	deleteFn      func(ctx context.Context, kc *kube.Client, opts kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error)
+}
+
+var defaultBenchDownDeps = benchDownDeps{
+	identityPath:  identity.DefaultPath,
+	newKubeClient: kube.New,
+	deleteFn:      deleteFromCluster,
+}
+
+func deleteFromCluster(ctx context.Context, kc *kube.Client, opts kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
+	results, err := kc.Delete(ctx, opts)
+	if err != nil {
+		return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatFinalizerStuck, "%v", err)
+	}
+	return results, nil
+}
+
+var benchDownCmd = &cli.Command{
+	Name:  "down",
+	Usage: "Tear down a benchmark by name",
+	Flags: append(kubeconfigFlags(),
+		&cli.StringFlag{Name: "name", Required: true, Usage: "Bench name to tear down"},
+		&cli.StringFlag{Name: "namespace", Aliases: []string{"n"}, Usage: "Namespace (defaults to eng-<alias>)"},
+	),
+	Action: func(ctx context.Context, command *cli.Command) error {
+		return runBenchDown(ctx, benchDownInput{
+			Name:       command.String("name"),
+			Namespace:  command.String("namespace"),
+			Kubeconfig: command.String("kubeconfig"),
+			Context:    command.String("context"),
+		}, os.Stdout, defaultBenchDownDeps)
+	},
+}
+
+func runBenchDown(ctx context.Context, in benchDownInput, out io.Writer, deps benchDownDeps) error {
+	eng, idErr := loadEngineer(deps.identityPath)
+	if idErr != nil {
+		return failBenchDown(out, idErr)
+	}
+	if e := validate.Name(eng.Alias, in.Name); e != nil {
+		return failBenchDown(out, e)
+	}
+
+	namespace := in.Namespace
+	if namespace == "" {
+		namespace = "eng-" + eng.Alias
+	}
+	if e := validate.Namespace(namespace, eng.Alias); e != nil {
+		return failBenchDown(out, e)
+	}
+
+	chainID := fmt.Sprintf("bench-%s-%s", eng.Alias, in.Name)
+	selector := fmt.Sprintf("sei.io/engineer=%s,sei.io/bench-name=%s", eng.Alias, in.Name)
+
+	kc, kerr := deps.newKubeClient(kube.Options{Kubeconfig: in.Kubeconfig, Context: in.Context})
+	if kerr != nil {
+		return failBenchDown(out, kerr)
+	}
+
+	results, dErr := deps.deleteFn(ctx, kc, kube.DeleteOptions{
+		Namespace:     namespace,
+		Resources:     benchDownTargets,
+		LabelSelector: selector,
+	})
+	if dErr != nil {
+		return failBenchDown(out, dErr)
+	}
+
+	resources := make([]render.ManifestRef, len(results))
+	for i, r := range results {
+		resources[i] = render.ManifestRef{
+			Kind:      r.Kind,
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Action:    r.Action,
+		}
+	}
+
+	now := time.Now().UTC()
+	res := benchDownResult{
+		Name:      in.Name,
+		ChainID:   chainID,
+		Namespace: namespace,
+		Resources: resources,
+		DeletedAt: &now,
+	}
+	if err := clioutput.Emit(out, clioutput.KindBenchDownResult, res); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+func failBenchDown(out io.Writer, e *clioutput.Error) error {
+	_ = clioutput.EmitError(out, clioutput.KindBenchDownResult, e)
+	return cli.Exit("", e.Code)
+}

--- a/cluster/bench_down_test.go
+++ b/cluster/bench_down_test.go
@@ -1,0 +1,128 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+)
+
+func TestRunBenchDown(t *testing.T) {
+	t.Run("emits BenchDownResult with per-resource actions and appliedAt", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		var capturedSelector string
+		deps := benchDownDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{Namespace: "eng-bdc"}, nil
+			},
+			deleteFn: func(_ context.Context, _ *kube.Client, opts kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				capturedSelector = opts.LabelSelector
+				return []kube.DeleteResult{
+					{Kind: "SeiNodeDeployment", Name: "bench-bdc-demo", Namespace: "eng-bdc", Action: "deleted"},
+					{Kind: "SeiNodeDeployment", Name: "bench-bdc-demo-rpc", Namespace: "eng-bdc", Action: "deleted"},
+					{Kind: "Job", Name: "seiload-bench-bdc-demo", Namespace: "eng-bdc", Action: "deleted"},
+					{Kind: "ConfigMap", Name: "seiload-profile-bench-bdc-demo", Namespace: "eng-bdc", Action: "not-found"},
+				}, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "demo"}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runBenchDown: %v\nbody=%s", err, buf.String())
+		}
+		if capturedSelector != "sei.io/engineer=bdc,sei.io/bench-name=demo" {
+			t.Errorf("selector: got %q", capturedSelector)
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		if env.Kind != clioutput.KindBenchDownResult {
+			t.Errorf("kind: %q", env.Kind)
+		}
+		var data benchDownResult
+		_ = json.Unmarshal(env.Data, &data)
+		if data.ChainID != "bench-bdc-demo" || data.Namespace != "eng-bdc" {
+			t.Errorf("identity fields: %+v", data)
+		}
+		if len(data.Resources) != 4 {
+			t.Errorf("resources: got %d, want 4", len(data.Resources))
+		}
+		if data.DeletedAt == nil {
+			t.Errorf("deletedAt should be set")
+		}
+		// Per-action wiring round-trips correctly.
+		seen := map[string]int{}
+		for _, r := range data.Resources {
+			seen[r.Action]++
+		}
+		if seen["deleted"] != 3 || seen["not-found"] != 1 {
+			t.Errorf("action distribution: %+v", seen)
+		}
+	})
+
+	t.Run("rejects bad name with validation category", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "Bad-Name"}, &buf, benchDownDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				t.Fatalf("kube client should not be constructed for invalid name")
+				return nil, nil
+			},
+			deleteFn: nil,
+		})
+		if err == nil || !strings.Contains(buf.String(), "validation") {
+			t.Errorf("expected validation error; got %s", buf.String())
+		}
+	})
+
+	t.Run("propagates kubeconfig errors with ExitIdentity", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "demo"}, &buf, benchDownDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatKubeconfigParse, "no kubeconfig")
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		ec, ok := err.(interface{ ExitCode() int })
+		if !ok || ec.ExitCode() != clioutput.ExitIdentity {
+			t.Errorf("exit code: got %v, want %d", err, clioutput.ExitIdentity)
+		}
+	})
+
+	t.Run("propagates delete errors with finalizer-stuck category", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "demo"}, &buf, benchDownDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{}, nil
+			},
+			deleteFn: func(context.Context, *kube.Client, kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				return nil, clioutput.New(clioutput.ExitBench, clioutput.CatFinalizerStuck, "PVC stuck")
+			},
+		})
+		if err == nil || !strings.Contains(buf.String(), "finalizer-stuck") {
+			t.Errorf("expected finalizer-stuck; got %s", buf.String())
+		}
+	})
+
+	t.Run("missing identity surfaces typed error", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "demo"}, &buf, benchDownDeps{
+			identityPath: func() (string, error) { return "", errors.New("home unset") },
+		})
+		if err == nil || !strings.Contains(buf.String(), `"category": "missing"`) {
+			t.Errorf("expected missing identity; got %s", buf.String())
+		}
+	})
+}

--- a/cluster/bench_list.go
+++ b/cluster/bench_list.go
@@ -1,0 +1,254 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/identity"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+)
+
+// benchOwnerSelector scopes lists to objects this engineer owns.
+// `app.kubernetes.io/part-of=seictl-bench` survives the rename if the
+// engineer alias changes; `sei.io/engineer=<alias>` is the per-engineer
+// IAM-aligned scope.
+const benchPartOf = "seictl-bench"
+
+type benchListResult struct {
+	Items []benchSummary `json:"items"`
+}
+
+type benchSummary struct {
+	ChainID           string `json:"chainId"`
+	Name              string `json:"name"`
+	Namespace         string `json:"namespace"`
+	Owner             string `json:"owner"`
+	Phase             string `json:"phase"`
+	ValidatorsReady   int    `json:"validatorsReady"`
+	ValidatorsDesired int    `json:"validatorsDesired"`
+	RPCReady          int    `json:"rpcReady"`
+	RPCDesired        int    `json:"rpcDesired"`
+	LoadJobPhase      string `json:"loadJobPhase"`
+	AgeSeconds        int64  `json:"ageSeconds"`
+	ImageDigest       string `json:"imageDigest"`
+}
+
+type benchListInput struct {
+	AllNamespaces bool
+	Namespace     string
+	Kubeconfig    string
+	Context       string
+}
+
+type benchListDeps struct {
+	identityPath  func() (string, error)
+	newKubeClient func(kube.Options) (*kube.Client, *clioutput.Error)
+	listFn        func(ctx context.Context, kc *kube.Client, opts kube.ListOptions) ([]unstructured.Unstructured, *clioutput.Error)
+}
+
+var defaultBenchListDeps = benchListDeps{
+	identityPath:  identity.DefaultPath,
+	newKubeClient: kube.New,
+	listFn:        listFromCluster,
+}
+
+func listFromCluster(ctx context.Context, kc *kube.Client, opts kube.ListOptions) ([]unstructured.Unstructured, *clioutput.Error) {
+	out, err := kc.List(ctx, opts)
+	if err != nil {
+		return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatApplyFailed, "%v", err)
+	}
+	return out, nil
+}
+
+var benchListCmd = &cli.Command{
+	Name:  "list",
+	Usage: "Owner-scoped list of running benchmarks",
+	Flags: append(kubeconfigFlags(),
+		&cli.BoolFlag{Name: "all-namespaces", Aliases: []string{"A"}, Usage: "List across all namespaces (defaults to eng-<alias>)"},
+		&cli.StringFlag{Name: "namespace", Aliases: []string{"n"}, Usage: "Namespace override"},
+	),
+	Action: func(ctx context.Context, command *cli.Command) error {
+		return runBenchList(ctx, benchListInput{
+			AllNamespaces: command.Bool("all-namespaces"),
+			Namespace:     command.String("namespace"),
+			Kubeconfig:    command.String("kubeconfig"),
+			Context:       command.String("context"),
+		}, os.Stdout, defaultBenchListDeps)
+	},
+}
+
+func runBenchList(ctx context.Context, in benchListInput, out io.Writer, deps benchListDeps) error {
+	eng, idErr := loadEngineer(deps.identityPath)
+	if idErr != nil {
+		return failBenchList(out, idErr)
+	}
+
+	namespace := in.Namespace
+	if namespace == "" {
+		namespace = "eng-" + eng.Alias
+	}
+	selector := fmt.Sprintf("app.kubernetes.io/part-of=%s,sei.io/engineer=%s", benchPartOf, eng.Alias)
+
+	kc, kerr := deps.newKubeClient(kube.Options{Kubeconfig: in.Kubeconfig, Context: in.Context})
+	if kerr != nil {
+		return failBenchList(out, kerr)
+	}
+
+	snds, lErr := deps.listFn(ctx, kc, kube.ListOptions{
+		Namespace:     namespace,
+		AllNamespaces: in.AllNamespaces,
+		Resources:     []string{"seinodedeployments.sei.io"},
+		LabelSelector: selector,
+	})
+	if lErr != nil {
+		return failBenchList(out, lErr)
+	}
+	jobs, lErr := deps.listFn(ctx, kc, kube.ListOptions{
+		Namespace:     namespace,
+		AllNamespaces: in.AllNamespaces,
+		Resources:     []string{"jobs.batch"},
+		LabelSelector: selector,
+	})
+	if lErr != nil {
+		return failBenchList(out, lErr)
+	}
+
+	res := benchListResult{Items: aggregateBenchSummaries(snds, jobs)}
+	if err := clioutput.Emit(out, clioutput.KindBenchListResult, res); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+// aggregateBenchSummaries groups SNDs + Jobs by chain-id (the
+// `sei.io/chain-id` label) and produces one benchSummary per group.
+// Validator vs. RPC SND is distinguished by the `sei.io/role` label.
+func aggregateBenchSummaries(snds, jobs []unstructured.Unstructured) []benchSummary {
+	type group struct {
+		validator *unstructured.Unstructured
+		rpc       *unstructured.Unstructured
+		job       *unstructured.Unstructured
+	}
+	groups := map[string]*group{}
+
+	for i := range snds {
+		snd := &snds[i]
+		chainID := snd.GetLabels()["sei.io/chain-id"]
+		if chainID == "" {
+			continue
+		}
+		g, ok := groups[chainID]
+		if !ok {
+			g = &group{}
+			groups[chainID] = g
+		}
+		switch snd.GetLabels()["sei.io/role"] {
+		case "validator":
+			g.validator = snd
+		case "rpc":
+			g.rpc = snd
+		}
+	}
+	for i := range jobs {
+		j := &jobs[i]
+		chainID := j.GetLabels()["sei.io/chain-id"]
+		if chainID == "" {
+			continue
+		}
+		g, ok := groups[chainID]
+		if !ok {
+			g = &group{}
+			groups[chainID] = g
+		}
+		g.job = j
+	}
+
+	out := make([]benchSummary, 0, len(groups))
+	for chainID, g := range groups {
+		out = append(out, summarize(chainID, g.validator, g.rpc, g.job))
+	}
+	return out
+}
+
+func summarize(chainID string, validator, rpc, job *unstructured.Unstructured) benchSummary {
+	summary := benchSummary{ChainID: chainID}
+
+	primary := validator
+	if primary == nil {
+		primary = rpc
+	}
+	if primary == nil && job != nil {
+		primary = job
+	}
+	if primary != nil {
+		labels := primary.GetLabels()
+		summary.Name = labels["sei.io/bench-name"]
+		summary.Namespace = primary.GetNamespace()
+		summary.Owner = labels["sei.io/engineer"]
+		summary.ImageDigest = labels["sei.io/image-sha"]
+		ts := primary.GetCreationTimestamp().Time
+		if !ts.IsZero() {
+			summary.AgeSeconds = int64(time.Since(ts).Seconds())
+		}
+	}
+	if validator != nil {
+		summary.Phase, _, _ = unstructured.NestedString(validator.Object, "status", "phase")
+		summary.ValidatorsDesired = intField(validator, "spec", "replicas")
+		summary.ValidatorsReady = intField(validator, "status", "readyReplicas")
+	}
+	if rpc != nil {
+		summary.RPCDesired = intField(rpc, "spec", "replicas")
+		summary.RPCReady = intField(rpc, "status", "readyReplicas")
+	}
+	if job != nil {
+		summary.LoadJobPhase = jobPhaseFor(job)
+	}
+	return summary
+}
+
+func intField(u *unstructured.Unstructured, fields ...string) int {
+	v, _, _ := unstructured.NestedInt64(u.Object, fields...)
+	return int(v)
+}
+
+// jobPhaseFor folds Job .status fields into a single phase string the
+// engineer can act on. Mirrors what kubectl prints in `Jobs:` columns.
+func jobPhaseFor(job *unstructured.Unstructured) string {
+	conditions, _, _ := unstructured.NestedSlice(job.Object, "status", "conditions")
+	for _, c := range conditions {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		ctype, _ := cm["type"].(string)
+		cstatus, _ := cm["status"].(string)
+		if cstatus != "True" {
+			continue
+		}
+		if strings.EqualFold(ctype, "Complete") {
+			return "Succeeded"
+		}
+		if strings.EqualFold(ctype, "Failed") {
+			return "Failed"
+		}
+	}
+	active := intField(job, "status", "active")
+	if active > 0 {
+		return "Running"
+	}
+	return "Pending"
+}
+
+func failBenchList(out io.Writer, e *clioutput.Error) error {
+	_ = clioutput.EmitError(out, clioutput.KindBenchListResult, e)
+	return cli.Exit("", e.Code)
+}

--- a/cluster/bench_list_test.go
+++ b/cluster/bench_list_test.go
@@ -1,0 +1,188 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+)
+
+func newSND(t *testing.T, name, role, chainID, ns string, replicas, ready int, phase, imageSHA string) unstructured.Unstructured {
+	t.Helper()
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("sei.io/v1alpha1")
+	u.SetKind("SeiNodeDeployment")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	u.SetLabels(map[string]string{
+		"sei.io/chain-id":              chainID,
+		"sei.io/role":                  role,
+		"sei.io/engineer":              "bdc",
+		"sei.io/bench-name":            strings.TrimPrefix(strings.TrimSuffix(chainID, "-rpc"), "bench-bdc-"),
+		"sei.io/image-sha":             imageSHA,
+		"app.kubernetes.io/part-of":    "seictl-bench",
+		"app.kubernetes.io/managed-by": "seictl",
+	})
+	u.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-3 * time.Minute)))
+	_ = unstructured.SetNestedField(u.Object, int64(replicas), "spec", "replicas")
+	_ = unstructured.SetNestedField(u.Object, int64(ready), "status", "readyReplicas")
+	if phase != "" {
+		_ = unstructured.SetNestedField(u.Object, phase, "status", "phase")
+	}
+	return u
+}
+
+func newJob(t *testing.T, name, chainID, ns string, active int, condComplete bool) unstructured.Unstructured {
+	t.Helper()
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("batch/v1")
+	u.SetKind("Job")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	u.SetLabels(map[string]string{
+		"sei.io/chain-id":              chainID,
+		"sei.io/engineer":              "bdc",
+		"sei.io/bench-name":            strings.TrimPrefix(chainID, "bench-bdc-"),
+		"app.kubernetes.io/part-of":    "seictl-bench",
+		"app.kubernetes.io/managed-by": "seictl",
+	})
+	u.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-3 * time.Minute)))
+	_ = unstructured.SetNestedField(u.Object, int64(active), "status", "active")
+	if condComplete {
+		_ = unstructured.SetNestedSlice(u.Object, []any{
+			map[string]any{"type": "Complete", "status": "True"},
+		}, "status", "conditions")
+	}
+	return u
+}
+
+func TestRunBenchList(t *testing.T) {
+	t.Run("aggregates SNDs and Job into one BenchSummary per chain-id", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		snds := []unstructured.Unstructured{
+			newSND(t, "bench-bdc-demo", "validator", "bench-bdc-demo", "eng-bdc", 4, 3, "Running", "abc123"),
+			newSND(t, "bench-bdc-demo-rpc", "rpc", "bench-bdc-demo", "eng-bdc", 1, 1, "", "abc123"),
+		}
+		jobs := []unstructured.Unstructured{
+			newJob(t, "seiload-bench-bdc-demo", "bench-bdc-demo", "eng-bdc", 1, false),
+		}
+
+		var listCalls int
+		deps := benchListDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{Namespace: "eng-bdc"}, nil
+			},
+			listFn: func(_ context.Context, _ *kube.Client, opts kube.ListOptions) ([]unstructured.Unstructured, *clioutput.Error) {
+				listCalls++
+				if !strings.Contains(opts.LabelSelector, "sei.io/engineer=bdc") {
+					t.Errorf("missing engineer scope in selector: %q", opts.LabelSelector)
+				}
+				switch opts.Resources[0] {
+				case "seinodedeployments.sei.io":
+					return snds, nil
+				case "jobs.batch":
+					return jobs, nil
+				}
+				return nil, nil
+			},
+		}
+
+		var buf bytes.Buffer
+		err := runBenchList(context.Background(), benchListInput{}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runBenchList: %v\nbody=%s", err, buf.String())
+		}
+		if listCalls != 2 {
+			t.Errorf("listFn calls: got %d, want 2 (SNDs + Jobs)", listCalls)
+		}
+
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data benchListResult
+		_ = json.Unmarshal(env.Data, &data)
+		if len(data.Items) != 1 {
+			t.Fatalf("items: got %d, want 1", len(data.Items))
+		}
+		s := data.Items[0]
+		if s.ChainID != "bench-bdc-demo" || s.Name != "demo" || s.Namespace != "eng-bdc" || s.Owner != "bdc" {
+			t.Errorf("identity fields: %+v", s)
+		}
+		if s.Phase != "Running" {
+			t.Errorf("phase: %q", s.Phase)
+		}
+		if s.ValidatorsDesired != 4 || s.ValidatorsReady != 3 {
+			t.Errorf("validator counts: %d/%d", s.ValidatorsReady, s.ValidatorsDesired)
+		}
+		if s.RPCDesired != 1 || s.RPCReady != 1 {
+			t.Errorf("rpc counts: %d/%d", s.RPCReady, s.RPCDesired)
+		}
+		if s.LoadJobPhase != "Running" {
+			t.Errorf("load job phase: %q", s.LoadJobPhase)
+		}
+		if s.ImageDigest != "abc123" {
+			t.Errorf("image digest: %q", s.ImageDigest)
+		}
+		if s.AgeSeconds < 100 || s.AgeSeconds > 300 {
+			t.Errorf("age (~3min): %d", s.AgeSeconds)
+		}
+	})
+
+	t.Run("empty cluster returns empty items", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		var buf bytes.Buffer
+		err := runBenchList(context.Background(), benchListInput{}, &buf, benchListDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{}, nil
+			},
+			listFn: func(context.Context, *kube.Client, kube.ListOptions) ([]unstructured.Unstructured, *clioutput.Error) {
+				return nil, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("runBenchList: %v", err)
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data benchListResult
+		_ = json.Unmarshal(env.Data, &data)
+		if len(data.Items) != 0 {
+			t.Errorf("expected empty items; got %+v", data.Items)
+		}
+	})
+
+	t.Run("completed job surfaces Succeeded phase", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		jobs := []unstructured.Unstructured{
+			newJob(t, "seiload-bench-bdc-demo", "bench-bdc-demo", "eng-bdc", 0, true),
+		}
+		deps := benchListDeps{
+			identityPath:  func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) { return &kube.Client{}, nil },
+			listFn: func(_ context.Context, _ *kube.Client, opts kube.ListOptions) ([]unstructured.Unstructured, *clioutput.Error) {
+				if opts.Resources[0] == "jobs.batch" {
+					return jobs, nil
+				}
+				return nil, nil
+			},
+		}
+		var buf bytes.Buffer
+		_ = runBenchList(context.Background(), benchListInput{}, &buf, deps)
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data benchListResult
+		_ = json.Unmarshal(env.Data, &data)
+		if len(data.Items) != 1 || data.Items[0].LoadJobPhase != "Succeeded" {
+			t.Errorf("expected Succeeded; got %+v", data.Items)
+		}
+	})
+}

--- a/cluster/internal/clioutput/envelope.go
+++ b/cluster/internal/clioutput/envelope.go
@@ -18,8 +18,10 @@ const APIVersion = "seictl.sei.io/v1"
 // Kinds emitted by cluster-facing verbs. New verbs add a constant here
 // rather than open-coding the string at the call site.
 const (
-	KindContextResult = "ContextResult"
-	KindBenchUpResult = "BenchUpResult"
+	KindContextResult   = "ContextResult"
+	KindBenchUpResult   = "BenchUpResult"
+	KindBenchDownResult = "BenchDownResult"
+	KindBenchListResult = "BenchListResult"
 )
 
 const (

--- a/cluster/internal/clioutput/envelope_test.go
+++ b/cluster/internal/clioutput/envelope_test.go
@@ -115,12 +115,16 @@ func TestEnvelopeContract_Stable(t *testing.T) {
 		t.Errorf("APIVersion: got %q, want %q", APIVersion, "seictl.sei.io/v1")
 	}
 	want := map[string]string{
-		"KindContextResult": "ContextResult",
-		"KindBenchUpResult": "BenchUpResult",
+		"KindContextResult":   "ContextResult",
+		"KindBenchUpResult":   "BenchUpResult",
+		"KindBenchDownResult": "BenchDownResult",
+		"KindBenchListResult": "BenchListResult",
 	}
 	got := map[string]string{
-		"KindContextResult": KindContextResult,
-		"KindBenchUpResult": KindBenchUpResult,
+		"KindContextResult":   KindContextResult,
+		"KindBenchUpResult":   KindBenchUpResult,
+		"KindBenchDownResult": KindBenchDownResult,
+		"KindBenchListResult": KindBenchListResult,
 	}
 	for k, v := range want {
 		if got[k] != v {

--- a/cluster/internal/kube/delete.go
+++ b/cluster/internal/kube/delete.go
@@ -1,0 +1,87 @@
+package kube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/utils/ptr"
+)
+
+// DeleteResult is what Delete emits per matched object.
+type DeleteResult struct {
+	Kind      string
+	Name      string
+	Namespace string
+	Action    string // "deleted" | "not-found" | "still-terminating"
+}
+
+// DeleteOptions mirrors ListOptions — same selector + resource types,
+// but every match is deleted with foreground propagation.
+type DeleteOptions struct {
+	Namespace     string
+	Resources     []string
+	LabelSelector string
+}
+
+// Delete tears down all objects matching the label selector across the
+// requested resource types. DeletePropagationForeground ensures children
+// (e.g., StatefulSet pods owned by a SeiNodeDeployment) cascade in order.
+//
+// Returns one DeleteResult per matched object. NotFound is treated as
+// success ("already gone"). The caller is responsible for the
+// finalizer-stuck timeout policy (LLD §Landmine).
+func (c *Client) Delete(ctx context.Context, opts DeleteOptions) ([]DeleteResult, error) {
+	if c.flags == nil {
+		return nil, errors.New("kube.Client has no ConfigFlags; constructed without cluster access")
+	}
+	if len(opts.Resources) == 0 {
+		return nil, errors.New("DeleteOptions.Resources required")
+	}
+
+	result := resource.NewBuilder(c.flags).
+		Unstructured().
+		ContinueOnError().
+		NamespaceParam(opts.Namespace).DefaultNamespace().
+		LabelSelectorParam(opts.LabelSelector).
+		ResourceTypes(opts.Resources...).
+		Flatten().
+		Do()
+	if err := result.Err(); err != nil {
+		return nil, wrapMappingErr(err)
+	}
+
+	var results []DeleteResult
+	visitErr := result.Visit(func(info *resource.Info, vErr error) error {
+		if vErr != nil {
+			return wrapMappingErr(vErr)
+		}
+		helper := resource.NewHelper(info.Client, info.Mapping)
+		_, err := helper.DeleteWithOptions(info.Namespace, info.Name, &metav1.DeleteOptions{
+			PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
+		})
+
+		action := "deleted"
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				action = "not-found"
+			} else {
+				return fmt.Errorf("delete %s/%s in %s: %w", info.Mapping.GroupVersionKind.Kind, info.Name, info.Namespace, err)
+			}
+		}
+		results = append(results, DeleteResult{
+			Kind:      info.Mapping.GroupVersionKind.Kind,
+			Name:      info.Name,
+			Namespace: info.Namespace,
+			Action:    action,
+		})
+		return nil
+	})
+	if visitErr != nil {
+		return nil, wrapMappingErr(visitErr)
+	}
+	return results, nil
+}

--- a/cluster/internal/kube/list.go
+++ b/cluster/internal/kube/list.go
@@ -1,0 +1,67 @@
+package kube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+// ListOptions selects what to list. Resources is a slice of resource
+// names (plural) like "seinodedeployments", "jobs", "configmaps".
+// LabelSelector follows the standard `key=value,key2=value2` form.
+type ListOptions struct {
+	Namespace     string
+	Resources     []string
+	LabelSelector string
+	AllNamespaces bool
+}
+
+// List returns Unstructured objects across the given resource types
+// filtered by labels. Errors short-circuit; partial results are not
+// returned (mirrors Apply's all-or-nothing contract).
+func (c *Client) List(ctx context.Context, opts ListOptions) ([]unstructured.Unstructured, error) {
+	if c.flags == nil {
+		return nil, errors.New("kube.Client has no ConfigFlags; constructed without cluster access")
+	}
+	if len(opts.Resources) == 0 {
+		return nil, errors.New("ListOptions.Resources required")
+	}
+
+	b := resource.NewBuilder(c.flags).
+		Unstructured().
+		ContinueOnError().
+		LabelSelectorParam(opts.LabelSelector).
+		ResourceTypes(opts.Resources...).
+		Flatten()
+
+	if opts.AllNamespaces {
+		b = b.AllNamespaces(true)
+	} else {
+		b = b.NamespaceParam(opts.Namespace).DefaultNamespace()
+	}
+
+	result := b.Do()
+	if err := result.Err(); err != nil {
+		return nil, wrapMappingErr(err)
+	}
+
+	var out []unstructured.Unstructured
+	visitErr := result.Visit(func(info *resource.Info, vErr error) error {
+		if vErr != nil {
+			return wrapMappingErr(vErr)
+		}
+		u, ok := info.Object.(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("unexpected object type %T for %s/%s", info.Object, info.Namespace, info.Name)
+		}
+		out = append(out, *u)
+		return nil
+	})
+	if visitErr != nil {
+		return nil, wrapMappingErr(visitErr)
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary

Slice 5 of the cluster-cli LLD. Engineers can now manage running benches alongside `bench up`. All three verbs (up / down / list) share the cli-runtime Builder + Helper machinery from #76 — the standardization payoff promised in that PR.

## What landed

**`cluster/internal/kube` primitives (~165 LoC):**
- `list.go` — `Client.List` wraps Builder with `LabelSelectorParam` + `ResourceTypes` for owner-scoped queries across kinds in one call.
- `delete.go` — `Client.Delete` wraps `Helper.DeleteWithOptions` with `DeletePropagationForeground` per LLD §Apply strategy. `NotFound` is treated as success.

**`cluster/` verbs:**
- `bench_down.go` — `seictl bench down --name <name>`. Label-selected delete via `sei.io/engineer=<alias>,sei.io/bench-name=<name>`. `BenchDownResult` schema matches LLD §`bench down`. Finalizer failures → `CatFinalizerStuck`.
- `bench_list.go` — `seictl bench list [--all-namespaces]`. Two list calls (SNDs + Jobs) scoped by `app.kubernetes.io/part-of=seictl-bench,sei.io/engineer=<alias>`. `aggregateBenchSummaries` groups by chain-id, distinguishes validator vs RPC SND via `sei.io/role`, folds Job conditions into a phase string. `BenchSummary` matches LLD §`bench list`.

**Schema additions:** `KindBenchDownResult` and `KindBenchListResult` in `clioutput`. Stable-pin test updated.

## Sample output

```
$ seictl bench list
{
  "apiVersion": "seictl.sei.io/v1",
  "kind": "BenchListResult",
  "data": {
    "items": [
      {
        "chainId": "bench-bdc-demo",
        "name": "demo",
        "namespace": "eng-bdc",
        "owner": "bdc",
        "phase": "Running",
        "validatorsReady": 3, "validatorsDesired": 4,
        "rpcReady": 1, "rpcDesired": 1,
        "loadJobPhase": "Running",
        "ageSeconds": 187,
        "imageDigest": "abc123"
      }
    ]
  }
}
```

## Test plan

- [x] `bench_down_test.go` — 5 subtests: 4-resource bundle with mixed deleted/not-found actions; bad name validation; kubeconfig error preserves `ExitIdentity`; finalizer-stuck propagation; missing identity
- [x] `bench_list_test.go` — 3 subtests: SND+Job aggregation; empty cluster; completed Job → `Succeeded`
- [x] `go test ./cluster/...` green
- [x] Manual smoke: `seictl bench --help` shows down/list/up; `seictl bench list` without identity returns `category: missing`, exit 40

## Deferred

- **envtest coverage for `kube.List` / `kube.Delete`** — same pattern as #77's apply tests. Trigger: bundle with slice 4 (`onboard --apply`) where the kube primitives get exercised end-to-end. Tracked informally; happy to file an issue if you want a hard pointer.
- **`--wait` / `--timeout` flags on `bench down`** — LLD lists them but the engineer-bench scale (single user, single cluster) doesn't need waiter logic in v1. Trigger: first request from someone scripting around teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)