### PR TITLE
feat(rpc): standalone rpc up/down primitives (closes #103)

### DIFF
--- a/cluster/internal/clioutput/envelope.go
+++ b/cluster/internal/clioutput/envelope.go
@@ -24,6 +24,8 @@ const (
 	KindBenchListResult = "BenchListResult"
 	KindChainUpResult   = "ChainUpResult"
 	KindChainDownResult = "ChainDownResult"
+	KindRPCUpResult     = "RPCUpResult"
+	KindRPCDownResult   = "RPCDownResult"
 	KindOnboardResult   = "OnboardResult"
 )
 

--- a/cluster/internal/validate/validate.go
+++ b/cluster/internal/validate/validate.go
@@ -113,6 +113,23 @@ func Validators(n int) *Error {
 	return nil
 }
 
+func RPCReplicas(n int) *Error {
+	if n < 1 || n > 21 {
+		return newErr(clioutput.CatValidation,
+			"rpc replica count %d is out of range [1, 21]", n)
+	}
+	return nil
+}
+
+// ChainID enforces a non-empty bech32-friendly chain identifier.
+// Engineers usually pass the value emitted by `chain up`'s envelope.
+func ChainID(s string) *Error {
+	if s == "" {
+		return newErr(clioutput.CatValidation, "chain-id must not be empty")
+	}
+	return nil
+}
+
 // Namespace enforces RFC-1123 label shape. If alias is non-empty, also
 // enforces the side-effecting-verb policy that the namespace equals
 // `eng-<alias>`. Pass empty alias for read-only verbs.

--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -1,0 +1,216 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	seiconfig "github.com/sei-protocol/sei-config"
+
+	"github.com/sei-protocol/seictl/cluster/internal/aws"
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/identity"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+	"github.com/sei-protocol/seictl/cluster/internal/render"
+	"github.com/sei-protocol/seictl/cluster/internal/validate"
+)
+
+const (
+	defaultRPCReplicas = 2
+	defaultRPCName     = "default"
+)
+
+type rpcUpResult struct {
+	ChainID     string               `json:"chainId"`
+	Name        string               `json:"name"`
+	Namespace   string               `json:"namespace"`
+	ImageRef    string               `json:"imageRef"`
+	ImageDigest string               `json:"imageDigest"`
+	Replicas    int                  `json:"replicas"`
+	Endpoints   Endpoints            `json:"endpoints"`
+	DryRun      bool                 `json:"dryRun"`
+	Manifests   []render.ManifestRef `json:"manifests"`
+	AppliedAt   *time.Time           `json:"appliedAt,omitempty"`
+}
+
+type rpcUpInput struct {
+	ChainID    string
+	Name       string
+	Image      string
+	Replicas   int
+	Apply      bool
+	Kubeconfig string
+	Context    string
+}
+
+type rpcDeps struct {
+	resolveDigest func(context.Context, string) (string, *clioutput.Error)
+	identityPath  func() (string, error)
+	newKubeClient func(kube.Options) (*kube.Client, *clioutput.Error)
+	apply         func(ctx context.Context, kc *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error)
+	getCaller     func(context.Context) (*aws.Caller, *clioutput.Error)
+}
+
+var defaultRPCDeps = rpcDeps{
+	resolveDigest: aws.ResolveDigest,
+	identityPath:  identity.DefaultPath,
+	newKubeClient: kube.New,
+	apply:         applyToCluster,
+	getCaller:     aws.GetCaller,
+}
+
+var RPCCmd = cli.Command{
+	Name:  "rpc",
+	Usage: "Manage RPC fleets peering with an existing chain",
+	Commands: []*cli.Command{
+		rpcDownCmd,
+		{
+			Name:  "up",
+			Usage: "Render or apply an RPC fleet against a named chain",
+			Flags: append(kubeconfigFlags(),
+				&cli.StringFlag{Name: "chain", Required: true, Usage: "Chain ID to peer with (e.g. bench-bdc-qa)"},
+				&cli.StringFlag{Name: "name", Value: defaultRPCName, Usage: "RPC fleet name (lets multiple fleets attach to one chain)"},
+				&cli.StringFlag{Name: "image", Required: true, Usage: "ECR image ref"},
+				&cli.IntFlag{Name: "replicas", Value: defaultRPCReplicas, Usage: "RPC replica count (1-21)"},
+				&cli.BoolFlag{Name: "apply", Usage: "Server-side apply the rendered manifest; default is dry-run"},
+			),
+			Action: func(ctx context.Context, command *cli.Command) error {
+				return runRPCUpCmd(ctx, rpcUpInput{
+					ChainID:    command.String("chain"),
+					Name:       command.String("name"),
+					Image:      command.String("image"),
+					Replicas:   int(command.Int("replicas")),
+					Apply:      command.Bool("apply"),
+					Kubeconfig: command.String("kubeconfig"),
+					Context:    command.String("context"),
+				}, os.Stdout, defaultRPCDeps)
+			},
+		},
+	},
+}
+
+func runRPCUpCmd(ctx context.Context, in rpcUpInput, out io.Writer, deps rpcDeps) error {
+	res, err := runRPCUp(ctx, in, deps)
+	if err != nil {
+		return failRPCUp(out, err)
+	}
+	if emitErr := clioutput.Emit(out, clioutput.KindRPCUpResult, res); emitErr != nil {
+		fmt.Fprintln(os.Stderr, emitErr)
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+func runRPCUp(ctx context.Context, in rpcUpInput, deps rpcDeps) (rpcUpResult, *clioutput.Error) {
+	eng, idErr := loadEngineer(deps.identityPath)
+	if idErr != nil {
+		return rpcUpResult{}, idErr
+	}
+	if e := validate.ChainID(in.ChainID); e != nil {
+		return rpcUpResult{}, e.ExitWith(clioutput.ExitBench)
+	}
+	if e := validate.Image(in.Image); e != nil {
+		return rpcUpResult{}, e.ExitWith(clioutput.ExitBench)
+	}
+	if e := validate.Name(eng.Alias, in.Name); e != nil {
+		return rpcUpResult{}, e.ExitWith(clioutput.ExitBench)
+	}
+	if e := validate.RPCReplicas(in.Replicas); e != nil {
+		return rpcUpResult{}, e.ExitWith(clioutput.ExitBench)
+	}
+	namespace := "eng-" + eng.Alias
+	if e := validate.Namespace(namespace, eng.Alias); e != nil {
+		return rpcUpResult{}, e.ExitWith(clioutput.ExitBench)
+	}
+	if _, callerErr := deps.getCaller(ctx); callerErr != nil {
+		return rpcUpResult{}, callerErr
+	}
+
+	digest, dErr := deps.resolveDigest(ctx, in.Image)
+	if dErr != nil {
+		return rpcUpResult{}, dErr
+	}
+	seidImage := digestPinned(in.Image, digest)
+	if err := aws.AssertECRDigestRef(seidImage); err != nil {
+		return rpcUpResult{}, clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution, "%v", err)
+	}
+
+	digestShort := shortDigest(digest)
+	docs, manifests, rerr := renderRPCManifests(eng.Alias, in.ChainID, in.Name, namespace, seidImage, digestShort, in.Replicas)
+	if rerr != nil {
+		return rpcUpResult{}, rerr
+	}
+
+	res := rpcUpResult{
+		ChainID:     in.ChainID,
+		Name:        in.Name,
+		Namespace:   namespace,
+		ImageRef:    in.Image,
+		ImageDigest: digest,
+		Replicas:    in.Replicas,
+		Endpoints:   deriveRPCEndpoints(in.ChainID, in.Name, namespace),
+		DryRun:      !in.Apply,
+		Manifests:   manifests,
+	}
+
+	if in.Apply {
+		kc, kerr := deps.newKubeClient(kube.Options{Kubeconfig: in.Kubeconfig, Context: in.Context})
+		if kerr != nil {
+			return rpcUpResult{}, kerr
+		}
+		applyResults, applyErr := deps.apply(ctx, kc, benchFieldOwner, namespace, docs)
+		if applyErr != nil {
+			return rpcUpResult{}, applyErr
+		}
+		res.Manifests = mergeApplyResults(manifests, applyResults)
+		now := time.Now().UTC()
+		res.AppliedAt = &now
+	}
+	return res, nil
+}
+
+func renderRPCManifests(alias, chainID, name, namespace, seidImage, digestShort string, replicas int) ([][]byte, []render.ManifestRef, *clioutput.Error) {
+	vars := map[string]string{
+		"CHAIN_ID":           chainID,
+		"RPC_NAME":           name,
+		"NAMESPACE":          namespace,
+		"ENGINEER_ALIAS":     alias,
+		"SEID_IMAGE":         seidImage,
+		"IMAGE_DIGEST_SHORT": digestShort,
+		"RPC_COUNT":          strconv.Itoa(replicas),
+		"PART_OF":            "seictl",
+	}
+	rpcYAML, e := renderEmbedded("rpc.yaml", vars)
+	if e != nil {
+		return nil, nil, e
+	}
+	docs := render.SplitYAML(rpcYAML)
+	refs := make([]render.ManifestRef, 0, len(docs))
+	for _, doc := range docs {
+		ref, err := render.ExtractRef(doc)
+		if err != nil {
+			return nil, nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatTemplateRender, "extract manifest ref: %v", err)
+		}
+		ref.Action = "create"
+		refs = append(refs, ref)
+	}
+	return docs, refs, nil
+}
+
+func deriveRPCEndpoints(chainID, name, namespace string) Endpoints {
+	host := fmt.Sprintf("%s-rpc-%s-internal.%s.svc.cluster.local", chainID, name, namespace)
+	return Endpoints{
+		TendermintRpc: []string{fmt.Sprintf("http://%s:%d", host, seiconfig.PortRPC)},
+		EvmJsonRpc:    []string{fmt.Sprintf("http://%s:%d", host, seiconfig.PortEVMHTTP)},
+	}
+}
+
+func failRPCUp(out io.Writer, e *clioutput.Error) error {
+	_ = clioutput.EmitError(out, clioutput.KindRPCUpResult, e)
+	return cli.Exit("", e.Code)
+}

