### PR TITLE
feat(sidecar): wire externally-supplied genesis accounts

### DIFF
--- a/sidecar/tasks/assemble_genesis.go
+++ b/sidecar/tasks/assemble_genesis.go
@@ -284,21 +284,17 @@ func (a *GenesisAssembler) addMissingGenesisAccounts(accountBalance string) erro
 		return nil
 	}
 
-	if err := writeBackAuthAndBank("assemble-genesis", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
-		return err
+	if err := writeBackAuthAndBank(cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+		return fmt.Errorf("assemble-genesis: %w", err)
 	}
 
 	assembleLog.Info("genesis accounts reconciled", "added", added, "total", len(accs))
 	return nil
 }
 
-// addExternalGenesisAccounts must run AFTER addMissingGenesisAccounts so
-// validator-derived accounts are visible for collision detection.
-// Collisions hard-fail: an address already in auth.accounts is almost
-// certainly an operator config error.
-//
-// Supply is not updated here — non-fork starts with empty Supply and
-// bank.InitGenesis recomputes from balances. The fork mirror updates it.
+// Run after addMissingGenesisAccounts so collisions catch validator-
+// derived addresses. Non-fork's empty Supply lets bank.InitGenesis
+// recompute from balances; the fork mirror updates Supply explicitly.
 func (a *GenesisAssembler) addExternalGenesisAccounts(accounts []GenesisAccountEntry) error {
 	if len(accounts) == 0 {
 		return nil
@@ -342,8 +338,8 @@ func (a *GenesisAssembler) addExternalGenesisAccounts(accounts []GenesisAccountE
 		assembleLog.Info("added external genesis account", "address", addr.String(), "balance", entry.Balance)
 	}
 
-	if err := writeBackAuthAndBank("assemble-genesis", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
-		return err
+	if err := writeBackAuthAndBank(cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+		return fmt.Errorf("assemble-genesis: %w", err)
 	}
 	return nil
 }

--- a/sidecar/tasks/assemble_genesis.go
+++ b/sidecar/tasks/assemble_genesis.go
@@ -49,12 +49,20 @@ type AssembleNodeEntry struct {
 	Name string `json:"name"`
 }
 
+// GenesisAccountEntry represents one externally-supplied genesis account.
+// Mirrors SeiNodeDeployment.spec.genesis.accounts[] on the controller side.
+type GenesisAccountEntry struct {
+	Address string `json:"address"`
+	Balance string `json:"balance"`
+}
+
 // AssembleGenesisRequest holds the typed parameters for the assemble-and-upload-genesis task.
 // S3 bucket, region, and prefix are derived from the sidecar's environment.
 type AssembleGenesisRequest struct {
-	AccountBalance string              `json:"accountBalance"`
-	Namespace      string              `json:"namespace"`
-	Nodes          []AssembleNodeEntry `json:"nodes"`
+	AccountBalance string                `json:"accountBalance"`
+	Namespace      string                `json:"namespace"`
+	Nodes          []AssembleNodeEntry   `json:"nodes"`
+	Accounts       []GenesisAccountEntry `json:"accounts,omitempty"`
 }
 
 // nodeNames returns the list of node name strings from the Nodes entries.
@@ -115,6 +123,10 @@ func (a *GenesisAssembler) Handler() engine.TaskHandler {
 		}
 
 		if err := a.addMissingGenesisAccounts(cfg.AccountBalance); err != nil {
+			return err
+		}
+
+		if err := a.addExternalGenesisAccounts(cfg.Accounts); err != nil {
 			return err
 		}
 
@@ -272,36 +284,67 @@ func (a *GenesisAssembler) addMissingGenesisAccounts(accountBalance string) erro
 		return nil
 	}
 
-	accs = authtypes.SanitizeGenesisAccounts(accs)
-	genAccs, err := authtypes.PackAccounts(accs)
-	if err != nil {
-		return fmt.Errorf("assemble-genesis: packing accounts: %w", err)
-	}
-	authGenState.Accounts = genAccs
-	authStateBz, err := cdc.MarshalAsJSON(&authGenState)
-	if err != nil {
-		return fmt.Errorf("assemble-genesis: marshaling auth state: %w", err)
-	}
-	appState[authtypes.ModuleName] = authStateBz
-
-	bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
-	bankStateBz, err := cdc.MarshalAsJSON(bankGenState)
-	if err != nil {
-		return fmt.Errorf("assemble-genesis: marshaling bank state: %w", err)
-	}
-	appState[banktypes.ModuleName] = bankStateBz
-
-	appStateJSON, err := json.Marshal(appState)
-	if err != nil {
-		return fmt.Errorf("assemble-genesis: marshaling app state: %w", err)
-	}
-	genDoc.AppState = appStateJSON
-
-	if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
-		return fmt.Errorf("assemble-genesis: writing genesis: %w", err)
+	if err := writeBackAuthAndBank("assemble-genesis", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+		return err
 	}
 
 	assembleLog.Info("genesis accounts reconciled", "added", added, "total", len(accs))
+	return nil
+}
+
+// addExternalGenesisAccounts must run AFTER addMissingGenesisAccounts so
+// validator-derived accounts are visible for collision detection.
+// Collisions hard-fail: an address already in auth.accounts is almost
+// certainly an operator config error.
+//
+// Supply is not updated here — non-fork starts with empty Supply and
+// bank.InitGenesis recomputes from balances. The fork mirror updates it.
+func (a *GenesisAssembler) addExternalGenesisAccounts(accounts []GenesisAccountEntry) error {
+	if len(accounts) == 0 {
+		return nil
+	}
+
+	cdc, _ := makeCodec()
+	ensureBech32()
+
+	genFile := filepath.Join(a.homeDir, "config", "genesis.json")
+	appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: reading genesis: %w", err)
+	}
+
+	authGenState := authtypes.GetGenesisStateFromAppState(cdc, appState)
+	accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: unpacking accounts: %w", err)
+	}
+
+	bankGenState := banktypes.GetGenesisStateFromAppState(cdc, appState)
+
+	for _, entry := range accounts {
+		addr, err := sdk.AccAddressFromBech32(entry.Address)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis: external account %q: %w", entry.Address, err)
+		}
+		if accs.Contains(addr) {
+			return fmt.Errorf("assemble-genesis: external account %s collides with an existing genesis account", addr.String())
+		}
+		coins, err := sdk.ParseCoinsNormalized(entry.Balance)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis: external account %s balance %q: %w", addr.String(), entry.Balance, err)
+		}
+
+		accs = append(accs, authtypes.NewBaseAccount(addr, nil, 0, 0))
+		bankGenState.Balances = append(bankGenState.Balances, banktypes.Balance{
+			Address: addr.String(),
+			Coins:   coins.Sort(),
+		})
+		assembleLog.Info("added external genesis account", "address", addr.String(), "balance", entry.Balance)
+	}
+
+	if err := writeBackAuthAndBank("assemble-genesis", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/sidecar/tasks/assemble_genesis_external_test.go
+++ b/sidecar/tasks/assemble_genesis_external_test.go
@@ -1,0 +1,295 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
+	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
+	genutiltypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/genutil/types"
+)
+
+// minimalGenesis writes a Tendermint genesis.json with empty app_state;
+// GetGenesisStateFromAppState defaults absent module keys, so this is
+// enough for auth+bank append tests.
+func minimalGenesis(t *testing.T, homeDir string) string {
+	t.Helper()
+	configDir := filepath.Join(homeDir, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	genFile := filepath.Join(configDir, "genesis.json")
+	body := `{
+		"chain_id": "test-chain-1",
+		"genesis_time": "2026-01-01T00:00:00Z",
+		"initial_height": "1",
+		"consensus_params": {
+			"block": {"max_bytes": "22020096", "max_gas": "-1"},
+			"evidence": {"max_age_num_blocks": "100000", "max_age_duration": "172800000000000", "max_bytes": "1048576"},
+			"validator": {"pub_key_types": ["ed25519"]},
+			"version": {}
+		},
+		"validators": [],
+		"app_hash": "",
+		"app_state": {}
+	}`
+	if err := os.WriteFile(genFile, []byte(body), 0o644); err != nil {
+		t.Fatalf("write genesis: %v", err)
+	}
+	return genFile
+}
+
+func readBankBalances(t *testing.T, genFile string) []banktypes.Balance {
+	t.Helper()
+	cdc, _ := makeCodec()
+	appState, _, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		t.Fatalf("reading genesis: %v", err)
+	}
+	bank := banktypes.GetGenesisStateFromAppState(cdc, appState)
+	return bank.Balances
+}
+
+func readAuthAccountAddrs(t *testing.T, genFile string) []string {
+	t.Helper()
+	cdc, _ := makeCodec()
+	appState, _, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		t.Fatalf("reading genesis: %v", err)
+	}
+	auth := authtypes.GetGenesisStateFromAppState(cdc, appState)
+	accs, err := authtypes.UnpackAccounts(auth.Accounts)
+	if err != nil {
+		t.Fatalf("unpacking accounts: %v", err)
+	}
+	out := make([]string, 0, len(accs))
+	for _, a := range accs {
+		out = append(out, a.GetAddress().String())
+	}
+	return out
+}
+
+func TestAddExternalGenesisAccounts_NoOpOnEmpty(t *testing.T) {
+	homeDir := t.TempDir()
+	genFile := minimalGenesis(t, homeDir)
+	mtimeBefore := mustModTime(t, genFile)
+
+	a := NewGenesisAssembler(homeDir, "bucket", "region", "test-chain-1", nil, nil)
+	if err := a.addExternalGenesisAccounts(nil); err != nil {
+		t.Fatalf("nil accounts: %v", err)
+	}
+	if err := a.addExternalGenesisAccounts([]GenesisAccountEntry{}); err != nil {
+		t.Fatalf("empty accounts: %v", err)
+	}
+
+	if mustModTime(t, genFile) != mtimeBefore {
+		t.Errorf("genesis.json was rewritten on no-op input")
+	}
+}
+
+func TestAddExternalGenesisAccounts_AppendsBalanceAndAccount(t *testing.T) {
+	homeDir := t.TempDir()
+	genFile := minimalGenesis(t, homeDir)
+
+	a := NewGenesisAssembler(homeDir, "bucket", "region", "test-chain-1", nil, nil)
+	addr := "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+	bal := "1000000000usei"
+
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: addr, Balance: bal}})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	balances := readBankBalances(t, genFile)
+	found := false
+	for _, b := range balances {
+		if b.Address == addr {
+			found = true
+			if b.Coins.String() != "1000000000usei" {
+				t.Errorf("balance: got %s, want %s", b.Coins.String(), bal)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("address %s not found in bank.balances; got %v", addr, balances)
+	}
+
+	addrs := readAuthAccountAddrs(t, genFile)
+	if !containsAddr(addrs, addr) {
+		t.Errorf("address %s not found in auth.accounts; got %v", addr, addrs)
+	}
+}
+
+func TestAddExternalGenesisAccounts_CollisionHardFails(t *testing.T) {
+	homeDir := t.TempDir()
+	_ = minimalGenesis(t, homeDir)
+
+	a := NewGenesisAssembler(homeDir, "bucket", "region", "test-chain-1", nil, nil)
+	addr := "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+
+	// First add succeeds.
+	if err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: addr, Balance: "1usei"}}); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	// Second add of the same address must error.
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: addr, Balance: "999usei"}})
+	if err == nil {
+		t.Fatal("expected collision error, got nil")
+	}
+	if !strings.Contains(err.Error(), "collides") {
+		t.Errorf("collision error message: got %q, want substring 'collides'", err.Error())
+	}
+}
+
+func TestAddExternalGenesisAccounts_RejectsDuplicateInSameBatch(t *testing.T) {
+	homeDir := t.TempDir()
+	_ = minimalGenesis(t, homeDir)
+
+	a := NewGenesisAssembler(homeDir, "bucket", "region", "test-chain-1", nil, nil)
+	addr := "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{
+		{Address: addr, Balance: "1usei"},
+		{Address: addr, Balance: "2usei"},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate-in-batch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "collides") {
+		t.Errorf("error: got %q, want substring 'collides'", err.Error())
+	}
+}
+
+func TestAddExternalGenesisAccounts_CollidesWithPreSeeded(t *testing.T) {
+	// Mirrors the production case where a validator-derived account
+	// (added by addMissingGenesisAccounts) collides with an external
+	// account on the same address. Seed via the codec API directly,
+	// not via the function under test, to prove collision detection
+	// does not depend on which path populated auth.accounts.
+	homeDir := t.TempDir()
+	genFile := minimalGenesis(t, homeDir)
+	addr := "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+	seedAuthAccount(t, genFile, addr)
+
+	a := NewGenesisAssembler(homeDir, "bucket", "region", "test-chain-1", nil, nil)
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: addr, Balance: "1usei"}})
+	if err == nil {
+		t.Fatal("expected collision against pre-seeded account, got nil")
+	}
+	if !strings.Contains(err.Error(), "collides") {
+		t.Errorf("error: got %q, want substring 'collides'", err.Error())
+	}
+}
+
+// seedAuthAccount writes a single bech32 entry into auth.accounts on the
+// genesis file via the same codec path the production code uses.
+func seedAuthAccount(t *testing.T, genFile, bech32 string) {
+	t.Helper()
+	cdc, _ := makeCodec()
+	ensureBech32()
+	appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		t.Fatalf("reading genesis: %v", err)
+	}
+	authGenState := authtypes.GetGenesisStateFromAppState(cdc, appState)
+	accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
+	if err != nil {
+		t.Fatalf("unpacking: %v", err)
+	}
+	addr, err := sdk.AccAddressFromBech32(bech32)
+	if err != nil {
+		t.Fatalf("parsing addr: %v", err)
+	}
+	accs = append(accs, authtypes.NewBaseAccount(addr, nil, 0, 0))
+	bank := banktypes.GetGenesisStateFromAppState(cdc, appState)
+	if err := writeBackAuthAndBank("test-seed", cdc, genFile, genDoc, appState, authGenState, accs, bank); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestAddExternalGenesisAccounts_RejectsBadBech32(t *testing.T) {
+	homeDir := t.TempDir()
+	_ = minimalGenesis(t, homeDir)
+
+	a := NewGenesisAssembler(homeDir, "bucket", "region", "test-chain-1", nil, nil)
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: "not-bech32", Balance: "1usei"}})
+	if err == nil {
+		t.Fatal("expected bech32 error, got nil")
+	}
+}
+
+func TestAddExternalGenesisAccounts_RejectsBadBalance(t *testing.T) {
+	homeDir := t.TempDir()
+	_ = minimalGenesis(t, homeDir)
+
+	a := NewGenesisAssembler(homeDir, "bucket", "region", "test-chain-1", nil, nil)
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{
+		Address: "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9",
+		Balance: "not-a-coin",
+	}})
+	if err == nil {
+		t.Fatal("expected balance parse error, got nil")
+	}
+}
+
+func TestForkAddExternalGenesisAccounts_UpdatesSupply(t *testing.T) {
+	homeDir := t.TempDir()
+	genFile := minimalGenesis(t, homeDir)
+
+	a := NewGenesisForkAssembler(homeDir, "bucket", "region", nil, nil)
+	addr := "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: addr, Balance: "5000usei"}})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	cdc, _ := makeCodec()
+	appState, _, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		t.Fatalf("reading genesis: %v", err)
+	}
+	bank := banktypes.GetGenesisStateFromAppState(cdc, appState)
+
+	// Supply must equal totalSupply or bank.InitGenesis panics
+	// (sei-cosmos/x/bank/keeper/genesis.go:48).
+	if bank.Supply.AmountOf("usei").String() != "5000" {
+		t.Errorf("supply usei: got %s, want 5000", bank.Supply.AmountOf("usei").String())
+	}
+}
+
+func TestForkAddExternalGenesisAccounts_CollisionHardFails(t *testing.T) {
+	homeDir := t.TempDir()
+	_ = minimalGenesis(t, homeDir)
+
+	a := NewGenesisForkAssembler(homeDir, "bucket", "region", nil, nil)
+	addr := "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+
+	if err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: addr, Balance: "1usei"}}); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	err := a.addExternalGenesisAccounts([]GenesisAccountEntry{{Address: addr, Balance: "999usei"}})
+	if err == nil {
+		t.Fatal("expected collision error, got nil")
+	}
+}
+
+func mustModTime(t *testing.T, path string) int64 {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	return st.ModTime().UnixNano()
+}
+
+func containsAddr(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/sidecar/tasks/assemble_genesis_external_test.go
+++ b/sidecar/tasks/assemble_genesis_external_test.go
@@ -205,7 +205,7 @@ func seedAuthAccount(t *testing.T, genFile, bech32 string) {
 	}
 	accs = append(accs, authtypes.NewBaseAccount(addr, nil, 0, 0))
 	bank := banktypes.GetGenesisStateFromAppState(cdc, appState)
-	if err := writeBackAuthAndBank("test-seed", cdc, genFile, genDoc, appState, authGenState, accs, bank); err != nil {
+	if err := writeBackAuthAndBank(cdc, genFile, genDoc, appState, authGenState, accs, bank); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 }

--- a/sidecar/tasks/assemble_genesis_fork.go
+++ b/sidecar/tasks/assemble_genesis_fork.go
@@ -35,11 +35,12 @@ const forkAssembleMarkerFile = ".sei-sidecar-fork-assemble-done"
 // The bucket and region come from the assembler's constructor (platform env vars).
 // sourceChainId tells the assembler where to find the exported state.
 type AssembleGenesisForkRequest struct {
-	SourceChainID  string              `json:"sourceChainId"`
-	ChainID        string              `json:"chainId"`
-	AccountBalance string              `json:"accountBalance"`
-	Namespace      string              `json:"namespace"`
-	Nodes          []AssembleNodeEntry `json:"nodes"`
+	SourceChainID  string                `json:"sourceChainId"`
+	ChainID        string                `json:"chainId"`
+	AccountBalance string                `json:"accountBalance"`
+	Namespace      string                `json:"namespace"`
+	Nodes          []AssembleNodeEntry   `json:"nodes"`
+	Accounts       []GenesisAccountEntry `json:"accounts,omitempty"`
 }
 
 func (r AssembleGenesisForkRequest) nodeNames() []string {
@@ -141,6 +142,9 @@ func (a *GenesisForkAssembler) assemble(ctx context.Context, req AssembleGenesis
 		return err
 	}
 	if err := a.addMissingGenesisAccounts(req.AccountBalance); err != nil {
+		return err
+	}
+	if err := a.addExternalGenesisAccounts(req.Accounts); err != nil {
 		return err
 	}
 	if err := a.collectGentxs(); err != nil {
@@ -403,35 +407,65 @@ func (a *GenesisForkAssembler) addMissingGenesisAccounts(accountBalance string) 
 	}
 
 	if added > 0 {
-		accs = authtypes.SanitizeGenesisAccounts(accs)
-		genAccs, err := authtypes.PackAccounts(accs)
-		if err != nil {
-			return fmt.Errorf("assemble-genesis-fork: packing accounts: %w", err)
-		}
-		authGenState.Accounts = genAccs
-		authStateBz, err := cdc.MarshalAsJSON(&authGenState)
-		if err != nil {
-			return fmt.Errorf("assemble-genesis-fork: marshaling auth state: %w", err)
-		}
-		appState[authtypes.ModuleName] = authStateBz
-
-		bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
-		bankStateBz, err := cdc.MarshalAsJSON(bankGenState)
-		if err != nil {
-			return fmt.Errorf("assemble-genesis-fork: marshaling bank state: %w", err)
-		}
-		appState[banktypes.ModuleName] = bankStateBz
-
-		appStateJSON, err := json.Marshal(appState)
-		if err != nil {
-			return fmt.Errorf("assemble-genesis-fork: marshaling app state: %w", err)
-		}
-		genDoc.AppState = appStateJSON
-		if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
-			return fmt.Errorf("assemble-genesis-fork: writing genesis: %w", err)
+		if err := writeBackAuthAndBank("assemble-genesis-fork", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+			return err
 		}
 	}
 	forkLog.Info("genesis accounts reconciled", "added", added)
+	return nil
+}
+
+// Fork mirror of GenesisAssembler.addExternalGenesisAccounts. Updates
+// bankGenState.Supply explicitly — fork inherits a non-empty Supply,
+// and bank.InitGenesis panics on Supply != totalSupply
+// (sei-cosmos/x/bank/keeper/genesis.go:48).
+func (a *GenesisForkAssembler) addExternalGenesisAccounts(accounts []GenesisAccountEntry) error {
+	if len(accounts) == 0 {
+		return nil
+	}
+
+	cdc, _ := makeCodec()
+	ensureBech32()
+
+	genFile := filepath.Join(a.homeDir, "config", "genesis.json")
+	appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: reading genesis: %w", err)
+	}
+
+	authGenState := authtypes.GetGenesisStateFromAppState(cdc, appState)
+	accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis-fork: unpacking accounts: %w", err)
+	}
+
+	bankGenState := banktypes.GetGenesisStateFromAppState(cdc, appState)
+
+	for _, entry := range accounts {
+		addr, err := sdk.AccAddressFromBech32(entry.Address)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: external account %q: %w", entry.Address, err)
+		}
+		if accs.Contains(addr) {
+			return fmt.Errorf("assemble-genesis-fork: external account %s collides with an existing genesis account", addr.String())
+		}
+		coins, err := sdk.ParseCoinsNormalized(entry.Balance)
+		if err != nil {
+			return fmt.Errorf("assemble-genesis-fork: external account %s balance %q: %w", addr.String(), entry.Balance, err)
+		}
+
+		accs = append(accs, authtypes.NewBaseAccount(addr, nil, 0, 0))
+		bankGenState.Balances = append(bankGenState.Balances, banktypes.Balance{
+			Address: addr.String(),
+			Coins:   coins.Sort(),
+		})
+		bankGenState.Supply = bankGenState.Supply.Add(coins...)
+		forkLog.Info("added external genesis account", "address", addr.String(), "balance", entry.Balance)
+	}
+
+	if err := writeBackAuthAndBank("assemble-genesis-fork", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/sidecar/tasks/assemble_genesis_fork.go
+++ b/sidecar/tasks/assemble_genesis_fork.go
@@ -407,8 +407,8 @@ func (a *GenesisForkAssembler) addMissingGenesisAccounts(accountBalance string) 
 	}
 
 	if added > 0 {
-		if err := writeBackAuthAndBank("assemble-genesis-fork", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
-			return err
+		if err := writeBackAuthAndBank(cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+			return fmt.Errorf("assemble-genesis-fork: %w", err)
 		}
 	}
 	forkLog.Info("genesis accounts reconciled", "added", added)
@@ -463,8 +463,8 @@ func (a *GenesisForkAssembler) addExternalGenesisAccounts(accounts []GenesisAcco
 		forkLog.Info("added external genesis account", "address", addr.String(), "balance", entry.Balance)
 	}
 
-	if err := writeBackAuthAndBank("assemble-genesis-fork", cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
-		return err
+	if err := writeBackAuthAndBank(cdc, genFile, genDoc, appState, authGenState, accs, bankGenState); err != nil {
+		return fmt.Errorf("assemble-genesis-fork: %w", err)
 	}
 	return nil
 }

--- a/sidecar/tasks/genesis_writeback.go
+++ b/sidecar/tasks/genesis_writeback.go
@@ -13,9 +13,8 @@ import (
 )
 
 // writeBackAuthAndBank serializes mutated auth + bank state and exports
-// the genesis file. `prefix` flavors error messages with the calling task.
+// the genesis file. Callers wrap the returned error with task context.
 func writeBackAuthAndBank(
-	prefix string,
 	cdc codec.Codec,
 	genFile string,
 	genDoc *tmtypes.GenesisDoc,
@@ -27,30 +26,30 @@ func writeBackAuthAndBank(
 	accs = authtypes.SanitizeGenesisAccounts(accs)
 	genAccs, err := authtypes.PackAccounts(accs)
 	if err != nil {
-		return fmt.Errorf("%s: packing accounts: %w", prefix, err)
+		return fmt.Errorf("packing accounts: %w", err)
 	}
 	authGenState.Accounts = genAccs
 	authStateBz, err := cdc.MarshalAsJSON(&authGenState)
 	if err != nil {
-		return fmt.Errorf("%s: marshaling auth state: %w", prefix, err)
+		return fmt.Errorf("marshaling auth state: %w", err)
 	}
 	appState[authtypes.ModuleName] = authStateBz
 
 	bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
 	bankStateBz, err := cdc.MarshalAsJSON(bankGenState)
 	if err != nil {
-		return fmt.Errorf("%s: marshaling bank state: %w", prefix, err)
+		return fmt.Errorf("marshaling bank state: %w", err)
 	}
 	appState[banktypes.ModuleName] = bankStateBz
 
 	appStateJSON, err := json.Marshal(appState)
 	if err != nil {
-		return fmt.Errorf("%s: marshaling app state: %w", prefix, err)
+		return fmt.Errorf("marshaling app state: %w", err)
 	}
 	genDoc.AppState = appStateJSON
 
 	if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
-		return fmt.Errorf("%s: writing genesis: %w", prefix, err)
+		return fmt.Errorf("writing genesis: %w", err)
 	}
 	return nil
 }

--- a/sidecar/tasks/genesis_writeback.go
+++ b/sidecar/tasks/genesis_writeback.go
@@ -1,0 +1,56 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	tmtypes "github.com/sei-protocol/sei-chain/sei-tendermint/types"
+
+	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
+	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
+	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
+	"github.com/sei-protocol/sei-chain/sei-cosmos/x/genutil"
+)
+
+// writeBackAuthAndBank serializes mutated auth + bank state and exports
+// the genesis file. `prefix` flavors error messages with the calling task.
+func writeBackAuthAndBank(
+	prefix string,
+	cdc codec.Codec,
+	genFile string,
+	genDoc *tmtypes.GenesisDoc,
+	appState map[string]json.RawMessage,
+	authGenState authtypes.GenesisState,
+	accs authtypes.GenesisAccounts,
+	bankGenState *banktypes.GenesisState,
+) error {
+	accs = authtypes.SanitizeGenesisAccounts(accs)
+	genAccs, err := authtypes.PackAccounts(accs)
+	if err != nil {
+		return fmt.Errorf("%s: packing accounts: %w", prefix, err)
+	}
+	authGenState.Accounts = genAccs
+	authStateBz, err := cdc.MarshalAsJSON(&authGenState)
+	if err != nil {
+		return fmt.Errorf("%s: marshaling auth state: %w", prefix, err)
+	}
+	appState[authtypes.ModuleName] = authStateBz
+
+	bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
+	bankStateBz, err := cdc.MarshalAsJSON(bankGenState)
+	if err != nil {
+		return fmt.Errorf("%s: marshaling bank state: %w", prefix, err)
+	}
+	appState[banktypes.ModuleName] = bankStateBz
+
+	appStateJSON, err := json.Marshal(appState)
+	if err != nil {
+		return fmt.Errorf("%s: marshaling app state: %w", prefix, err)
+	}
+	genDoc.AppState = appStateJSON
+
+	if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+		return fmt.Errorf("%s: writing genesis: %w", prefix, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Sidecar-side wiring for [sei-protocol/sei-k8s-controller#160](https://github.com/sei-protocol/sei-k8s-controller/issues/160). Adds `addExternalGenesisAccounts` to `GenesisAssembler` and `GenesisForkAssembler`, consuming a new `Accounts []GenesisAccountEntry` field on the request structs.

The qa-testing harness ([sei-protocol/qa-testing `feat/seictl-harness`](https://github.com/sei-protocol/qa-testing/tree/feat/seictl-harness)) needs a deterministic way to fund a known admin address on each ephemeral chain. The CRD has had `Spec.Genesis.Accounts[]` declared but unwired since inception — see issue body for the full gap analysis. This PR closes the sidecar-side half. The controller PR follows once this lands and a new sidecar image SHA is available.

## Changes

- **New `addExternalGenesisAccounts`** on both `GenesisAssembler` and `GenesisForkAssembler`. Runs between `addMissingGenesisAccounts` and `collectGentxs` so validator-derived state is visible for collision detection.
- **Hard-fails on collision** with any existing `auth.accounts` entry. Last-write-wins and silent-drop both produce unsurprising-looking-but-wrong chains; an operator-pasted address that collides is almost certainly a config error.
- **Fork mirror updates `bankGenState.Supply`** explicitly. Non-fork doesn't because `bank.InitGenesis` recomputes from balances when `Supply` is empty (`sei-cosmos/x/bank/keeper/genesis.go:48`); fork inherits a non-empty `Supply` that must stay in sync.
- **Extracts `writeBackAuthAndBank` helper.** Three call sites of identical `sanitize → pack → marshal → export` boilerplate collapse to one.
- **9 unit tests:** empty-input no-op, append, intra-batch duplicate, collision against pre-seeded entry, bad bech32, bad balance, fork supply update, fork collision.

Diff: +477/-49 across 4 files.

## Coral validation

Two cross-review rounds (platform-engineer):

1. **Pre-implementation** ([issue#160 thread](https://github.com/sei-protocol/sei-k8s-controller/issues/160)): flagged collision-policy ambiguity and fork-supply-update requirement. Both addressed in this PR.
2. **Post-implementation**: largely clean, two should-fixes — added intra-batch duplicate test + pre-seeded collision test (matches the issue acceptance criterion's wording on validator-derived path).

## Test plan

- [x] `go test ./sidecar/tasks/ -run "TestAddExternalGenesisAccounts|TestForkAddExternalGenesisAccounts"` — all 9 pass
- [x] `go test ./sidecar/tasks/ -run "TestAssembler|TestForkAssembler"` — pre-existing tests green (refactor regression check)
- [x] `go vet ./sidecar/...` — clean
- [x] Post-merge: rebuild sidecar image, capture new SHA for the controller PR's `DefaultSidecarImage` bump.

## Backwards compatibility

The new `Accounts` field is `omitempty`. Controllers that don't send it (today's behavior) result in `nil` slice → early no-op return. Wire-format compatible.

## Related

- sei-protocol/sei-k8s-controller#160 (parent issue, controller-side wiring follows)
- sei-protocol/qa-testing `feat/seictl-harness` (consumer)
- sei-protocol/platform#235 (Phase 1 envelope this slots into)

🤖 Generated with [Claude Code](https://claude.com/claude-code)