### PR TITLE
fix(cluster): fail-fast on Job spec mutation in bench up (closes #89)

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -74,19 +74,21 @@ type benchUpInput struct {
 }
 
 type benchDeps struct {
-	resolveDigest func(context.Context, string) (string, *clioutput.Error)
-	identityPath  func() (string, error)
-	newKubeClient func(kube.Options) (*kube.Client, *clioutput.Error)
-	apply         func(ctx context.Context, kc *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error)
-	getCaller     func(context.Context) (*aws.Caller, *clioutput.Error)
+	resolveDigest  func(context.Context, string) (string, *clioutput.Error)
+	identityPath   func() (string, error)
+	newKubeClient  func(kube.Options) (*kube.Client, *clioutput.Error)
+	apply          func(ctx context.Context, kc *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error)
+	getJobSnapshot func(ctx context.Context, kc *kube.Client, namespace, name string) kube.JobSnapshot
+	getCaller      func(context.Context) (*aws.Caller, *clioutput.Error)
 }
 
 var defaultBenchDeps = benchDeps{
-	resolveDigest: aws.ResolveDigest,
-	identityPath:  identity.DefaultPath,
-	newKubeClient: kube.New,
-	apply:         applyToCluster,
-	getCaller:     aws.GetCaller,
+	resolveDigest:  aws.ResolveDigest,
+	identityPath:   identity.DefaultPath,
+	newKubeClient:  kube.New,
+	apply:          applyToCluster,
+	getJobSnapshot: getJobSnapshotFromCluster,
+	getCaller:      aws.GetCaller,
 }
 
 func applyToCluster(ctx context.Context, kc *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
@@ -95,6 +97,16 @@ func applyToCluster(ctx context.Context, kc *kube.Client, fieldOwner, namespace 
 		return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatApplyFailed, "%v", err)
 	}
 	return results, nil
+}
+
+// Read-side errors collapse to {Found: false} so the apply path
+// remains the source of truth for failure categorization.
+func getJobSnapshotFromCluster(ctx context.Context, kc *kube.Client, namespace, name string) kube.JobSnapshot {
+	snap, err := kc.GetJobSnapshot(ctx, namespace, name)
+	if err != nil {
+		return kube.JobSnapshot{}
+	}
+	return snap
 }
 
 var BenchCmd = cli.Command{
@@ -199,6 +211,18 @@ func runBenchUp(ctx context.Context, in benchUpInput, out io.Writer, deps benchD
 		})
 		if kerr != nil {
 			return failBenchUp(out, kerr)
+		}
+		// Apply walks cmYAML → sndYAML → jobYAML; a Job-immutability
+		// 422 mid-stream would leave the SNDs already mutated, so
+		// catch the would-be Job mutation before any apply runs.
+		jobName := "seiload-" + chainID
+		deadlineSeconds := int64(in.Duration) * 60
+		if snap := deps.getJobSnapshot(ctx, kc, namespace, jobName); snap.Found {
+			if snap.ImageSHA != digestShort || snap.DeadlineSeconds != deadlineSeconds {
+				return failBenchUp(out, clioutput.Newf(clioutput.ExitBench, clioutput.CatJobImmutable,
+					"Job %s/%s already exists with image-sha=%q and activeDeadlineSeconds=%d; rendered would be %q and %d. Kubernetes Jobs are immutable in these fields — run `seictl bench down --name %s` first.",
+					namespace, jobName, snap.ImageSHA, snap.DeadlineSeconds, digestShort, deadlineSeconds, in.Name))
+			}
 		}
 		applyResults, applyErr := deps.apply(ctx, kc, benchFieldOwner, namespace, docs)
 		if applyErr != nil {

--- a/cluster/bench_test.go
+++ b/cluster/bench_test.go
@@ -31,6 +31,10 @@ func okCaller(context.Context) (*aws.Caller, *clioutput.Error) {
 	return &aws.Caller{Account: "189176372795", Region: "eu-central-1", PrincipalARN: "arn:aws:sts::189176372795:assumed-role/Eng/bdc"}, nil
 }
 
+func noJobSnapshot(context.Context, *kube.Client, string, string) kube.JobSnapshot {
+	return kube.JobSnapshot{}
+}
+
 func stubBenchDeps(t *testing.T, alias string) benchDeps {
 	t.Helper()
 	path := writeEngineerFile(t, alias)
@@ -222,7 +226,8 @@ func TestRunBenchUp(t *testing.T) {
 			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
 				return &kube.Client{ContextName: "harbor", Namespace: "eng-bdc"}, nil
 			},
-			getCaller: okCaller,
+			getJobSnapshot: noJobSnapshot,
+			getCaller:      okCaller,
 			apply: func(_ context.Context, _ *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
 				if fieldOwner != benchFieldOwner {
 					t.Errorf("field owner: got %q, want %q", fieldOwner, benchFieldOwner)
@@ -315,6 +320,91 @@ func TestRunBenchUp(t *testing.T) {
 		}
 	})
 
+	t.Run("apply refuses Job-immutable mutation before any apply runs", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		applyCalled := false
+		deps := benchDeps{
+			resolveDigest: func(context.Context, string) (string, *clioutput.Error) {
+				return benchTestDigest, nil
+			},
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{}, nil
+			},
+			getCaller: okCaller,
+			getJobSnapshot: func(context.Context, *kube.Client, string, string) kube.JobSnapshot {
+				return kube.JobSnapshot{Found: true, ImageSHA: "stale-sha", DeadlineSeconds: 300}
+			},
+			apply: func(context.Context, *kube.Client, string, string, [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
+				applyCalled = true
+				return nil, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v2",
+			Name:     "demo",
+			Size:     "s",
+			Duration: 10,
+			Apply:    true,
+		}, &buf, deps)
+		if err == nil {
+			t.Fatalf("expected error, got success: %s", buf.String())
+		}
+		if !strings.Contains(buf.String(), clioutput.CatJobImmutable) {
+			t.Errorf("expected category %q; got %s", clioutput.CatJobImmutable, buf.String())
+		}
+		if !strings.Contains(buf.String(), "bench down") {
+			t.Errorf("expected error to mention `bench down` recovery; got %s", buf.String())
+		}
+		if applyCalled {
+			t.Errorf("apply must not be called when Job spec would be mutated")
+		}
+	})
+
+	t.Run("apply proceeds when existing Job matches rendered (idempotent re-run)", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		applyCalled := false
+		deps := benchDeps{
+			resolveDigest: func(context.Context, string) (string, *clioutput.Error) {
+				return benchTestDigest, nil
+			},
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{}, nil
+			},
+			getCaller: okCaller,
+			getJobSnapshot: func(context.Context, *kube.Client, string, string) kube.JobSnapshot {
+				// Match the rendered values: digest from benchTestDigest's
+				// short form, deadline from --duration=5 → 300s.
+				return kube.JobSnapshot{Found: true, ImageSHA: shortDigest(benchTestDigest), DeadlineSeconds: 300}
+			},
+			apply: func(context.Context, *kube.Client, string, string, [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
+				applyCalled = true
+				return []kube.ApplyResult{
+					{Kind: "ConfigMap", Action: "unchanged"},
+					{Kind: "SeiNodeDeployment", Action: "unchanged"},
+					{Kind: "SeiNodeDeployment", Action: "unchanged"},
+					{Kind: "Job", Action: "unchanged"},
+				}, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runBenchUp(context.Background(), benchUpInput{
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Name:     "demo",
+			Size:     "s",
+			Duration: 5,
+			Apply:    true,
+		}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runBenchUp: %v\nbody=%s", err, buf.String())
+		}
+		if !applyCalled {
+			t.Errorf("apply should be called when the existing Job matches the rendered Job")
+		}
+	})
+
 	t.Run("apply propagates SSA failures with CatApplyFailed", func(t *testing.T) {
 		path := writeEngineerFile(t, "bdc")
 		deps := benchDeps{
@@ -325,7 +415,8 @@ func TestRunBenchUp(t *testing.T) {
 			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
 				return &kube.Client{}, nil
 			},
-			getCaller: okCaller,
+			getJobSnapshot: noJobSnapshot,
+			getCaller:      okCaller,
 			apply: func(context.Context, *kube.Client, string, string, [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
 				return nil, clioutput.New(clioutput.ExitBench, clioutput.CatApplyFailed, "API server says no")
 			},

--- a/cluster/internal/clioutput/envelope.go
+++ b/cluster/internal/clioutput/envelope.go
@@ -45,6 +45,7 @@ const (
 	CatNameCollision   = "name-collision"
 	CatFinalizerStuck  = "finalizer-stuck"
 	CatTemplateRender  = "template-render"
+	CatJobImmutable    = "job-immutable"
 
 	CatAliasInvalid        = "alias-invalid"
 	CatPlatformRepoMissing = "platform-repo-missing"

--- a/cluster/internal/kube/get.go
+++ b/cluster/internal/kube/get.go
@@ -1,0 +1,45 @@
+package kube
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// JobSnapshot exposes the subset of Job state that callers need to
+// reason about Job immutability without importing batchv1.
+type JobSnapshot struct {
+	Found           bool
+	ImageSHA        string // labels["sei.io/image-sha"]
+	DeadlineSeconds int64  // spec.activeDeadlineSeconds
+}
+
+// GetJobSnapshot returns {Found: false} on NotFound; other apiserver
+// errors propagate.
+func (c *Client) GetJobSnapshot(ctx context.Context, namespace, name string) (JobSnapshot, error) {
+	cfg, err := c.flags.ToRESTConfig()
+	if err != nil {
+		return JobSnapshot{}, err
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return JobSnapshot{}, err
+	}
+	j, err := cs.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return JobSnapshot{Found: false}, nil
+		}
+		return JobSnapshot{}, err
+	}
+	snap := JobSnapshot{
+		Found:    true,
+		ImageSHA: j.Labels["sei.io/image-sha"],
+	}
+	if j.Spec.ActiveDeadlineSeconds != nil {
+		snap.DeadlineSeconds = *j.Spec.ActiveDeadlineSeconds
+	}
+	return snap, nil
+}


### PR DESCRIPTION
## Summary

Closes #89. K8s Jobs reject mutations to `spec.template`, `completions`, `parallelism`, `selector`, and (in many apiserver versions) `activeDeadlineSeconds`. `kube.Apply` walks bench manifests in `cmYAML → sndYAML → jobYAML` order, so a re-`bench up` with a different `--image` or `--duration` would bump the SeiNodeDeployments first, then hit 422 on the Job — leaving new validator/RPC images racing the previous bench's still-running seiload Job. The error surfaced only as generic `CatApplyFailed` with no Job-immutability hint.

The fix is a bench-up-local pre-flight: after `kube.Client` construction and before apply, `GetJobSnapshot` pulls the existing Job's `image-sha` label and `activeDeadlineSeconds`. If the Job exists and either field would change, the new `CatJobImmutable` category fires with a message naming both existing and rendered values plus the `bench down` recovery path — all before any SND patch.

## Design call resolution

Per the discussion in #89, this PR takes the **specific** route (bench.go-local check) rather than the **generic** route (immutable-fields-per-Kind table in `kube.Apply`). Today, `Job` is the only immutable-field Kind in bench manifests, and the `cluster/` subtree explicitly favors YAGNI ("Three similar lines is better than a premature helper" per `CLAUDE.md`). If a future bench manifest adds another immutable Kind (`PersistentVolumeClaim`, `Service.spec.clusterIP`, etc.), the generic route becomes the right refactor — but it's not load-bearing today.

The `kube` package gains a thin `JobSnapshot` accessor that exposes just the two fields bench needs, keeping `batchv1` from leaking into `bench.go` and preserving the `cluster/internal/kube` boundary.

## Read-side resilience

Snapshot errors (RBAC, transient apiserver flake) collapse to `{Found: false}`, so the existing `CatApplyFailed` path remains the source of truth for real apply failures rather than hard-failing on a transient pre-flight read.

## Diff

| File | Change |
|------|--------|
| `cluster/internal/kube/get.go` | New file — `JobSnapshot` type and `GetJobSnapshot` method on `kube.Client` |
| `cluster/bench.go` | `getJobSnapshot` field on `benchDeps`; pre-flight check between client construction and apply |
| `cluster/internal/clioutput/envelope.go` | Add `CatJobImmutable = "job-immutable"` to the `ExitBench` category group |
| `cluster/bench_test.go` | Two new sub-tests: `apply refuses Job-immutable mutation before any apply runs` and `apply proceeds when existing Job matches rendered (idempotent re-run)`; `noJobSnapshot` helper added for the existing apply-path tests |

## Test plan

- [x] `go test ./cluster/...` — passes (existing + 2 new sub-tests).
- [x] `make lint` — clean.
- [x] Manual verification: deploy a bench with `--duration 5`, then `bench up --duration 10` on the same name; confirm the error envelope reports `category: "job-immutable"`, names both deadline values, and tells the operator to run `bench down` first; confirm no SND mutation happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)