### PR TITLE
fix(cluster): low-severity cleanup batch (closes #87, #88, #92)

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -147,21 +147,21 @@ func runBenchUp(ctx context.Context, in benchUpInput, out io.Writer, deps benchD
 	}
 
 	if e := validate.Image(in.Image); e != nil {
-		return failBenchUp(out, e)
+		return failBenchUp(out, e.ExitWith(clioutput.ExitBench))
 	}
 	if e := validate.Name(eng.Alias, in.Name); e != nil {
-		return failBenchUp(out, e)
+		return failBenchUp(out, e.ExitWith(clioutput.ExitBench))
 	}
 	if e := validate.Size(in.Size); e != nil {
-		return failBenchUp(out, e)
+		return failBenchUp(out, e.ExitWith(clioutput.ExitBench))
 	}
 	if e := validate.DurationMinutes(in.Duration); e != nil {
-		return failBenchUp(out, e)
+		return failBenchUp(out, e.ExitWith(clioutput.ExitBench))
 	}
 
 	namespace := "eng-" + eng.Alias
 	if e := validate.Namespace(namespace, eng.Alias); e != nil {
-		return failBenchUp(out, e)
+		return failBenchUp(out, e.ExitWith(clioutput.ExitBench))
 	}
 
 	if _, callerErr := deps.getCaller(ctx); callerErr != nil {

--- a/cluster/bench_down.go
+++ b/cluster/bench_down.go
@@ -107,7 +107,7 @@ func runBenchDown(ctx context.Context, in benchDownInput, out io.Writer, deps be
 		return failBenchDown(out, idErr)
 	}
 	if e := validate.Name(eng.Alias, in.Name); e != nil {
-		return failBenchDown(out, e)
+		return failBenchDown(out, e.ExitWith(clioutput.ExitBench))
 	}
 
 	namespace := in.Namespace
@@ -115,7 +115,7 @@ func runBenchDown(ctx context.Context, in benchDownInput, out io.Writer, deps be
 		namespace = "eng-" + eng.Alias
 	}
 	if e := validate.Namespace(namespace, eng.Alias); e != nil {
-		return failBenchDown(out, e)
+		return failBenchDown(out, e.ExitWith(clioutput.ExitBench))
 	}
 
 	chainID := fmt.Sprintf("bench-%s-%s", eng.Alias, in.Name)

--- a/cluster/bench_down.go
+++ b/cluster/bench_down.go
@@ -30,14 +30,9 @@ type benchDownResult struct {
 	ChainID   string               `json:"chainId"`
 	Namespace string               `json:"namespace"`
 	Resources []render.ManifestRef `json:"resources"`
-	// DeletedAt is set only when every resource reached "deleted" or
-	// "not-found"; while any resource is still-terminating, the
-	// deletion has been requested but not completed.
-	DeletedAt *time.Time `json:"deletedAt,omitempty"`
-	// Hint is a human-readable next-step prompt populated when at
-	// least one resource is still-terminating, so an agent caller
-	// re-running `bench up` immediately knows to wait.
-	Hint string `json:"hint,omitempty"`
+	DryRun    bool                 `json:"dryRun"`
+	DeletedAt *time.Time           `json:"deletedAt,omitempty"`
+	Hint      string               `json:"hint,omitempty"`
 }
 
 type benchDownInput struct {
@@ -45,18 +40,21 @@ type benchDownInput struct {
 	Namespace  string
 	Kubeconfig string
 	Context    string
+	DryRun     bool
 }
 
 type benchDownDeps struct {
 	identityPath  func() (string, error)
 	newKubeClient func(kube.Options) (*kube.Client, *clioutput.Error)
 	deleteFn      func(ctx context.Context, kc *kube.Client, opts kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error)
+	dryRunListFn  func(ctx context.Context, kc *kube.Client, opts kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error)
 }
 
 var defaultBenchDownDeps = benchDownDeps{
 	identityPath:  identity.DefaultPath,
 	newKubeClient: kube.New,
 	deleteFn:      deleteFromCluster,
+	dryRunListFn:  dryRunListFromCluster,
 }
 
 func deleteFromCluster(ctx context.Context, kc *kube.Client, opts kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
@@ -67,12 +65,30 @@ func deleteFromCluster(ctx context.Context, kc *kube.Client, opts kube.DeleteOpt
 	return results, nil
 }
 
+func dryRunListFromCluster(ctx context.Context, kc *kube.Client, opts kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error) {
+	objs, err := kc.List(ctx, opts)
+	if err != nil {
+		return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatApplyFailed, "%v", err)
+	}
+	out := make([]kube.DeleteResult, len(objs))
+	for i, o := range objs {
+		out[i] = kube.DeleteResult{
+			Kind:      o.GetKind(),
+			Name:      o.GetName(),
+			Namespace: o.GetNamespace(),
+			Action:    "would-delete",
+		}
+	}
+	return out, nil
+}
+
 var benchDownCmd = &cli.Command{
 	Name:  "down",
 	Usage: "Tear down a benchmark by name",
 	Flags: append(kubeconfigFlags(),
 		&cli.StringFlag{Name: "name", Required: true, Usage: "Bench name to tear down"},
 		&cli.StringFlag{Name: "namespace", Aliases: []string{"n"}, Usage: "Namespace (defaults to eng-<alias>)"},
+		&cli.BoolFlag{Name: "dry-run", Usage: "List the resources that would be deleted without deleting them"},
 	),
 	Action: func(ctx context.Context, command *cli.Command) error {
 		return runBenchDown(ctx, benchDownInput{
@@ -80,6 +96,7 @@ var benchDownCmd = &cli.Command{
 			Namespace:  command.String("namespace"),
 			Kubeconfig: command.String("kubeconfig"),
 			Context:    command.String("context"),
+			DryRun:     command.Bool("dry-run"),
 		}, os.Stdout, defaultBenchDownDeps)
 	},
 }
@@ -109,11 +126,23 @@ func runBenchDown(ctx context.Context, in benchDownInput, out io.Writer, deps be
 		return failBenchDown(out, kerr)
 	}
 
-	results, dErr := deps.deleteFn(ctx, kc, kube.DeleteOptions{
-		Namespace:     namespace,
-		Resources:     benchDownTargets,
-		LabelSelector: selector,
-	})
+	var (
+		results []kube.DeleteResult
+		dErr    *clioutput.Error
+	)
+	if in.DryRun {
+		results, dErr = deps.dryRunListFn(ctx, kc, kube.ListOptions{
+			Namespace:     namespace,
+			Resources:     benchDownTargets,
+			LabelSelector: selector,
+		})
+	} else {
+		results, dErr = deps.deleteFn(ctx, kc, kube.DeleteOptions{
+			Namespace:     namespace,
+			Resources:     benchDownTargets,
+			LabelSelector: selector,
+		})
+	}
 	if dErr != nil {
 		return failBenchDown(out, dErr)
 	}
@@ -133,18 +162,21 @@ func runBenchDown(ctx context.Context, in benchDownInput, out io.Writer, deps be
 		ChainID:   chainID,
 		Namespace: namespace,
 		Resources: resources,
+		DryRun:    in.DryRun,
 	}
-	terminating := 0
-	for _, r := range results {
-		if r.Action == "still-terminating" {
-			terminating++
+	if !in.DryRun {
+		terminating := 0
+		for _, r := range results {
+			if r.Action == "still-terminating" {
+				terminating++
+			}
 		}
-	}
-	if terminating == 0 {
-		now := time.Now().UTC()
-		res.DeletedAt = &now
-	} else {
-		res.Hint = fmt.Sprintf("%d resource(s) still terminating; wait before re-running `bench up` with the same name", terminating)
+		if terminating == 0 {
+			now := time.Now().UTC()
+			res.DeletedAt = &now
+		} else {
+			res.Hint = fmt.Sprintf("%d resource(s) still terminating; wait before re-running `bench up` with the same name", terminating)
+		}
 	}
 	if err := clioutput.Emit(out, clioutput.KindBenchDownResult, res); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cluster/bench_down.go
+++ b/cluster/bench_down.go
@@ -164,7 +164,12 @@ func runBenchDown(ctx context.Context, in benchDownInput, out io.Writer, deps be
 		Resources: resources,
 		DryRun:    in.DryRun,
 	}
-	if !in.DryRun {
+	switch {
+	case in.DryRun:
+		if len(results) == 0 {
+			res.Hint = fmt.Sprintf("no resources match selector %q in namespace %q — bench may not exist or already be torn down", selector, namespace)
+		}
+	default:
 		terminating := 0
 		for _, r := range results {
 			if r.Action == "still-terminating" {

--- a/cluster/bench_down_test.go
+++ b/cluster/bench_down_test.go
@@ -142,6 +142,9 @@ func TestRunBenchDown(t *testing.T) {
 		if data.DeletedAt != nil {
 			t.Errorf("DeletedAt should be nil on dry-run; got %v", data.DeletedAt)
 		}
+		if data.Hint != "" {
+			t.Errorf("Hint should be empty when dry-run finds matches; got %q", data.Hint)
+		}
 		if len(data.Resources) != 2 {
 			t.Errorf("resources: got %d, want 2", len(data.Resources))
 		}
@@ -152,7 +155,7 @@ func TestRunBenchDown(t *testing.T) {
 		}
 	})
 
-	t.Run("dry-run on absent bench returns empty resources, no DeletedAt", func(t *testing.T) {
+	t.Run("dry-run on absent bench returns empty resources with disambiguating hint", func(t *testing.T) {
 		path := writeEngineerFile(t, "bdc")
 		deps := benchDownDeps{
 			identityPath: func() (string, error) { return path, nil },
@@ -174,6 +177,9 @@ func TestRunBenchDown(t *testing.T) {
 		_ = json.Unmarshal(env.Data, &data)
 		if !data.DryRun || data.DeletedAt != nil || len(data.Resources) != 0 {
 			t.Errorf("expected dry-run/empty/nil-deletedAt; got %+v", data)
+		}
+		if !strings.Contains(data.Hint, "may not exist or already be torn down") {
+			t.Errorf("Hint should disambiguate the empty result for agent callers; got %q", data.Hint)
 		}
 	})
 

--- a/cluster/bench_down_test.go
+++ b/cluster/bench_down_test.go
@@ -100,6 +100,83 @@ func TestRunBenchDown(t *testing.T) {
 		}
 	})
 
+	t.Run("dry-run lists resources without deleting", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		var capturedSelector string
+		deleteCalled := false
+		deps := benchDownDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{Namespace: "eng-bdc"}, nil
+			},
+			deleteFn: func(context.Context, *kube.Client, kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				deleteCalled = true
+				return nil, nil
+			},
+			dryRunListFn: func(_ context.Context, _ *kube.Client, opts kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				capturedSelector = opts.LabelSelector
+				return []kube.DeleteResult{
+					{Kind: "SeiNodeDeployment", Name: "bench-bdc-demo", Namespace: "eng-bdc", Action: "would-delete"},
+					{Kind: "Job", Name: "seiload-bench-bdc-demo", Namespace: "eng-bdc", Action: "would-delete"},
+				}, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "demo", DryRun: true}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runBenchDown: %v\nbody=%s", err, buf.String())
+		}
+		if deleteCalled {
+			t.Errorf("deleteFn must not be called on --dry-run")
+		}
+		if capturedSelector != "sei.io/engineer=bdc,sei.io/bench-name=demo" {
+			t.Errorf("selector: got %q", capturedSelector)
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data benchDownResult
+		_ = json.Unmarshal(env.Data, &data)
+		if !data.DryRun {
+			t.Errorf("envelope DryRun should be true")
+		}
+		if data.DeletedAt != nil {
+			t.Errorf("DeletedAt should be nil on dry-run; got %v", data.DeletedAt)
+		}
+		if len(data.Resources) != 2 {
+			t.Errorf("resources: got %d, want 2", len(data.Resources))
+		}
+		for _, r := range data.Resources {
+			if r.Action != "would-delete" {
+				t.Errorf("expected would-delete action; got %q on %s", r.Action, r.Kind)
+			}
+		}
+	})
+
+	t.Run("dry-run on absent bench returns empty resources, no DeletedAt", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		deps := benchDownDeps{
+			identityPath: func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{Namespace: "eng-bdc"}, nil
+			},
+			dryRunListFn: func(context.Context, *kube.Client, kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				return nil, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runBenchDown(context.Background(), benchDownInput{Name: "missing", DryRun: true}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runBenchDown: %v\nbody=%s", err, buf.String())
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data benchDownResult
+		_ = json.Unmarshal(env.Data, &data)
+		if !data.DryRun || data.DeletedAt != nil || len(data.Resources) != 0 {
+			t.Errorf("expected dry-run/empty/nil-deletedAt; got %+v", data)
+		}
+	})
+
 	t.Run("rejects bad name with validation category", func(t *testing.T) {
 		path := writeEngineerFile(t, "bdc")
 		var buf bytes.Buffer

--- a/cluster/internal/githubpr/githubpr.go
+++ b/cluster/internal/githubpr/githubpr.go
@@ -105,6 +105,9 @@ func CreatePR(opts Options) (*Result, error) {
 	if _, err := runIn(opts.RepoPath, "git", "fetch", "origin", opts.BaseBranch); err != nil {
 		return nil, fmt.Errorf("git fetch: %w", err)
 	}
+	if err := refuseLossyCheckout(opts.RepoPath, opts.Branch); err != nil {
+		return nil, err
+	}
 	if _, err := runIn(opts.RepoPath, "git", "checkout", "-B", opts.Branch, "origin/"+opts.BaseBranch); err != nil {
 		return nil, fmt.Errorf("git checkout branch: %w", err)
 	}
@@ -180,6 +183,20 @@ func DiscoverRepo(start string) (string, error) {
 func isDir(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
+}
+
+func refuseLossyCheckout(repoPath, branch string) error {
+	if _, err := runIn(repoPath, "git", "rev-parse", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
+		return nil
+	}
+	countOut, err := runIn(repoPath, "git", "rev-list", "--count", "origin/"+branch+".."+branch)
+	if err != nil {
+		return fmt.Errorf("local branch %q exists with no remote tracking ref; refusing `git checkout -B` so its commits are not discarded — `git switch %s` to inspect or `git reflog` to recover, then `git branch -D %s` to start fresh", branch, branch, branch)
+	}
+	if count := strings.TrimSpace(string(countOut)); count != "0" {
+		return fmt.Errorf("local branch %q has %s commit(s) ahead of origin/%s; refusing `git checkout -B` so they are not discarded — `git switch %s` to inspect or `git reflog` to recover, then `git branch -D %s` to start fresh", branch, count, branch, branch, branch)
+	}
+	return nil
 }
 
 func runIn(dir string, name string, args ...string) ([]byte, error) {

--- a/cluster/internal/githubpr/githubpr_test.go
+++ b/cluster/internal/githubpr/githubpr_test.go
@@ -1,0 +1,94 @@
+package githubpr
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func gitFixture(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	repo := filepath.Join(root, "repo")
+	mustGit(t, root, "init", "--bare", "--initial-branch=main", origin)
+	mustGit(t, root, "clone", origin, repo)
+	mustGit(t, repo, "config", "user.email", "test@example.com")
+	mustGit(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	mustGit(t, repo, "checkout", "-B", "main")
+	mustGit(t, repo, "add", "README.md")
+	mustGit(t, repo, "commit", "-m", "initial")
+	mustGit(t, repo, "push", "-u", "origin", "main")
+	return repo
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestRefuseLossyCheckout_NoLocalBranch(t *testing.T) {
+	repo := gitFixture(t)
+	if err := refuseLossyCheckout(repo, "seictl/never-existed"); err != nil {
+		t.Errorf("expected no error when branch is absent; got %v", err)
+	}
+}
+
+func TestRefuseLossyCheckout_BranchUpToDateWithRemote(t *testing.T) {
+	repo := gitFixture(t)
+	mustGit(t, repo, "checkout", "-b", "seictl/clean", "main")
+	mustGit(t, repo, "push", "-u", "origin", "seictl/clean")
+	if err := refuseLossyCheckout(repo, "seictl/clean"); err != nil {
+		t.Errorf("expected no error for tracked branch with no extra commits; got %v", err)
+	}
+}
+
+func TestRefuseLossyCheckout_LocalCommitsAheadOfRemote(t *testing.T) {
+	repo := gitFixture(t)
+	mustGit(t, repo, "checkout", "-b", "seictl/onboard-bdc", "main")
+	mustGit(t, repo, "push", "-u", "origin", "seictl/onboard-bdc")
+	if err := os.WriteFile(filepath.Join(repo, "extra.txt"), []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	mustGit(t, repo, "add", "extra.txt")
+	mustGit(t, repo, "commit", "-m", "local-only")
+
+	err := refuseLossyCheckout(repo, "seictl/onboard-bdc")
+	if err == nil {
+		t.Fatalf("expected refusal")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "git reflog") || !strings.Contains(msg, "git switch") {
+		t.Errorf("error should hint git reflog and git switch; got %q", msg)
+	}
+}
+
+func TestRefuseLossyCheckout_LocalBranchNeverPushed(t *testing.T) {
+	repo := gitFixture(t)
+	mustGit(t, repo, "checkout", "-b", "seictl/onboard-bdc", "main")
+	if err := os.WriteFile(filepath.Join(repo, "extra.txt"), []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	mustGit(t, repo, "add", "extra.txt")
+	mustGit(t, repo, "commit", "-m", "local-only")
+
+	err := refuseLossyCheckout(repo, "seictl/onboard-bdc")
+	if err == nil {
+		t.Fatalf("expected refusal for never-pushed branch")
+	}
+	if !strings.Contains(err.Error(), "no remote tracking ref") {
+		t.Errorf("error should name the no-remote-tracking-ref case; got %q", err)
+	}
+}

--- a/cluster/internal/identity/identity.go
+++ b/cluster/internal/identity/identity.go
@@ -67,8 +67,10 @@ func Read(path string) (*Engineer, *clioutput.Error) {
 		return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatMalformed,
 			"engineer identity is missing required field: alias").WithDetail(path)
 	}
-	if e := validate.Alias(e.Alias); e != nil {
-		return nil, e.WithDetail(path)
+	if vErr := validate.Alias(e.Alias); vErr != nil {
+		// validate.Alias hardcodes ExitOnboard; rebrand for the read-side surface.
+		vErr.Code = clioutput.ExitIdentity
+		return nil, vErr.WithDetail(path)
 	}
 	return &e, nil
 }

--- a/cluster/internal/identity/identity.go
+++ b/cluster/internal/identity/identity.go
@@ -68,9 +68,7 @@ func Read(path string) (*Engineer, *clioutput.Error) {
 			"engineer identity is missing required field: alias").WithDetail(path)
 	}
 	if vErr := validate.Alias(e.Alias); vErr != nil {
-		// validate.Alias hardcodes ExitOnboard; rebrand for the read-side surface.
-		vErr.Code = clioutput.ExitIdentity
-		return nil, vErr.WithDetail(path)
+		return nil, vErr.ExitWith(clioutput.ExitIdentity).WithDetail(path)
 	}
 	return &e, nil
 }

--- a/cluster/internal/identity/identity.go
+++ b/cluster/internal/identity/identity.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/validate"
 )
 
 const (
@@ -65,6 +66,9 @@ func Read(path string) (*Engineer, *clioutput.Error) {
 	if e.Alias == "" {
 		return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatMalformed,
 			"engineer identity is missing required field: alias").WithDetail(path)
+	}
+	if e := validate.Alias(e.Alias); e != nil {
+		return nil, e.WithDetail(path)
 	}
 	return &e, nil
 }

--- a/cluster/internal/identity/identity_test.go
+++ b/cluster/internal/identity/identity_test.go
@@ -142,6 +142,9 @@ func TestRead_RejectsInvalidAlias(t *testing.T) {
 			if cliErr == nil || cliErr.Category != clioutput.CatAliasInvalid {
 				t.Errorf("expected alias-invalid, got %+v", cliErr)
 			}
+			if cliErr != nil && cliErr.Code != clioutput.ExitIdentity {
+				t.Errorf("exit code: got %d, want %d (read-side errors must not surface ExitOnboard)", cliErr.Code, clioutput.ExitIdentity)
+			}
 		})
 	}
 }

--- a/cluster/internal/identity/identity_test.go
+++ b/cluster/internal/identity/identity_test.go
@@ -119,6 +119,33 @@ func TestRead_MissingAliasField(t *testing.T) {
 	}
 }
 
+func TestRead_RejectsInvalidAlias(t *testing.T) {
+	cases := []struct {
+		name  string
+		alias string
+	}{
+		{"reserved", "kube-system"},
+		{"path-traversal", "../etc"},
+		{"glob", "*"},
+		{"uppercase", "Brandon"},
+		{"too-long", "this-alias-is-way-too-long-for-the-30-char-cap-on-aliases"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := tightTempDir(t)
+			path := filepath.Join(dir, "engineer.json")
+			body, _ := json.Marshal(Engineer{Alias: tc.alias, Name: "Anon"})
+			if err := os.WriteFile(path, body, FileMode); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			_, cliErr := Read(path)
+			if cliErr == nil || cliErr.Category != clioutput.CatAliasInvalid {
+				t.Errorf("expected alias-invalid, got %+v", cliErr)
+			}
+		})
+	}
+}
+
 func TestRead_RefusesLoosePerms(t *testing.T) {
 	dir := tightTempDir(t)
 	path := filepath.Join(dir, "engineer.json")

--- a/cluster/internal/validate/validate.go
+++ b/cluster/internal/validate/validate.go
@@ -46,45 +46,60 @@ var (
 	}
 )
 
-func Alias(s string) *clioutput.Error {
+// Error is a validation failure carrying the CLI category and message.
+// Callers attach the exit code at the call site via ExitWith — validation
+// owns the WHAT (this input is invalid, here is why); the caller owns the
+// WHEN/WHERE (which verb is failing, hence which exit code).
+type Error struct {
+	Category string
+	Message  string
+}
+
+func (e *Error) Error() string { return e.Category + ": " + e.Message }
+
+func (e *Error) ExitWith(code int) *clioutput.Error {
+	return clioutput.New(code, e.Category, e.Message)
+}
+
+func newErr(category, format string, args ...any) *Error {
+	return &Error{Category: category, Message: fmt.Sprintf(format, args...)}
+}
+
+func Alias(s string) *Error {
 	if !aliasRe.MatchString(s) {
-		return clioutput.Newf(clioutput.ExitOnboard, clioutput.CatAliasInvalid,
-			"alias %q does not match %s", s, aliasRe)
+		return newErr(clioutput.CatAliasInvalid, "alias %q does not match %s", s, aliasRe)
 	}
 	if _, denied := aliasDenyList[s]; denied {
-		return clioutput.Newf(clioutput.ExitOnboard, clioutput.CatAliasInvalid,
-			"alias %q is reserved", s)
+		return newErr(clioutput.CatAliasInvalid, "alias %q is reserved", s)
 	}
 	return nil
 }
 
 // Name validates a benchmark name and enforces the combined
 // `bench-<alias>-<name>` chain-id stays within K8s' 63-char label cap.
-func Name(alias, name string) *clioutput.Error {
+func Name(alias, name string) *Error {
 	if !nameRe.MatchString(name) {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
-			"name %q does not match %s", name, nameRe)
+		return newErr(clioutput.CatValidation, "name %q does not match %s", name, nameRe)
 	}
 	chainID := fmt.Sprintf("bench-%s-%s", alias, name)
 	if len(chainID) > maxK8sLabel {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
+		return newErr(clioutput.CatValidation,
 			"combined chain-id %q is %d chars, max %d", chainID, len(chainID), maxK8sLabel)
 	}
 	return nil
 }
 
-func Size(s string) *clioutput.Error {
+func Size(s string) *Error {
 	switch s {
 	case BenchSizeSmall, BenchSizeMedium, BenchSizeLarge:
 		return nil
 	}
-	return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
-		"size %q is not one of s|m|l", s)
+	return newErr(clioutput.CatValidation, "size %q is not one of s|m|l", s)
 }
 
-func DurationMinutes(n int) *clioutput.Error {
+func DurationMinutes(n int) *Error {
 	if n < BenchDurationMin || n > BenchDurationMax {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
+		return newErr(clioutput.CatValidation,
 			"duration %d minutes is out of range [%d, %d]", n, BenchDurationMin, BenchDurationMax)
 	}
 	return nil
@@ -93,15 +108,15 @@ func DurationMinutes(n int) *clioutput.Error {
 // Namespace enforces RFC-1123 label shape. If alias is non-empty, also
 // enforces the side-effecting-verb policy that the namespace equals
 // `eng-<alias>`. Pass empty alias for read-only verbs.
-func Namespace(ns, alias string) *clioutput.Error {
+func Namespace(ns, alias string) *Error {
 	if len(ns) > maxK8sLabel || !namespaceRe.MatchString(ns) {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatNamespacePolicy,
+		return newErr(clioutput.CatNamespacePolicy,
 			"namespace %q is not a valid RFC-1123 label", ns)
 	}
 	if alias != "" {
 		want := "eng-" + alias
 		if ns != want {
-			return clioutput.Newf(clioutput.ExitBench, clioutput.CatNamespacePolicy,
+			return newErr(clioutput.CatNamespacePolicy,
 				"namespace must equal %q for engineer %q (got %q)", want, alias, ns)
 		}
 	}
@@ -110,34 +125,31 @@ func Namespace(ns, alias string) *clioutput.Error {
 
 // Image enforces the registry policy (ECR-only, sei/* prefix, tag or
 // digest required). Digest resolution lives in internal/aws.
-func Image(ref string) *clioutput.Error {
+func Image(ref string) *Error {
 	if ref == "" {
-		return clioutput.New(clioutput.ExitBench, clioutput.CatImagePolicy,
-			"image is required")
+		return newErr(clioutput.CatImagePolicy, "image is required")
 	}
 	slash := strings.IndexByte(ref, '/')
 	if slash < 0 {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
-			"image %q is missing registry hostname", ref)
+		return newErr(clioutput.CatImagePolicy, "image %q is missing registry hostname", ref)
 	}
 	host := ref[:slash]
 	if host != AllowedRegistry {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+		return newErr(clioutput.CatImagePolicy,
 			"image registry must be %s (got %s)", AllowedRegistry, host)
 	}
 	rest := ref[slash+1:]
 	if !strings.HasPrefix(rest, AllowedRepoPrefix) {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+		return newErr(clioutput.CatImagePolicy,
 			"image repo must start with %q (got %q)", AllowedRepoPrefix, rest)
 	}
 	repoTail := rest[len(AllowedRepoPrefix):]
 	if repoTail == "" {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
+		return newErr(clioutput.CatImagePolicy,
 			"image %q is missing repo name after %q", ref, AllowedRepoPrefix)
 	}
 	if !strings.ContainsAny(repoTail, ":@") {
-		return clioutput.Newf(clioutput.ExitBench, clioutput.CatImagePolicy,
-			"image %q must specify a tag or digest", ref)
+		return newErr(clioutput.CatImagePolicy, "image %q must specify a tag or digest", ref)
 	}
 	return nil
 }

--- a/cluster/onboard.go
+++ b/cluster/onboard.go
@@ -111,7 +111,7 @@ var OnboardCmd = cli.Command{
 
 func runOnboard(ctx context.Context, in onboardInput, out io.Writer, deps onboardDeps) error {
 	if e := validate.Alias(in.Alias); e != nil {
-		return failOnboard(out, e)
+		return failOnboard(out, e.ExitWith(clioutput.ExitOnboard))
 	}
 
 	idPath, err := deps.identityPath()


### PR DESCRIPTION
## Summary

Batch PR for the three Low-severity findings from the cluster bugbash run, plus a follow-up commit addressing the coral team's review.

| Issue | Commit | Title |
|-------|--------|-------|
| #87 | 6052f9f | Re-validate engineer alias in `identity.Read` |
| #92 | d06ab1b | Refuse `git checkout -B` on a branch with local commits ahead of its tracking ref |
| #88 | 7446a5a | Add `--dry-run` flag to `bench down` |
| (review) | 0e826d1 | Address coral review: #87 exit-code bleed and #88 empty-result ambiguity |

Each commit closes one issue except the last, which folds two coral-review must-fix items into the same surface as the originals (rather than opening another PR for tweaks within already-touched files).

## Per-issue details

### #87 — Re-validate alias in identity.Read

`identity.Read` now calls `validate.Alias(e.Alias)` after the empty-check, so all consumers (bench, bench-down, bench-list, context) inherit a single trust boundary instead of each verb remembering to re-validate before composing namespaces, IAM names, and label selectors. Table-driven test covers reserved (`kube-system`), traversal (`..`), glob (`*`), uppercase, and too-long aliases.

**Coral review fold-in:** `validate.Alias` hardcodes `ExitOnboard` (it was originally onboard-only); without an adjustment, a bench-side error would exit 20 ("onboard") instead of 40 ("identity") — public-contract bleed for scripts and agent callers. `identity.Read` now rebrands the error's `Code` to `ExitIdentity`, preserving Category and Detail. Test asserts the exit code, not just the category.

### #92 — Refuse `git checkout -B` on a branch with local commits ahead

New `refuseLossyCheckout(repoPath, branch string) error` helper runs in `CreatePR` before the existing `git checkout -B`. Refuses if the local branch exists AND either (a) has commits ahead of `origin/<branch>` or (b) has no remote tracking ref at all. Error messages name `git switch`, `git reflog`, and `git branch -D` as recovery options. New `githubpr_test.go` with a real-git fixture (skipped when git isn't on PATH) covers the absent / tracked-clean / ahead-of-remote / never-pushed cases.

### #88 — Add `--dry-run` flag to `bench down`

Mirrors `kubectl delete --dry-run=server`: list the resources that would be deleted and report each with action `would-delete`, but skip the Delete API call. Default behavior remains "act on invocation" for parity with `rm`, `helm uninstall`, and `terraform destroy` — only the opt-in preview is added. Resources are listed via `kube.Client.List`. `DeletedAt` and the still-terminating `Hint` are skipped on dry-run.

**Coral review fold-in:** an agent caller running `--dry-run` couldn't tell "bench doesn't exist" from "already torn down" — both produced an empty `Resources` slice. Now an empty dry-run populates a Hint ("no resources match selector — bench may not exist or already be torn down") so the consumer can branch correctly. Tests updated.

## Coral review

Three specialists reviewed (kubernetes-specialist, security-specialist, platform-engineer):

- **kubernetes-specialist** flagged the #87 exit-code bleed (folded in) and noted #92 + #88 are correct.
- **security-specialist** reviewed the trust boundary on #87 and the error-message safety on #92; LGTM all three.
- **platform-engineer** flagged the #88 empty-result ambiguity (folded in), gave non-blocking feedback on #92's error-message ergonomics and #88's `CatApplyFailed` vocabulary for List errors (deferred — see below).

## Deferred (worth filing as follow-up issues if desired)

- #92 error message density: a newline-separated `Recovery:` block is more agent-extractable; `git push origin <branch>` is missing as a recovery option (most common case for the "already pushed" path).
- #88 `CatApplyFailed` for List errors: codebase-wide pattern — `bench_list` uses the same. Changing `bench_down` unilaterally would diverge from `bench_list`; should be one PR that introduces `CatListFailed` (or similar) and updates both.
- Minor: `%w` wrap on the no-tracking-ref case in `refuseLossyCheckout`; friendly message when a pre-existing bad-alias `engineer.json` blocks onboard re-entry.

## Test plan

- [x] `go test ./cluster/...` — all pass (existing + new identity, githubpr, bench_down tests).
- [x] `make lint` — clean.
- [x] Coral review run with three specialists (k8s, security, platform); must-fix items folded in.
- [x] Manual verification of #92: trigger the lossy-checkout case in a personal repo and confirm the recovery hint is actionable.
- [x] Manual verification of #88: `bench down --dry-run --name <existing>` reports `would-delete` actions; `bench down --dry-run --name nonexistent` reports the disambiguating hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)