### PR TITLE
feat(bench): emit RPC endpoint URLs in BenchUpResult (closes #100)

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	seiconfig "github.com/sei-protocol/sei-config"
+
 	"github.com/sei-protocol/seictl/cluster/internal/aws"
 	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
 	"github.com/sei-protocol/seictl/cluster/internal/identity"
@@ -58,9 +60,17 @@ type benchUpResult struct {
 	RPCNodes     int                  `json:"rpcNodes"`
 	Duration     string               `json:"duration"`
 	ResultsS3URI string               `json:"resultsS3Uri"`
+	Endpoints    Endpoints            `json:"endpoints"`
 	DryRun       bool                 `json:"dryRun"`
 	Manifests    []render.ManifestRef `json:"manifests"`
 	AppliedAt    *time.Time           `json:"appliedAt,omitempty"`
+}
+
+// Field names mirror downstream env-var contracts (SEI_TENDERMINT_RPC,
+// SEI_EVM_JSON_RPC) — rename = break two contracts.
+type Endpoints struct {
+	TendermintRpc []string `json:"tendermintRpc"`
+	EvmJsonRpc    []string `json:"evmJsonRpc"`
 }
 
 type benchUpInput struct {
@@ -200,6 +210,7 @@ func runBenchUp(ctx context.Context, in benchUpInput, out io.Writer, deps benchD
 		RPCNodes:     sizeProfile.RPC,
 		Duration:     fmt.Sprintf("%dm", in.Duration),
 		ResultsS3URI: s3URI,
+		Endpoints:    deriveEndpoints(chainID, namespace),
 		DryRun:       !in.Apply,
 		Manifests:    manifests,
 	}
@@ -363,6 +374,14 @@ func shortDigest(d string) string {
 		return d
 	}
 	return d[i+1 : i+1+12]
+}
+
+func deriveEndpoints(chainID, namespace string) Endpoints {
+	host := fmt.Sprintf("%s-rpc-internal.%s.svc.cluster.local", chainID, namespace)
+	return Endpoints{
+		TendermintRpc: []string{fmt.Sprintf("http://%s:%d", host, seiconfig.PortRPC)},
+		EvmJsonRpc:    []string{fmt.Sprintf("http://%s:%d", host, seiconfig.PortEVMHTTP)},
+	}
 }
 
 // rpcEndpointsJSON formats the seiload profile's `endpoints` array

--- a/cluster/bench_test.go
+++ b/cluster/bench_test.go
@@ -99,6 +99,15 @@ func TestRunBenchUp(t *testing.T) {
 		if data.ResultsS3URI != want {
 			t.Errorf("s3 uri: got %q, want %q", data.ResultsS3URI, want)
 		}
+
+		wantTM := "http://bench-bdc-demo-rpc-internal.eng-bdc.svc.cluster.local:26657"
+		wantEVM := "http://bench-bdc-demo-rpc-internal.eng-bdc.svc.cluster.local:8545"
+		if len(data.Endpoints.TendermintRpc) != 1 || data.Endpoints.TendermintRpc[0] != wantTM {
+			t.Errorf("tendermintRpc: got %v, want [%s]", data.Endpoints.TendermintRpc, wantTM)
+		}
+		if len(data.Endpoints.EvmJsonRpc) != 1 || data.Endpoints.EvmJsonRpc[0] != wantEVM {
+			t.Errorf("evmJsonRpc: got %v, want [%s]", data.Endpoints.EvmJsonRpc, wantEVM)
+		}
 		if len(data.Manifests) != 4 {
 			t.Fatalf("expected 4 manifests (validator SND, rpc SND, seiload Job, profile CM); got %d", len(data.Manifests))
 		}

--- a/docs/design/validation-substrate.md
+++ b/docs/design/validation-substrate.md
@@ -131,36 +131,27 @@ Composites (`bench up`) compose primitive waits: `chain wait → rpc wait → lo
 
 ### Endpoint emission
 
-`chain up`, `rpc up`, and `bench up` emit per-pod endpoint URLs in their JSON envelopes (already shipped in `bench up` via `ResultsS3URI` + manifest references; extend to include `endpoints` when the primitives ship). Downstream tooling — engineer shell scripts, GHA workflows, MCP agents, external test binaries — reads them and acts.
+`bench up` emits aggregate ClusterIP URLs for the rendered RPC fleet in its JSON envelope. Downstream tooling — engineer shell scripts, GHA workflows, MCP agents, external test binaries — reads them and acts.
 
-**Endpoint contract (locked):** split by RPC type, list per type, per-pod URLs.
+**Endpoint contract (locked):** split by RPC type, list per type. v1 emits a single-element list per type pointing at the SeiNodeDeployment's internal ClusterIP Service (which kube-proxy load-balances across healthy pods). Per-pod entries are additive when a consumer needs sharding.
 
 ```json
 {
   "endpoints": {
-    "tendermintRpc": [
-      "http://bench-bdc-foo-rpc-0.bench-bdc-foo-rpc-headless.eng-bdc.svc.cluster.local:26657",
-      "http://bench-bdc-foo-rpc-1.bench-bdc-foo-rpc-headless.eng-bdc.svc.cluster.local:26657"
-    ],
-    "evmJsonRpc": [
-      "http://bench-bdc-foo-rpc-0.bench-bdc-foo-rpc-headless.eng-bdc.svc.cluster.local:8545",
-      "http://bench-bdc-foo-rpc-1.bench-bdc-foo-rpc-headless.eng-bdc.svc.cluster.local:8545"
-    ],
-    "cosmosGrpc": [
-      "bench-bdc-foo-rpc-0.bench-bdc-foo-rpc-headless.eng-bdc.svc.cluster.local:9090",
-      "bench-bdc-foo-rpc-1.bench-bdc-foo-rpc-headless.eng-bdc.svc.cluster.local:9090"
-    ]
+    "tendermintRpc": ["http://bench-bdc-foo-rpc-internal.eng-bdc.svc.cluster.local:26657"],
+    "evmJsonRpc":    ["http://bench-bdc-foo-rpc-internal.eng-bdc.svc.cluster.local:8545"]
   }
 }
 ```
 
-Three rules behind the shape:
+Two rules behind the shape:
 
 - **Split by RPC type, not flat-with-discriminator.** Most consumers know which port they want (seiload by profile, qa-testing's mocha by suite). A flat list with a `{type, url}` object would force every consumer to filter; the split eliminates that.
-- **Per-pod, not aggregate.** Consumers shard, round-robin, or pick a single replica. Per-pod URLs give them the option; an aggregate Service URL only allows kube-proxy round-robin.
-- **Full URLs (with scheme + port) for HTTP types; `host:port` for gRPC** because gRPC clients don't take `http://` prefixes — Sei's gRPC is h2c.
+- **List per type.** Single-element today, multi-element when per-pod sharding lands. Consumers can already do `endpoints.evmJsonRpc[0]` and stay forwards-compatible.
 
-Adding new endpoint types (e.g. `evmWebSocket`, `cosmosLcd`) is backwards-compatible. Renaming or restructuring `endpoints.<type>` is not — these field names are the contract.
+Why aggregate, not per-pod, in v1: the SND controller already publishes the internal ClusterIP Service via `.status.internalService` for stateless HTTP types (RPC, EVM HTTP, REST). kube-proxy load-balances across healthy pods. Per-pod URLs are needed only for sharding consumers (seiload generates its own profile config separately) and for stateful protocols like gRPC + EVM WebSocket where kube-proxy L4 LB doesn't work — both deferred until a real consumer asks.
+
+Adding new endpoint types (e.g. `evmWebSocket`, `cosmosGrpc`, `cosmosLcd`) is backwards-compatible. Renaming or restructuring `endpoints.<type>` is not — these field names are the contract.
 
 Two consumption shapes:
 
@@ -187,7 +178,7 @@ exit $exit_code
 
 The first concrete external test binary consuming this contract is the qa-testing TS/mocha harness. Its design lives in [`sei-protocol/qa-testing` `docs/design/seictl-harness.md`](https://github.com/sei-protocol/qa-testing/blob/main/docs/design/seictl-harness.md) and exists as a reference for how downstream tooling adopts the endpoint contract:
 
-- **Env-var names** mirror the JSON envelope's field names — `SEI_EVM_JSON_RPC` reads `endpoints.evmJsonRpc[0]`, `SEI_TENDERMINT_RPC` reads `endpoints.tendermintRpc[0]`, `SEI_COSMOS_GRPC` reads `endpoints.cosmosGrpc[0]`. Renaming either side breaks the integration.
+- **Env-var names** mirror the JSON envelope's field names — `SEI_EVM_JSON_RPC` reads `endpoints.evmJsonRpc[0]`, `SEI_TENDERMINT_RPC` reads `endpoints.tendermintRpc[0]`. Renaming either side breaks the integration.
 - **Exit codes** follow platform#235's `0` / `1` / `2` (pass / test fail / infra fail). The harness wraps mocha and classifies failures.
 - **One-line stdout summary** (`{"passed":N,"failed":M,"exitCode":0,"reportPath":"..."}`) lets seictl-driven loops parse the verdict without reading the mochawesome JSON.
 


### PR DESCRIPTION
## Summary

Adds the \`endpoints\` field to \`BenchUpResult\`'s JSON envelope. Until this lands, the qa-testing harness's orchestration recipe (\`jq -r '.endpoints.evmJsonRpc[0]'\`) returns \`null\` — no consumer can complete the seictl-driven round-trip.

Closes #100. Updates the validation-substrate design doc to match the simpler aggregate-instead-of-per-pod call we made during implementation.

## What changed

**Schema delta** (\`cluster/bench.go\`):

\`\`\`go
type Endpoints struct {
    TendermintRpc []string \`json:\"tendermintRpc\"\`
    EvmJsonRpc    []string \`json:\"evmJsonRpc\"\`
}
\`\`\`

**URL shape:** \`http://<chainId>-rpc-internal.<namespace>.svc.cluster.local:<port>\` — points at the SND's internal ClusterIP Service (already published on \`.status.internalService\`). kube-proxy load-balances across healthy pods.

**Why aggregate, not per-pod:** the design originally locked per-pod, but during implementation we recognized the SND controller already publishes the internal ClusterIP Service for stateless HTTP types and kube-proxy LB does the right thing for typical consumers (qa-testing harness, GHA glue, future fuzzers). Per-pod is needed only for sharding (seiload generates its own profile config separately) and stateful protocols (gRPC + EVM WS) which can't kube-proxy LB. Both deferred until a consumer asks. Lists are kept (single-element today) so per-pod expansion is additive.

## Verification

- \`go test ./cluster/...\` — all green
- Live verified: \`AWS_PROFILE=sei seictl bench up --image <real-tag> --name smoke\` emits:
  \`\`\`json
  {
    \"endpoints\": {
      \"tendermintRpc\": [\"http://bench-bdchatham-smoke-rpc-internal.eng-bdchatham.svc.cluster.local:26657\"],
      \"evmJsonRpc\":    [\"http://bench-bdchatham-smoke-rpc-internal.eng-bdchatham.svc.cluster.local:8545\"]
    }
  }
  \`\`\`

## Test plan

- [x] Unit tests cover the new field shape
- [x] Live dry-run against harbor
- [ ] Skim the design doc diff to confirm aggregate-vs-per-pod framing reads right
- [ ] (Follow-up) Update qa-testing harness design (sei-protocol/qa-testing) to drop \`SEI_COSMOS_GRPC\` from the locked env-var list — it's deferred until per-pod / stateful-protocol support lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)