### PR TITLE
fix(cluster): emit still-terminating when bench-down hasn't actually completed (closes #90)

### DIFF
--- a/cluster/bench_down.go
+++ b/cluster/bench_down.go
@@ -30,7 +30,14 @@ type benchDownResult struct {
 	ChainID   string               `json:"chainId"`
 	Namespace string               `json:"namespace"`
 	Resources []render.ManifestRef `json:"resources"`
-	DeletedAt *time.Time           `json:"deletedAt,omitempty"`
+	// DeletedAt is set only when every resource reached "deleted" or
+	// "not-found"; while any resource is still-terminating, the
+	// deletion has been requested but not completed.
+	DeletedAt *time.Time `json:"deletedAt,omitempty"`
+	// Hint is a human-readable next-step prompt populated when at
+	// least one resource is still-terminating, so an agent caller
+	// re-running `bench up` immediately knows to wait.
+	Hint string `json:"hint,omitempty"`
 }
 
 type benchDownInput struct {
@@ -121,13 +128,23 @@ func runBenchDown(ctx context.Context, in benchDownInput, out io.Writer, deps be
 		}
 	}
 
-	now := time.Now().UTC()
 	res := benchDownResult{
 		Name:      in.Name,
 		ChainID:   chainID,
 		Namespace: namespace,
 		Resources: resources,
-		DeletedAt: &now,
+	}
+	terminating := 0
+	for _, r := range results {
+		if r.Action == "still-terminating" {
+			terminating++
+		}
+	}
+	if terminating == 0 {
+		now := time.Now().UTC()
+		res.DeletedAt = &now
+	} else {
+		res.Hint = fmt.Sprintf("%d resource(s) still terminating; wait before re-running `bench up` with the same name", terminating)
 	}
 	if err := clioutput.Emit(out, clioutput.KindBenchDownResult, res); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cluster/bench_down_test.go
+++ b/cluster/bench_down_test.go
@@ -65,6 +65,41 @@ func TestRunBenchDown(t *testing.T) {
 		}
 	})
 