--- a/cluster/rpc_down.go
+++ b/cluster/rpc_down.go
@@ -1,0 +1,170 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/identity"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+	"github.com/sei-protocol/seictl/cluster/internal/render"
+	"github.com/sei-protocol/seictl/cluster/internal/validate"
+)
+
+var rpcDownTargets = []string{"seinodedeployments.sei.io"}
+
+type rpcDownResult struct {
+	ChainID   string               `json:"chainId"`
+	Name      string               `json:"name"`
+	Namespace string               `json:"namespace"`
+	Resources []render.ManifestRef `json:"resources"`
+	DryRun    bool                 `json:"dryRun"`
+	DeletedAt *time.Time           `json:"deletedAt,omitempty"`
+	Hint      string               `json:"hint,omitempty"`
+}
+
+type rpcDownInput struct {
+	ChainID    string
+	Name       string
+	Namespace  string
+	Kubeconfig string
+	Context    string
+	DryRun     bool
+}
+
+type rpcDownDeps struct {
+	identityPath  func() (string, error)
+	newKubeClient func(kube.Options) (*kube.Client, *clioutput.Error)
+	deleteFn      func(ctx context.Context, kc *kube.Client, opts kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error)
+	dryRunListFn  func(ctx context.Context, kc *kube.Client, opts kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error)
+}
+
+var defaultRPCDownDeps = rpcDownDeps{
+	identityPath:  identity.DefaultPath,
+	newKubeClient: kube.New,
+	deleteFn:      deleteFromCluster,
+	dryRunListFn:  dryRunListFromCluster,
+}
+
+var rpcDownCmd = &cli.Command{
+	Name:  "down",
+	Usage: "Tear down an RPC fleet by chain + name",
+	Flags: append(kubeconfigFlags(),
+		&cli.StringFlag{Name: "chain", Required: true, Usage: "Chain ID the RPC fleet peers with"},
+		&cli.StringFlag{Name: "name", Value: defaultRPCName, Usage: "RPC fleet name"},
+		&cli.StringFlag{Name: "namespace", Aliases: []string{"n"}, Usage: "Namespace (defaults to eng-<alias>)"},
+		&cli.BoolFlag{Name: "dry-run", Usage: "List the resources that would be deleted without deleting them"},
+	),
+	Action: func(ctx context.Context, command *cli.Command) error {
+		return runRPCDown(ctx, rpcDownInput{
+			ChainID:    command.String("chain"),
+			Name:       command.String("name"),
+			Namespace:  command.String("namespace"),
+			Kubeconfig: command.String("kubeconfig"),
+			Context:    command.String("context"),
+			DryRun:     command.Bool("dry-run"),
+		}, os.Stdout, defaultRPCDownDeps)
+	},
+}
+
+func runRPCDown(ctx context.Context, in rpcDownInput, out io.Writer, deps rpcDownDeps) error {
+	eng, idErr := loadEngineer(deps.identityPath)
+	if idErr != nil {
+		return failRPCDown(out, idErr)
+	}
+	if e := validate.ChainID(in.ChainID); e != nil {
+		return failRPCDown(out, e.ExitWith(clioutput.ExitBench))
+	}
+	if e := validate.Name(eng.Alias, in.Name); e != nil {
+		return failRPCDown(out, e.ExitWith(clioutput.ExitBench))
+	}
+
+	namespace := in.Namespace
+	if namespace == "" {
+		namespace = "eng-" + eng.Alias
+	}
+	if e := validate.Namespace(namespace, eng.Alias); e != nil {
+		return failRPCDown(out, e.ExitWith(clioutput.ExitBench))
+	}
+
+	selector := fmt.Sprintf("sei.io/engineer=%s,sei.io/chain-id=%s,sei.io/rpc-name=%s,app.kubernetes.io/component=rpc",
+		eng.Alias, in.ChainID, in.Name)
+
+	kc, kerr := deps.newKubeClient(kube.Options{Kubeconfig: in.Kubeconfig, Context: in.Context})
+	if kerr != nil {
+		return failRPCDown(out, kerr)
+	}
+
+	var (
+		results []kube.DeleteResult
+		dErr    *clioutput.Error
+	)
+	if in.DryRun {
+		results, dErr = deps.dryRunListFn(ctx, kc, kube.ListOptions{
+			Namespace:     namespace,
+			Resources:     rpcDownTargets,
+			LabelSelector: selector,
+		})
+	} else {
+		results, dErr = deps.deleteFn(ctx, kc, kube.DeleteOptions{
+			Namespace:     namespace,
+			Resources:     rpcDownTargets,
+			LabelSelector: selector,
+		})
+	}
+	if dErr != nil {
+		return failRPCDown(out, dErr)
+	}
+
+	resources := make([]render.ManifestRef, len(results))
+	for i, r := range results {
+		resources[i] = render.ManifestRef{
+			Kind:      r.Kind,
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Action:    r.Action,
+		}
+	}
+
+	res := rpcDownResult{
+		ChainID:   in.ChainID,
+		Name:      in.Name,
+		Namespace: namespace,
+		Resources: resources,
+		DryRun:    in.DryRun,
+	}
+	switch {
+	case in.DryRun:
+		if len(results) == 0 {
+			res.Hint = fmt.Sprintf("no resources match selector %q in namespace %q — rpc fleet may not exist or already be torn down", selector, namespace)
+		}
+	default:
+		terminating := 0
+		for _, r := range results {
+			if r.Action == "still-terminating" {
+				terminating++
+			}
+		}
+		if terminating == 0 {
+			now := time.Now().UTC()
+			res.DeletedAt = &now
+		} else {
+			res.Hint = fmt.Sprintf("%d resource(s) still terminating; wait before re-running with the same name", terminating)
+		}
+	}
+	if err := clioutput.Emit(out, clioutput.KindRPCDownResult, res); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+func failRPCDown(out io.Writer, e *clioutput.Error) error {
+	_ = clioutput.EmitError(out, clioutput.KindRPCDownResult, e)
+	return cli.Exit("", e.Code)
+}

--- a/cluster/rpc_down_test.go
+++ b/cluster/rpc_down_test.go
@@ -1,0 +1,96 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+)
+
+func TestRunRPCDown(t *testing.T) {
+	t.Run("dry-run uses chain-id + rpc-name + component=rpc selector", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		var capturedSelector string
+		deps := rpcDownDeps{
+			identityPath:  func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) { return &kube.Client{}, nil },
+			dryRunListFn: func(_ context.Context, _ *kube.Client, opts kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				capturedSelector = opts.LabelSelector
+				return []kube.DeleteResult{
+					{Kind: "SeiNodeDeployment", Name: "bench-bdc-qa-rpc-default", Namespace: "eng-bdc", Action: "would-delete"},
+				}, nil
+			},
+		}
+		var buf bytes.Buffer
+		_ = runRPCDown(context.Background(), rpcDownInput{ChainID: "bench-bdc-qa", Name: "default", DryRun: true}, &buf, deps)
+		want := "sei.io/engineer=bdc,sei.io/chain-id=bench-bdc-qa,sei.io/rpc-name=default,app.kubernetes.io/component=rpc"
+		if capturedSelector != want {
+			t.Errorf("selector: got %q\nwant %q", capturedSelector, want)
+		}
+	})
+
+	t.Run("dry-run with no matches surfaces hint", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		deps := rpcDownDeps{
+			identityPath:  func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) { return &kube.Client{}, nil },
+			dryRunListFn: func(context.Context, *kube.Client, kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				return nil, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runRPCDown(context.Background(), rpcDownInput{ChainID: "bench-bdc-qa", Name: "default", DryRun: true}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runRPCDown: %v", err)
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data rpcDownResult
+		_ = json.Unmarshal(env.Data, &data)
+		if !strings.Contains(data.Hint, "no resources match") {
+			t.Errorf("expected hint about no matches; got %q", data.Hint)
+		}
+	})
+
+	t.Run("delete sets DeletedAt when nothing is terminating", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		deps := rpcDownDeps{
+			identityPath:  func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) { return &kube.Client{}, nil },
+			deleteFn: func(context.Context, *kube.Client, kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
+				return []kube.DeleteResult{
+					{Kind: "SeiNodeDeployment", Name: "bench-bdc-qa-rpc-default", Namespace: "eng-bdc", Action: "deleted"},
+				}, nil
+			},
+		}
+		var buf bytes.Buffer
+		err := runRPCDown(context.Background(), rpcDownInput{ChainID: "bench-bdc-qa", Name: "default"}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runRPCDown: %v", err)
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data rpcDownResult
+		_ = json.Unmarshal(env.Data, &data)
+		if data.DeletedAt == nil {
+			t.Errorf("DeletedAt should be set")
+		}
+	})
+
+	t.Run("rejects empty chain-id", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		deps := rpcDownDeps{
+			identityPath:  func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) { return &kube.Client{}, nil },
+		}
+		var buf bytes.Buffer
+		err := runRPCDown(context.Background(), rpcDownInput{ChainID: "", Name: "default"}, &buf, deps)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}

