### PR TITLE
fix(cluster): verify caller AWS account matches onboardAccount (closes #91)

### DIFF
--- a/cluster/internal/clioutput/envelope.go
+++ b/cluster/internal/clioutput/envelope.go
@@ -53,6 +53,7 @@ const (
 	CatPRCreateFailed      = "pr-create-failed"
 	CatAWSCreateFailed     = "aws-create-failed"
 	CatBaseBranchStale     = "base-branch-stale"
+	CatWrongAccount        = "wrong-account"
 
 	CatMalformed       = "malformed"
 	CatMissing         = "missing"

--- a/cluster/onboard.go
+++ b/cluster/onboard.go
@@ -123,8 +123,14 @@ func runOnboard(ctx context.Context, in onboardInput, out io.Writer, deps onboar
 		return failOnboard(out, e)
 	}
 
-	if _, callerErr := deps.getCaller(ctx); callerErr != nil {
+	caller, callerErr := deps.getCaller(ctx)
+	if callerErr != nil {
 		return failOnboard(out, callerErr)
+	}
+	if caller.Account != onboardAccount {
+		return failOnboard(out, clioutput.Newf(clioutput.ExitOnboard, clioutput.CatWrongAccount,
+			"AWS caller account %s does not match expected harbor account %s; switch profiles and retry",
+			caller.Account, onboardAccount))
 	}
 
 	repoPath := ""

--- a/cluster/onboard_test.go
+++ b/cluster/onboard_test.go
@@ -231,6 +231,37 @@ func TestRunOnboard_PropagatesGHAuthFailure(t *testing.T) {
 	}
 }
 
+func TestRunOnboard_RefusesWrongAWSAccount(t *testing.T) {
+	deps, _, _ := onboardStubs(t)
+	deps.getCaller = func(context.Context) (*aws.Caller, *clioutput.Error) {
+		return &aws.Caller{Account: "999999999999", Region: "eu-central-1", PrincipalARN: "arn:aws:sts::999999999999:assumed-role/foo"}, nil
+	}
+	iamCalled := false
+	deps.provisionIAM = func(context.Context, aws.EngineerScope, bool) ([]aws.IAMArtifact, *clioutput.Error) {
+		iamCalled = true
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+	err := runOnboard(context.Background(), onboardInput{Alias: "bdc", Apply: true}, &buf, deps)
+	if err == nil {
+		t.Fatalf("expected error, got success: %s", buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, clioutput.CatWrongAccount) {
+		t.Errorf("expected category %q; got %s", clioutput.CatWrongAccount, out)
+	}
+	if !strings.Contains(out, "999999999999") {
+		t.Errorf("error should name actual account; got %s", out)
+	}
+	if !strings.Contains(out, onboardAccount) {
+		t.Errorf("error should name expected account; got %s", out)
+	}
+	if iamCalled {
+		t.Errorf("provisionIAM must not be called when caller account is wrong")
+	}
+}
+
 func TestRunOnboard_PropagatesIAMFailureWithAWSCreateFailed(t *testing.T) {
 	deps, _, _ := onboardStubs(t)
 	deps.provisionIAM = func(context.Context, aws.EngineerScope, bool) ([]aws.IAMArtifact, *clioutput.Error) {


### PR DESCRIPTION
## Summary

Closes #91. The onboard flow constructs IAM resources from the hardcoded `onboardAccount = "189176372795"` but never compared the caller's actual AWS account to that constant. An engineer with a profile pointing at a sandbox/staging account would silently provision IAM in the wrong account with cross-account ARN references — unassumable role, PR referencing a non-existent cell.

The fix captures the caller value from the existing `getCaller` call (was being discarded with `_`) and adds a comparison guard. On mismatch, fails fast with a new `CatWrongAccount` category before any IAM API call, naming both the actual and expected account.

## Provenance

Surfaced in the bugbash dry-run against `cluster/` (#86, Item 5). Challenger pass downgraded from finder's implied High to Medium severity: narrow failure mode, recoverable, no security exposure (unassumable role grants no privileges).

## Diff

| File | Change |
|------|--------|
| `cluster/onboard.go` | 4-line guard after the existing `getCaller` call |
| `cluster/internal/clioutput/envelope.go` | Add `CatWrongAccount = "wrong-account"` to the `ExitOnboard` category group |
| `cluster/onboard_test.go` | New `TestRunOnboard_RefusesWrongAWSAccount` covering the failure path; asserts `provisionIAM` is not called and the error message names both account numbers |

## Test plan

- [x] `go test ./cluster/...` — passes (new test plus all existing).
- [x] `make lint` — clean.
- [x] Manual verification: build `seictl onboard --apply` against a non-harbor AWS profile and confirm the error message names both accounts and does not call IAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)