### PR TITLE
feat(cluster): fail-fast AWS preflight with profile-aware hint

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -78,6 +78,7 @@ type benchDeps struct {
 	identityPath  func() (string, error)
 	newKubeClient func(kube.Options) (*kube.Client, *clioutput.Error)
 	apply         func(ctx context.Context, kc *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error)
+	getCaller     func(context.Context) (*aws.Caller, *clioutput.Error)
 }
 
 var defaultBenchDeps = benchDeps{
@@ -85,6 +86,7 @@ var defaultBenchDeps = benchDeps{
 	identityPath:  identity.DefaultPath,
 	newKubeClient: kube.New,
 	apply:         applyToCluster,
+	getCaller:     aws.GetCaller,
 }
 
 func applyToCluster(ctx context.Context, kc *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
@@ -148,6 +150,10 @@ func runBenchUp(ctx context.Context, in benchUpInput, out io.Writer, deps benchD
 	namespace := "eng-" + eng.Alias
 	if e := validate.Namespace(namespace, eng.Alias); e != nil {
 		return failBenchUp(out, e)
+	}
+
+	if _, callerErr := deps.getCaller(ctx); callerErr != nil {
+		return failBenchUp(out, callerErr)
 	}
 
 	digest, dErr := deps.resolveDigest(ctx, in.Image)

--- a/cluster/bench_test.go
+++ b/cluster/bench_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sei-protocol/seictl/cluster/internal/aws"
 	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
 	"github.com/sei-protocol/seictl/cluster/internal/identity"
 	"github.com/sei-protocol/seictl/cluster/internal/kube"
@@ -26,6 +27,10 @@ func writeEngineerFile(t *testing.T, alias string) string {
 	return path
 }
 
+func okCaller(context.Context) (*aws.Caller, *clioutput.Error) {
+	return &aws.Caller{Account: "189176372795", Region: "eu-central-1", PrincipalARN: "arn:aws:sts::189176372795:assumed-role/Eng/bdc"}, nil
+}
+
 func stubBenchDeps(t *testing.T, alias string) benchDeps {
 	t.Helper()
 	path := writeEngineerFile(t, alias)
@@ -38,6 +43,7 @@ func stubBenchDeps(t *testing.T, alias string) benchDeps {
 			t.Fatalf("apply should not be called on dry-run path")
 			return nil, nil
 		},
+		getCaller: okCaller,
 	}
 }
 
@@ -169,6 +175,7 @@ func TestRunBenchUp(t *testing.T) {
 				return "", clioutput.New(clioutput.ExitBench, clioutput.CatImageResolution, "ecr unavailable")
 			},
 			identityPath: func() (string, error) { return path, nil },
+			getCaller:    okCaller,
 		}
 		var buf bytes.Buffer
 		err := runBenchUp(context.Background(), benchUpInput{
@@ -215,6 +222,7 @@ func TestRunBenchUp(t *testing.T) {
 			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
 				return &kube.Client{ContextName: "harbor", Namespace: "eng-bdc"}, nil
 			},
+			getCaller: okCaller,
 			apply: func(_ context.Context, _ *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
 				if fieldOwner != benchFieldOwner {
 					t.Errorf("field owner: got %q, want %q", fieldOwner, benchFieldOwner)
@@ -281,6 +289,7 @@ func TestRunBenchUp(t *testing.T) {
 			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
 				return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatKubeconfigParse, "no kubeconfig")
 			},
+			getCaller: okCaller,
 			apply: func(context.Context, *kube.Client, string, string, [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
 				t.Fatalf("apply should not be called when kubeconfig fails")
 				return nil, nil
@@ -316,6 +325,7 @@ func TestRunBenchUp(t *testing.T) {
 			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
 				return &kube.Client{}, nil
 			},
+			getCaller: okCaller,
 			apply: func(context.Context, *kube.Client, string, string, [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
 				return nil, clioutput.New(clioutput.ExitBench, clioutput.CatApplyFailed, "API server says no")
 			},

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -59,13 +59,18 @@ func runContext(ctx context.Context, kubeconfig, kubeContext string, out io.Writ
 		Namespace:   kc.Namespace,
 	}
 
-	// AWS is best-effort: SSO sessions expire and engineers run `context`
-	// to diagnose that.
-	if caller, awsErr := deps.getCaller(ctx); awsErr == nil {
-		res.AWSAccount = caller.Account
-		res.AWSRegion = caller.Region
-		res.AWSPrincipalARN = caller.PrincipalARN
+	// AWS is required: every side-effecting verb needs it, so failing
+	// here saves the engineer from running through more verbs that all
+	// fail in different shapes. The error message carries the specific
+	// remediation hint via aws.CredsHint.
+	caller, awsErr := deps.getCaller(ctx)
+	if awsErr != nil {
+		_ = clioutput.EmitError(out, clioutput.KindContextResult, awsErr)
+		return cli.Exit("", awsErr.Code)
 	}
+	res.AWSAccount = caller.Account
+	res.AWSRegion = caller.Region
+	res.AWSPrincipalARN = caller.PrincipalARN
 
 	if path, err := deps.identityPath(); err == nil {
 		eng, idErr := identity.Read(path)

--- a/cluster/context_test.go
+++ b/cluster/context_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sei-protocol/seictl/cluster/internal/aws"
@@ -85,12 +86,13 @@ func TestRunContext(t *testing.T) {
 		}
 	})
 
-	t.Run("aws failure leaves aws fields empty", func(t *testing.T) {
+	t.Run("aws failure exits ExitIdentity with error envelope", func(t *testing.T) {
 		path := writeKubeconfig(t)
 
 		stub := contextDeps{
 			getCaller: func(context.Context) (*aws.Caller, *clioutput.Error) {
-				return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatAWSUnavailable, "expired SSO")
+				return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatAWSUnavailable,
+					"AWS_PROFILE not set; ~/.aws/config has profile \"sei\"")
 			},
 			identityPath: func() (string, error) {
 				return "", errors.New("skip")
@@ -98,17 +100,27 @@ func TestRunContext(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		if err := runContext(context.Background(), path, "", &buf, stub); err != nil {
-			t.Fatalf("runContext should not fail on AWS error: %v", err)
+		err := runContext(context.Background(), path, "", &buf, stub)
+		if err == nil {
+			t.Fatalf("runContext should fail when AWS unavailable")
+		}
+		type exitCoder interface{ ExitCode() int }
+		ec, ok := err.(exitCoder)
+		if !ok {
+			t.Fatalf("error must implement ExitCode(); got %T", err)
+		}
+		if ec.ExitCode() != clioutput.ExitIdentity {
+			t.Errorf("exit code: got %d want %d", ec.ExitCode(), clioutput.ExitIdentity)
 		}
 		var env clioutput.Envelope
 		if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 			t.Fatalf("unmarshal: %v", err)
 		}
-		var data contextResult
-		_ = json.Unmarshal(env.Data, &data)
-		if data.AWSAccount != "" || data.AWSPrincipalARN != "" {
-			t.Errorf("aws fields should be empty: %+v", data)
+		if env.Error == nil || env.Error.Category != clioutput.CatAWSUnavailable {
+			t.Errorf("expected error envelope with aws-unavailable, got %+v", env.Error)
+		}
+		if env.Error != nil && !strings.Contains(env.Error.Message, "AWS_PROFILE") {
+			t.Errorf("error message should carry the hint, got %q", env.Error.Message)
 		}
 	})
 

--- a/cluster/internal/aws/caller.go
+++ b/cluster/internal/aws/caller.go
@@ -20,12 +20,18 @@ type Caller struct {
 
 // GetCaller resolves the active AWS principal via STS GetCallerIdentity.
 // Errors map to ExitIdentity / CatAWSUnavailable — this is a read of
-// auth state, not a creation.
+// auth state, not a creation. When the failure is "no credentials
+// resolvable" (vs e.g. permission denied), the message is prefixed with
+// CredsHint() so the engineer sees the specific remediation.
 func GetCaller(ctx context.Context) (*Caller, *clioutput.Error) {
 	cfg, err := awscfg.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatAWSUnavailable,
-			"load AWS config: %v", err)
+			"%s (load AWS config: %v)", CredsHint(), err)
+	}
+	if _, credsErr := cfg.Credentials.Retrieve(ctx); credsErr != nil {
+		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatAWSUnavailable,
+			"%s (%v)", CredsHint(), credsErr)
 	}
 	out, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, nil)
 	if err != nil {

--- a/cluster/internal/aws/creds_hint.go
+++ b/cluster/internal/aws/creds_hint.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CredsHint returns a one-line remediation for the "no AWS credentials
+// resolvable" case. It reads AWS_PROFILE and ~/.aws/config so the message
+// names a profile the engineer can actually use, instead of a generic
+// "Unable to locate credentials".
+func CredsHint() string {
+	if p := os.Getenv("AWS_PROFILE"); p != "" {
+		return fmt.Sprintf("AWS_PROFILE=%s is set but credentials don't resolve; try `aws sso login --profile %s`", p, p)
+	}
+	profiles := readAWSConfigProfiles()
+	switch len(profiles) {
+	case 0:
+		return "no AWS credentials and no profiles in ~/.aws/config; configure SSO via `aws configure sso`"
+	case 1:
+		return fmt.Sprintf("no default profile; ~/.aws/config has profile %q — try `export AWS_PROFILE=%s && aws sso login --profile %s`",
+			profiles[0], profiles[0], profiles[0])
+	default:
+		return fmt.Sprintf("no default profile; ~/.aws/config has profiles %v — set AWS_PROFILE to one and `aws sso login --profile <name>`",
+			profiles)
+	}
+}
+
+// readAWSConfigProfiles returns the profile names from ~/.aws/config in
+// stable (alphabetical) order. Section types other than `default` /
+// `profile X` (e.g. `sso-session X`) are skipped — they're not selectable
+// via AWS_PROFILE.
+func readAWSConfigProfiles() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	f, err := os.Open(filepath.Join(home, ".aws", "config"))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	seen := map[string]struct{}{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "[") || !strings.HasSuffix(line, "]") {
+			continue
+		}
+		header := strings.TrimSpace(line[1 : len(line)-1])
+		switch {
+		case header == "default":
+			seen["default"] = struct{}{}
+		case strings.HasPrefix(header, "profile "):
+			seen[strings.TrimSpace(strings.TrimPrefix(header, "profile "))] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cluster/internal/aws/creds_hint_test.go
+++ b/cluster/internal/aws/creds_hint_test.go
@@ -1,0 +1,71 @@
+package aws
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCredsHint(t *testing.T) {
+	// Isolate from the developer's real ~/.aws/config and AWS_PROFILE.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AWS_PROFILE", "")
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	t.Run("AWS_PROFILE set takes precedence", func(t *testing.T) {
+		t.Setenv("AWS_PROFILE", "sei")
+		got := CredsHint()
+		if !strings.Contains(got, "AWS_PROFILE=sei") || !strings.Contains(got, "aws sso login --profile sei") {
+			t.Errorf("hint should reference the set profile and login command; got %q", got)
+		}
+	})
+
+	t.Run("no profile, single named profile in config", func(t *testing.T) {
+		t.Setenv("AWS_PROFILE", "")
+		writeConfig(t, awsDir, `[profile sei]
+sso_region = us-west-1
+`)
+		got := CredsHint()
+		if !strings.Contains(got, `"sei"`) || !strings.Contains(got, "AWS_PROFILE=sei") {
+			t.Errorf("hint should suggest the only profile; got %q", got)
+		}
+	})
+
+	t.Run("no profile, multiple profiles in config", func(t *testing.T) {
+		t.Setenv("AWS_PROFILE", "")
+		writeConfig(t, awsDir, `[profile alpha]
+[profile beta]
+[sso-session ignored]
+[default]
+`)
+		got := CredsHint()
+		// All three (alpha, beta, default) should appear, sso-session should not.
+		if !strings.Contains(got, "alpha") || !strings.Contains(got, "beta") || !strings.Contains(got, "default") {
+			t.Errorf("hint should list named profiles + default; got %q", got)
+		}
+		if strings.Contains(got, "ignored") {
+			t.Errorf("hint should skip sso-session entries; got %q", got)
+		}
+	})
+
+	t.Run("no config file at all", func(t *testing.T) {
+		t.Setenv("AWS_PROFILE", "")
+		_ = os.Remove(filepath.Join(awsDir, "config"))
+		got := CredsHint()
+		if !strings.Contains(got, "no AWS credentials") {
+			t.Errorf("hint should explain the empty state; got %q", got)
+		}
+	})
+}
+
+func writeConfig(t *testing.T, awsDir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(awsDir, "config"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Engineers running \`seictl context\` with a missing \`AWS_PROFILE\` previously got empty \`awsAccount\`/\`awsPrincipalArn\` fields and exit 0. Surfaced live during the first harbor smoke — empty fields are ambiguous (could be expired SSO, missing profile, permission issues), and the engineer has no signal what to fix. Now \`context\` is a real gatekeeper: fails with \`ExitIdentity\` (40) and a category-\`aws-unavailable\` error whose message names the specific remediation.

## Behavior change

\`seictl context\` now treats AWS resolution as required, not best-effort. Onboard already had this preflight; bench up gets an early one too so AWS-creds failures don't leak through as confusing \`image-resolution\` errors.

## Hint shapes

- **\`AWS_PROFILE\` set, doesn't resolve**: "AWS_PROFILE=foo is set but credentials don't resolve; try \`aws sso login --profile foo\`"
- **No env, single profile in config**: "no default profile; ~/.aws/config has profile \"sei\" — try \`export AWS_PROFILE=sei && aws sso login --profile sei\`"
- **No env, multiple profiles**: "no default profile; ~/.aws/config has profiles [alpha beta default] — set AWS_PROFILE to one and \`aws sso login --profile <name>\`"
- **No config file at all**: "no AWS credentials and no profiles in ~/.aws/config; configure SSO via \`aws configure sso\`"

## Verified live

```
\$ seictl context
{
  ...
  "error": {
    "code": 40,
    "category": "aws-unavailable",
    "message": "no default profile; ~/.aws/config has profile \"sei\" — try \`export AWS_PROFILE=sei && aws sso login --profile sei\` (failed to refresh cached credentials, ...)"
  }
}
\$ echo \$?
40

\$ AWS_PROFILE=sei seictl context
{
  ...
  "data": {
    "awsAccount": "189176372795",
    "awsPrincipalArn": "arn:aws:sts::189176372795:assumed-role/AWSReservedSSO_..."
  }
}
```

## Test plan

- [x] \`go test ./cluster/...\` green
- [x] Live verification: \`seictl context\` with no AWS_PROFILE → exit 40 with hint
- [x] Live verification: \`AWS_PROFILE=sei seictl context\` → exit 0 with full data
- [x] Live verification: \`AWS_PROFILE=nonexistent seictl context\` → exit 40 with hint pointing at the (typo'd) profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)