--- a/cluster/rpc_test.go
+++ b/cluster/rpc_test.go
@@ -1,0 +1,237 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+	"github.com/sei-protocol/seictl/cluster/internal/kube"
+)
+
+const rpcTestDigest = "sha256:fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"
+
+func stubRPCDeps(t *testing.T, alias string) rpcDeps {
+	t.Helper()
+	path := writeEngineerFile(t, alias)
+	return rpcDeps{
+		resolveDigest: func(context.Context, string) (string, *clioutput.Error) { return rpcTestDigest, nil },
+		identityPath:  func() (string, error) { return path, nil },
+		apply: func(context.Context, *kube.Client, string, string, [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
+			t.Fatalf("apply should not be called on dry-run path")
+			return nil, nil
+		},
+		getCaller: okCaller,
+	}
+}
+
+func TestRunRPCUp(t *testing.T) {
+	t.Run("dry-run emits RPCUpResult envelope with both endpoint types", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runRPCUpCmd(context.Background(), rpcUpInput{
+			ChainID:  "bench-bdc-qa",
+			Name:     "default",
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1.2.3",
+			Replicas: 2,
+		}, &buf, stubRPCDeps(t, "bdc"))
+		if err != nil {
+			t.Fatalf("runRPCUpCmd: %v\n%s", err, buf.String())
+		}
+
+		var env clioutput.Envelope
+		if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+			t.Fatalf("envelope unmarshal: %v\n%s", err, buf.String())
+		}
+		if env.Kind != clioutput.KindRPCUpResult || env.APIVersion != clioutput.APIVersion {
+			t.Errorf("envelope: kind=%q apiVersion=%q", env.Kind, env.APIVersion)
+		}
+		if env.Error != nil {
+			t.Fatalf("error body: %+v", env.Error)
+		}
+
+		var data rpcUpResult
+		if err := json.Unmarshal(env.Data, &data); err != nil {
+			t.Fatalf("data unmarshal: %v", err)
+		}
+		if data.ChainID != "bench-bdc-qa" || data.Name != "default" || data.Replicas != 2 {
+			t.Errorf("envelope fields: %+v", data)
+		}
+		if !data.DryRun {
+			t.Errorf("dryRun should be true")
+		}
+
+		wantTM := "http://bench-bdc-qa-rpc-default-internal.eng-bdc.svc.cluster.local:26657"
+		wantEVM := "http://bench-bdc-qa-rpc-default-internal.eng-bdc.svc.cluster.local:8545"
+		if len(data.Endpoints.TendermintRpc) != 1 || data.Endpoints.TendermintRpc[0] != wantTM {
+			t.Errorf("tendermintRpc: got %v, want [%s]", data.Endpoints.TendermintRpc, wantTM)
+		}
+		if len(data.Endpoints.EvmJsonRpc) != 1 || data.Endpoints.EvmJsonRpc[0] != wantEVM {
+			t.Errorf("evmJsonRpc: got %v, want [%s]", data.Endpoints.EvmJsonRpc, wantEVM)
+		}
+
+		if len(data.Manifests) != 1 {
+			t.Fatalf("expected 1 manifest; got %d", len(data.Manifests))
+		}
+		m := data.Manifests[0]
+		if m.Kind != "SeiNodeDeployment" || m.Name != "bench-bdc-qa-rpc-default" {
+			t.Errorf("manifest: %+v", m)
+		}
+	})
+
+	t.Run("multi-fleet naming — different --name yields different SND name", func(t *testing.T) {
+		for _, fleetName := range []string{"qa-test", "shadow", "long"} {
+			var buf bytes.Buffer
+			err := runRPCUpCmd(context.Background(), rpcUpInput{
+				ChainID:  "bench-bdc-foo",
+				Name:     fleetName,
+				Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+				Replicas: 2,
+			}, &buf, stubRPCDeps(t, "bdc"))
+			if err != nil {
+				t.Fatalf("runRPCUpCmd(%s): %v", fleetName, err)
+			}
+			var env clioutput.Envelope
+			_ = json.Unmarshal(buf.Bytes(), &env)
+			var data rpcUpResult
+			_ = json.Unmarshal(env.Data, &data)
+			wantName := "bench-bdc-foo-rpc-" + fleetName
+			if data.Manifests[0].Name != wantName {
+				t.Errorf("multi-fleet name: got %q, want %q", data.Manifests[0].Name, wantName)
+			}
+		}
+	})
+
+	t.Run("rejects empty chain-id", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runRPCUpCmd(context.Background(), rpcUpInput{
+			ChainID:  "",
+			Name:     "default",
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Replicas: 2,
+		}, &buf, stubRPCDeps(t, "bdc"))
+		if err == nil || !strings.Contains(buf.String(), "validation") {
+			t.Errorf("expected validation error; got %s", buf.String())
+		}
+	})
+
+	t.Run("rejects replicas outside [1,21]", func(t *testing.T) {
+		for _, n := range []int{0, 22, -1} {
+			var buf bytes.Buffer
+			err := runRPCUpCmd(context.Background(), rpcUpInput{
+				ChainID:  "bench-bdc-qa",
+				Name:     "default",
+				Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+				Replicas: n,
+			}, &buf, stubRPCDeps(t, "bdc"))
+			if err == nil || !strings.Contains(buf.String(), "validation") {
+				t.Errorf("replicas=%d should fail validation; got %s", n, buf.String())
+			}
+		}
+	})
+
+	t.Run("rejects non-ECR image", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runRPCUpCmd(context.Background(), rpcUpInput{
+			ChainID:  "bench-bdc-qa",
+			Name:     "default",
+			Image:    "docker.io/sei/sei-chain:v1",
+			Replicas: 2,
+		}, &buf, stubRPCDeps(t, "bdc"))
+		if err == nil || !strings.Contains(buf.String(), "image-policy") {
+			t.Errorf("expected image-policy error; got %s", buf.String())
+		}
+	})
+
+	t.Run("apply happy path sets appliedAt", func(t *testing.T) {
+		path := writeEngineerFile(t, "bdc")
+		deps := rpcDeps{
+			resolveDigest: func(context.Context, string) (string, *clioutput.Error) { return rpcTestDigest, nil },
+			identityPath:  func() (string, error) { return path, nil },
+			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) {
+				return &kube.Client{ContextName: "harbor", Namespace: "eng-bdc"}, nil
+			},
+			apply: func(_ context.Context, _ *kube.Client, fieldOwner, namespace string, docs [][]byte) ([]kube.ApplyResult, *clioutput.Error) {
+				if fieldOwner != benchFieldOwner {
+					t.Errorf("field owner: got %q", fieldOwner)
+				}
+				if len(docs) != 1 {
+					t.Errorf("expected 1 doc; got %d", len(docs))
+				}
+				return []kube.ApplyResult{{Kind: "SeiNodeDeployment", Name: "stub", Namespace: "eng-bdc", Action: "create"}}, nil
+			},
+			getCaller: okCaller,
+		}
+		var buf bytes.Buffer
+		err := runRPCUpCmd(context.Background(), rpcUpInput{
+			ChainID:  "bench-bdc-qa",
+			Name:     "default",
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Replicas: 2,
+			Apply:    true,
+		}, &buf, deps)
+		if err != nil {
+			t.Fatalf("runRPCUpCmd: %v\n%s", err, buf.String())
+		}
+		var env clioutput.Envelope
+		_ = json.Unmarshal(buf.Bytes(), &env)
+		var data rpcUpResult
+		_ = json.Unmarshal(env.Data, &data)
+		if data.AppliedAt == nil {
+			t.Errorf("appliedAt should be set on --apply")
+		}
+	})
+
+	t.Run("missing identity surfaces typed error", func(t *testing.T) {
+		deps := rpcDeps{
+			resolveDigest: func(context.Context, string) (string, *clioutput.Error) { return rpcTestDigest, nil },
+			identityPath:  func() (string, error) { return "", errors.New("home unset") },
+		}
+		var buf bytes.Buffer
+		err := runRPCUpCmd(context.Background(), rpcUpInput{
+			ChainID:  "bench-bdc-qa",
+			Name:     "default",
+			Image:    "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Replicas: 2,
+		}, &buf, deps)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(buf.String(), `"category": "missing"`) {
+			t.Errorf("expected missing identity error; got %s", buf.String())
+		}
+	})
+
+	t.Run("rendered manifest has rpc component label and peer selector", func(t *testing.T) {
+		docs, _, err := renderRPCManifests("bdc", "bench-bdc-qa", "default", "eng-bdc", "img@sha256:0", "0123456789ab", 2)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if len(docs) != 1 {
+			t.Fatalf("expected 1 doc; got %d", len(docs))
+		}
+		body := string(docs[0])
+		for _, want := range []string{
+			"app.kubernetes.io/component: rpc",
+			"app.kubernetes.io/part-of: seictl",
+			"sei.io/role: rpc",
+			"sei.io/chain-id: bench-bdc-qa",
+			"sei.io/rpc-name: default",
+			"sei.io/engineer: bdc",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("rendered doc missing label %q", want)
+			}
+		}
+		for _, want := range []string{
+			"sei.io/chain-id: bench-bdc-qa",
+			"sei.io/role: validator",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("rendered doc missing peer selector %q", want)
+			}
+		}
+	})
+}

