### PR TITLE
fix(ci): drop workflow_run trigger from GoReleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [ published ]
   workflow_dispatch:
-  workflow_run:
-    workflows: [Releaser]
-    types: [completed]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

GoReleaser was firing twice per release — once on `release: published` (correct, checks out the tagged commit) and once on `workflow_run: [Releaser] completed` (race-prone, checks out `main` HEAD). The workflow_run path failed on every release for the past several months with:

```
git tag v0.0.X was not made against commit <main HEAD>
```

…because by the time goreleaser fires on workflow_run completion, `main` may have advanced past the tagged commit (or the tag may not be created yet, depending on uci's internal ordering).

Dropping the workflow_run trigger fixes binary-asset publishing for `v0.0.32+`.

## Effect

- Future releases publish binaries normally via the `release: published` trigger.
- `v0.0.31` (already published, currently has no binary assets) needs a one-time `gh workflow run goreleaser.yml --ref v0.0.31 --repo sei-protocol/seictl` to backfill its assets retroactively.

## Why this matters now

Unblocks sei-protocol/platform#313 — the nightly workflow can switch from extracting the binary from `ghcr.io/sei-protocol/seictl:v0.0.31` (current workaround) to `gh release download` once binaries publish reliably.

## Test plan

- [ ] After merge, `gh workflow run goreleaser.yml --ref v0.0.31` against this repo. Confirm `gh release view v0.0.31` shows `seictl_Linux_x86_64.tar.gz` + checksums.
- [ ] On the next version.json bump, confirm GoReleaser fires only once (no `workflow_run`-triggered run in `gh run list --workflow goreleaser.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)