+	t.Run("omits deletedAt and emits hint when any resource is still-terminating", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		deps := benchDownDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{Namespace: "eng-bdc"}, nil
+			},
+			deleteFn: func(context.Context, *kube.Client, kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				return []kube.DeleteResult{
+					{Kind: "SeiNodeDeployment", Name: "bench-bdc-demo", Namespace: "eng-bdc", Action: "still-terminating"},
+					{Kind: "Job", Name: "seiload-bench-bdc-demo", Namespace: "eng-bdc", Action: "deleted"},
+					{Kind: "ConfigMap", Name: "seiload-profile-bench-bdc-demo", Namespace: "eng-bdc", Action: "deleted"},
+				}, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "demo"}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runBenchDown: %v\nbody=%s", err, buf.String())
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data benchDownResult
+		_ = json.Unmarshal(env.Data, &data)
+		if data.DeletedAt != nil {
+			t.Errorf("deletedAt should be nil when any resource is still-terminating; got %v", data.DeletedAt)
+		}
+		if !strings.Contains(data.Hint, "still terminating") {
+			t.Errorf("hint should mention still-terminating; got %q", data.Hint)
+		}
+		if !strings.Contains(data.Hint, "bench up") {
+			t.Errorf("hint should mention bench up so the operator knows what to wait for; got %q", data.Hint)
+		}
+	})
+
 	t.Run("rejects bad name with validation category", func(t *testing.T) {
 		path := writeEngineerFile(t, "bdc")
 		var buf bytes.Buffer

--- a/cluster/internal/kube/delete.go
+++ b/cluster/internal/kube/delete.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/utils/ptr"
@@ -72,6 +73,20 @@ func (c *Client) Delete(ctx context.Context, opts DeleteOptions) ([]DeleteResult
 				return fmt.Errorf("delete %s/%s in %s: %w", info.Mapping.GroupVersionKind.Kind, info.Name, info.Namespace, err)
 			}
 		}
+		// FinalizerDeleteDependents is K8s machinery the apiserver auto-adds
+		// when foreground propagation is requested; counting it as "real"
+		// false-positives on childless objects in the brief window before
+		// GC reaps. A read-side error here is silently treated as "deleted"
+		// — the apiserver already accepted the delete.
+		if action == "deleted" {
+			if got, gerr := helper.Get(info.Namespace, info.Name); gerr == nil {
+				if accessor, aerr := meta.Accessor(got); aerr == nil {
+					if !accessor.GetDeletionTimestamp().IsZero() && hasRealFinalizer(accessor.GetFinalizers()) {
+						action = "still-terminating"
+					}
+				}
+			}
+		}
 		results = append(results, DeleteResult{
 			Kind:      info.Mapping.GroupVersionKind.Kind,
 			Name:      info.Name,
@@ -84,4 +99,13 @@ func (c *Client) Delete(ctx context.Context, opts DeleteOptions) ([]DeleteResult
 		return nil, wrapMappingErr(visitErr)
 	}
 	return results, nil
+}
+
+func hasRealFinalizer(fs []string) bool {
+	for _, f := range fs {
+		if f != metav1.FinalizerDeleteDependents {
+			return true
+		}
+	}
+	return false
 }

--- a/cluster/internal/kube/list_delete_envtest_test.go
+++ b/cluster/internal/kube/list_delete_envtest_test.go
@@ -141,6 +141,54 @@ func TestDelete_LabelSelectorDeletesMatchingObjects(t *testing.T) {
 	}
 }
 
+func TestDelete_StillTerminatingWhenFinalizerHolds(t *testing.T) {
+	ns := testEnv.UniqueNamespace(t, "del-term")
+	kc := newTestClient(t)
+
+	// Seed a CM with a finalizer; envtest has no controller to release it,
+	// so DeleteWithOptions sets deletionTimestamp and the object lingers.
+	cs, err := kubernetes.NewForConfig(testEnv.RESTConfig())
+	if err != nil {
+		t.Fatalf("clientset: %v", err)
+	}
+	_, err = cs.CoreV1().ConfigMaps(ns).Create(context.Background(),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "stuck",
+				Namespace:  ns,
+				Labels:     map[string]string{"sei.io/bench-name": "demo"},
+				Finalizers: []string{"seictl.test/hold"},
+			},
+			Data: map[string]string{"k": "v"},
+		},
+		metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed cm: %v", err)
+	}
+
+	results, err := kc.Delete(context.Background(), kube.DeleteOptions{
+		Namespace:     ns,
+		Resources:     []string{"configmaps"},
+		LabelSelector: "sei.io/bench-name=demo",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(results))
+	}
+	if results[0].Action != "still-terminating" {
+		t.Errorf("action: got %q, want \"still-terminating\"", results[0].Action)
+	}
+
+	// Release the finalizer so the test cleans up.
+	cm, gerr := cs.CoreV1().ConfigMaps(ns).Get(context.Background(), "stuck", metav1.GetOptions{})
+	if gerr == nil {
+		cm.Finalizers = nil
+		_, _ = cs.CoreV1().ConfigMaps(ns).Update(context.Background(), cm, metav1.UpdateOptions{})
+	}
+}
+
 func TestDelete_EmptyResultOnNoMatches(t *testing.T) {
 	ns := testEnv.UniqueNamespace(t, "del-empty")
 	kc := newTestClient(t)


### PR DESCRIPTION
## Summary

Closes #90. `helper.DeleteWithOptions` returns once the apiserver accepts the delete; foreground propagation only blocks the *parent's* removal until children cascade, not the API call itself. Pre-fix, every result was hard-coded to `"deleted"` and `bench_down` stamped `DeletedAt` unconditionally — the `still-terminating` action enum documented in `delete.go:19` was unreachable. Operators following the documented `bench down` → `bench up` cycle would race into 409/422 against still-Terminating SeiNodeDeployments with no signal to wait.

After `DeleteWithOptions` accepts, post-flight `Get` distinguishes "actually gone" from "still terminating". `bench_down` only stamps `DeletedAt` when every result reached `deleted` or `not-found`; otherwise it surfaces a `Hint` pointing the operator at the wait.

## Discrimination detail

The naive `len(finalizers) > 0` check false-positives in two paths: envtest (no GC, machinery finalizers never reaped) and the brief production window between `DeleteWithOptions` accepting and GC reaping a childless object. The fix counts only "real" finalizers — i.e., excludes `metav1.FinalizerDeleteDependents`, the placeholder the apiserver auto-adds for foreground propagation. This means:

| Scenario | Behavior |
|----------|----------|
| Production SND with cascading children | Has SND-controller finalizer → still-terminating ✓ |
| Production ConfigMap, no children | GC reaps in ms; if Get races within window, only the placeholder is seen → deleted ✓ |
| envtest object (no GC), only placeholder | Filtered out → deleted ✓ |
| envtest object with real test finalizer | still-terminating ✓ |

## Provenance

Surfaced in the bugbash dry-run against `cluster/` (#86, Item 4). Challenger pass confirmed at **High** severity: operational footgun on the documented up/down cycle, single-engineer blocking, recoverable only by waiting and retrying with no signal telling the operator to wait.

## Diff

| File | Change |
|------|--------|
| `cluster/internal/kube/delete.go` | Post-flight `Get` after `DeleteWithOptions`; `hasRealFinalizer` helper that excludes the foreground-propagation placeholder |
| `cluster/bench_down.go` | `Hint` field on `benchDownResult`; conditional `DeletedAt` (set only when all results are `deleted` / `not-found`) |
| `cluster/internal/kube/list_delete_envtest_test.go` | New `TestDelete_StillTerminatingWhenFinalizerHolds` (seed CM with finalizer, assert envelope reports still-terminating) |
| `cluster/bench_down_test.go` | New orchestration test: `DeletedAt` omitted and `Hint` populated when any result is still-terminating |

## Test plan

- [x] `go test ./cluster/...` — passes (existing + new unit tests).
- [x] `make test-envtest` — passes (existing happy-path + new still-terminating test).
- [x] `make lint` — clean.
- [x] Manual verification: `bench down` against an SND with a finalizer in a real cluster; confirm envelope reports `action: "still-terminating"`, omits `deletedAt`, and includes the wait hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)