--- a/cluster/templates/rpc.yaml
+++ b/cluster/templates/rpc.yaml
@@ -1,0 +1,45 @@
+# Source: sei-protocol/platform autobake/templates/seinodedeployment.yaml
+# Vars: CHAIN_ID, RPC_NAME, NAMESPACE, ENGINEER_ALIAS, SEID_IMAGE,
+#       IMAGE_DIGEST_SHORT, RPC_COUNT, PART_OF
+# Standalone RPC fleet that peers with an existing chain's validators
+# via LabelPeerSource. Multi-fleet capable: name = ${CHAIN_ID}-rpc-${RPC_NAME}.
+apiVersion: sei.io/v1alpha1
+kind: SeiNodeDeployment
+metadata:
+  name: ${CHAIN_ID}-rpc-${RPC_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: seictl
+    app.kubernetes.io/part-of: ${PART_OF}
+    app.kubernetes.io/component: rpc
+    sei.io/chain-id: ${CHAIN_ID}
+    sei.io/engineer: ${ENGINEER_ALIAS}
+    sei.io/rpc-name: ${RPC_NAME}
+    sei.io/image-sha: ${IMAGE_DIGEST_SHORT}
+    sei.io/role: rpc
+spec:
+  replicas: ${RPC_COUNT}
+  deletionPolicy: Delete
+  updateStrategy:
+    type: InPlace
+  template:
+    metadata:
+      labels:
+        sei.io/chain-id: ${CHAIN_ID}
+        sei.io/engineer: ${ENGINEER_ALIAS}
+        sei.io/rpc-name: ${RPC_NAME}
+        sei.io/role: rpc
+    spec:
+      chainId: ${CHAIN_ID}
+      image: ${SEID_IMAGE}
+      entrypoint:
+        command: ["seid"]
+        args: ["start", "--home", "/sei"]
+      peers:
+        - label:
+            selector:
+              sei.io/chain-id: ${CHAIN_ID}
+              sei.io/role: validator
+      fullNode: {}
+      overrides:
+        evm.ws_enabled: "true"

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 			&cluster.ContextCmd,
 			&cluster.BenchCmd,
 			&cluster.ChainCmd,
+			&cluster.RPCCmd,
 			&cluster.OnboardCmd,
 		},
 		Flags: []cli.Flag{


### PR DESCRIPTION
## Summary

Closes [#103](https://github.com/sei-protocol/seictl/issues/103). Last verb in the primitive split started by [#104](https://github.com/sei-protocol/seictl/pull/104).

Adds `seictl rpc up` / `rpc down` for standing up an RPC fleet that peers with an existing chain. Multi-fleet capable via `--name` (default `default`) — engineers can attach multiple RPC fleets to one chain (qa-test, shadow, etc.) without collision.

## CLI

```
seictl rpc up --chain bench-bdc-qa --image <ref>
              [--name default] [--replicas 2] [--apply]
seictl rpc down --chain bench-bdc-qa [--name default]
```

## What's in the diff

- `cluster/rpc.go` (~190 LoC) — `runRPCUp`, `rpcDeps`, `RPCCmd`
- `cluster/rpc_down.go` (~160 LoC) — `runRPCDown`, label-selector delete
- `cluster/templates/rpc.yaml` — multi-fleet SND template; peer selector uses the validation-substrate-locked schema (`sei.io/chain-id` + `sei.io/role=validator`), not the older `sei.io/nodedeployment`
- 11 new tests across `rpc_test.go` + `rpc_down_test.go`
- New envelope kinds: `KindRPCUpResult`, `KindRPCDownResult`
- `validate.RPCReplicas()` and `validate.ChainID()` helpers

## Endpoint emission

Both `tendermintRpc` AND `evmJsonRpc` (rpc fleet serves both, unlike chain). Single-element list per type — aggregate ClusterIP per the locked contract. Service DNS:

```
${CHAIN_ID}-rpc-${RPC_NAME}-internal.${NAMESPACE}.svc.cluster.local
```

## V1 cuts (coral synthesis)

- **Bench up's existing `rpc-snd.yaml` template untouched.** The new `rpc.yaml` is rpc-up's; bench up keeps shipping single-fleet shape until a real consumer wants multi-fleet there. Avoids regressing bench up's endpoint URLs and SSA-tracked label set.
- **No pre-flight chain-existence check** — SND controller resolves peer selectors continuously; the fleet picks up validators as they ready.
- **No image inheritance from chain SND** — explicit `--image` flag matches chain up. Engineers can run mismatched images intentionally (qa-testing: stable validators + RPC under test).
- **No `rpc wait` / `list` / `logs` standalone verbs** — orchestrator uses kubectl directly.

## Live verification

```
$ seictl rpc up --chain bench-bdchatham-qa --image .../sei-chain:<sha>
{
  "kind": "RPCUpResult",
  "data": {
    "chainId": "bench-bdchatham-qa",
    "name": "default",
    "replicas": 2,
    "endpoints": {
      "tendermintRpc": ["http://bench-bdchatham-qa-rpc-default-internal.eng-bdchatham.svc.cluster.local:26657"],
      "evmJsonRpc":    ["http://bench-bdchatham-qa-rpc-default-internal.eng-bdchatham.svc.cluster.local:8545"]
    },
    "manifests": [
      {"kind": "SeiNodeDeployment", "name": "bench-bdchatham-qa-rpc-default", "namespace": "eng-bdchatham", "action": "create"}
    ]
  }
}
```

## Test plan

- [x] `go test ./cluster/...` — all green (11 new tests + existing chain/bench tests pass)
- [x] Live dry-run against harbor produces correct envelope
- [x] Live apply once the qa-testing harness orchestration recipe runs end-to-end (separate workstream)

## What this completes

The qa-testing integration loop is now end-to-end-able:

```sh
seictl chain up --image $IMAGE --name qa --apply -o json > chain.json
seictl rpc up --chain $(jq -r .data.chainId chain.json) --image $IMAGE --apply -o json > rpc.json
kubectl exec <validator-pod> -- seid tx bank send <validator> $ADMIN_ADDR 100000000usei ...
SEI_EVM_JSON_RPC=$(jq -r .data.endpoints.evmJsonRpc[0] rpc.json) yarn qa-test
seictl rpc down --chain ... --name default
seictl chain down --name qa
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)