### PR TITLE
feat(client): typed Task wrappers for assemble-genesis with Accounts field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9
 	github.com/aws/smithy-go v1.25.0
+	github.com/cosmos/btcutil v1.0.5
 	github.com/ethereum/go-ethereum v1.16.8
 	github.com/google/uuid v1.6.0
 	github.com/leanovate/gopter v0.2.11
@@ -94,7 +95,6 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.7.0 // indirect
 	github.com/confio/ics23/go v0.9.0 // indirect
 	github.com/consensys/gnark-crypto v0.18.0 // indirect
-	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v1.0.0 // indirect

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -9,18 +9,13 @@ import (
 	"github.com/sei-protocol/seictl/sidecar/engine"
 )
 
-// seiBech32HRP is the human-readable prefix on the Sei chain. The
-// validate path uses bech32.Decode to also confirm the checksum,
-// catching off-by-one typos that a prefix check alone would miss.
 const seiBech32HRP = "sei"
 
-// validateSeiAccountAddress performs a strict bech32 decode + HRP check.
-// Cheaper than sei-cosmos's sdk.AccAddressFromBech32 (~one tiny dep vs
-// the full cosmos-sdk pull). The sidecar still calls sdk.AccAddressFromBech32
-// server-side for SDK-shape conformance.
+// btcutil's bech32 decode validates checksum + alphabet; cheaper than
+// pulling sei-cosmos's sdk.AccAddressFromBech32 just for client-side
+// validation. Sidecar still does the SDK-shape check server-side.
 func validateSeiAccountAddress(addr string) error {
-	// 1023 is bech32's spec max length; well above any realistic sei addr.
-	hrp, _, err := bech32.Decode(addr, 1023)
+	hrp, _, err := bech32.Decode(addr, 1023) // bech32 spec max length
 	if err != nil {
 		return fmt.Errorf("address %q: %w", addr, err)
 	}
@@ -649,15 +644,14 @@ type GenesisNodeParam struct {
 	Name string `json:"name"`
 }
 
-// GenesisAccountEntry funds a non-validator account at genesis. Mirrors
-// SeiNodeDeployment.spec.genesis.accounts[] on the controller-CRD side.
+// GenesisAccountEntry mirrors SeiNodeDeployment.spec.genesis.accounts[]
+// on the controller-CRD side.
 type GenesisAccountEntry struct {
 	Address string `json:"address"`
 	Balance string `json:"balance"`
 }
 
-// genesisAccountsToWire returns nil (omits the field) when accounts is
-// empty so old sidecars without the Accounts field decode unchanged.
+// nil omits the wire field so old sidecars decode the request unchanged.
 func genesisAccountsToWire(accounts []GenesisAccountEntry) []interface{} {
 	if len(accounts) == 0 {
 		return nil
@@ -669,8 +663,7 @@ func genesisAccountsToWire(accounts []GenesisAccountEntry) []interface{} {
 	return out
 }
 
-// validateGenesisAccounts strict-checks each address; balance shape is
-// validated server-side via sdk.ParseCoinsNormalized.
+// Balance shape is validated server-side via sdk.ParseCoinsNormalized.
 func validateGenesisAccounts(prefix string, accounts []GenesisAccountEntry) error {
 	for i, a := range accounts {
 		if a.Address == "" {
@@ -729,10 +722,9 @@ func (t AssembleAndUploadGenesisTask) ToTaskRequest() TaskRequest {
 	return req
 }
 
-// AssembleGenesisForkTask assembles a fork-mode chain genesis: the
-// sidecar downloads exported state for SourceChainID, strips old
-// validators, rewrites identity to ChainID, and runs collect-gentxs
-// over the new validator set.
+// AssembleGenesisForkTask is the fork-mode counterpart of
+// AssembleAndUploadGenesisTask. The sidecar forks SourceChainID's
+// exported state into ChainID.
 type AssembleGenesisForkTask struct {
 	TaskMeta
 	SourceChainID  string

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -651,7 +651,6 @@ type GenesisAccountEntry struct {
 	Balance string `json:"balance"`
 }
 
-// nil omits the wire field so old sidecars decode the request unchanged.
 func genesisAccountsToWire(accounts []GenesisAccountEntry) []interface{} {
 	if len(accounts) == 0 {
 		return nil

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -3,10 +3,32 @@ package client
 import (
 	"fmt"
 
+	"github.com/cosmos/btcutil/bech32"
 	"github.com/google/uuid"
 	seiconfig "github.com/sei-protocol/sei-config"
 	"github.com/sei-protocol/seictl/sidecar/engine"
 )
+
+// seiBech32HRP is the human-readable prefix on the Sei chain. The
+// validate path uses bech32.Decode to also confirm the checksum,
+// catching off-by-one typos that a prefix check alone would miss.
+const seiBech32HRP = "sei"
+
+// validateSeiAccountAddress performs a strict bech32 decode + HRP check.
+// Cheaper than sei-cosmos's sdk.AccAddressFromBech32 (~one tiny dep vs
+// the full cosmos-sdk pull). The sidecar still calls sdk.AccAddressFromBech32
+// server-side for SDK-shape conformance.
+func validateSeiAccountAddress(addr string) error {
+	// 1023 is bech32's spec max length; well above any realistic sei addr.
+	hrp, _, err := bech32.Decode(addr, 1023)
+	if err != nil {
+		return fmt.Errorf("address %q: %w", addr, err)
+	}
+	if hrp != seiBech32HRP {
+		return fmt.Errorf("address %q: hrp %q, expected %q", addr, hrp, seiBech32HRP)
+	}
+	return nil
+}
 
 // TaskBuilder is implemented by every typed task struct. It converts a
 // strongly-typed task description into the generic TaskRequest wire format
@@ -627,6 +649,43 @@ type GenesisNodeParam struct {
 	Name string `json:"name"`
 }
 
+// GenesisAccountEntry funds a non-validator account at genesis. Mirrors
+// SeiNodeDeployment.spec.genesis.accounts[] on the controller-CRD side.
+type GenesisAccountEntry struct {
+	Address string `json:"address"`
+	Balance string `json:"balance"`
+}
+
+// genesisAccountsToWire returns nil (omits the field) when accounts is
+// empty so old sidecars without the Accounts field decode unchanged.
+func genesisAccountsToWire(accounts []GenesisAccountEntry) []interface{} {
+	if len(accounts) == 0 {
+		return nil
+	}
+	out := make([]interface{}, len(accounts))
+	for i, a := range accounts {
+		out[i] = map[string]interface{}{"address": a.Address, "balance": a.Balance}
+	}
+	return out
+}
+
+// validateGenesisAccounts strict-checks each address; balance shape is
+// validated server-side via sdk.ParseCoinsNormalized.
+func validateGenesisAccounts(prefix string, accounts []GenesisAccountEntry) error {
+	for i, a := range accounts {
+		if a.Address == "" {
+			return fmt.Errorf("%s: accounts[%d] missing required field Address", prefix, i)
+		}
+		if a.Balance == "" {
+			return fmt.Errorf("%s: accounts[%d] missing required field Balance", prefix, i)
+		}
+		if err := validateSeiAccountAddress(a.Address); err != nil {
+			return fmt.Errorf("%s: accounts[%d]: %w", prefix, i, err)
+		}
+	}
+	return nil
+}
+
 // AssembleAndUploadGenesisTask collects per-node artifacts and produces final genesis.json.
 // S3 coordinates are derived by the sidecar from its environment.
 type AssembleAndUploadGenesisTask struct {
@@ -634,6 +693,7 @@ type AssembleAndUploadGenesisTask struct {
 	AccountBalance string
 	Namespace      string
 	Nodes          []GenesisNodeParam
+	Accounts       []GenesisAccountEntry
 }
 
 func (t AssembleAndUploadGenesisTask) TaskType() string { return TaskTypeAssembleGenesis }
@@ -648,7 +708,7 @@ func (t AssembleAndUploadGenesisTask) Validate() error {
 	if len(t.Nodes) == 0 {
 		return fmt.Errorf("assemble-and-upload-genesis: at least one node is required")
 	}
-	return nil
+	return validateGenesisAccounts("assemble-and-upload-genesis", t.Accounts)
 }
 
 func (t AssembleAndUploadGenesisTask) ToTaskRequest() TaskRequest {
@@ -660,6 +720,64 @@ func (t AssembleAndUploadGenesisTask) ToTaskRequest() TaskRequest {
 		"accountBalance": t.AccountBalance,
 		"namespace":      t.Namespace,
 		"nodes":          nodes,
+	}
+	if accounts := genesisAccountsToWire(t.Accounts); accounts != nil {
+		p["accounts"] = accounts
+	}
+	req := TaskRequest{Type: t.TaskType(), Params: &p}
+	t.applyMeta(&req)
+	return req
+}
+
+// AssembleGenesisForkTask assembles a fork-mode chain genesis: the
+// sidecar downloads exported state for SourceChainID, strips old
+// validators, rewrites identity to ChainID, and runs collect-gentxs
+// over the new validator set.
+type AssembleGenesisForkTask struct {
+	TaskMeta
+	SourceChainID  string
+	ChainID        string
+	AccountBalance string
+	Namespace      string
+	Nodes          []GenesisNodeParam
+	Accounts       []GenesisAccountEntry
+}
+
+func (t AssembleGenesisForkTask) TaskType() string { return TaskTypeAssembleGenesisFork }
+
+func (t AssembleGenesisForkTask) Validate() error {
+	if t.SourceChainID == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing required field SourceChainID")
+	}
+	if t.ChainID == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing required field ChainID")
+	}
+	if t.AccountBalance == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing required field AccountBalance")
+	}
+	if t.Namespace == "" {
+		return fmt.Errorf("assemble-genesis-fork: missing required field Namespace")
+	}
+	if len(t.Nodes) == 0 {
+		return fmt.Errorf("assemble-genesis-fork: at least one node is required")
+	}
+	return validateGenesisAccounts("assemble-genesis-fork", t.Accounts)
+}
+
+func (t AssembleGenesisForkTask) ToTaskRequest() TaskRequest {
+	nodes := make([]interface{}, len(t.Nodes))
+	for i, n := range t.Nodes {
+		nodes[i] = map[string]interface{}{"name": n.Name}
+	}
+	p := map[string]interface{}{
+		"sourceChainId":  t.SourceChainID,
+		"chainId":        t.ChainID,
+		"accountBalance": t.AccountBalance,
+		"namespace":      t.Namespace,
+		"nodes":          nodes,
+	}
+	if accounts := genesisAccountsToWire(t.Accounts); accounts != nil {
+		p["accounts"] = accounts
 	}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	t.applyMeta(&req)

--- a/sidecar/client/tasks_genesis_accounts_test.go
+++ b/sidecar/client/tasks_genesis_accounts_test.go
@@ -1,0 +1,144 @@
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	validSeiAddr1 = "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+	validSeiAddr2 = "sei140x77qfrg4ncn27dauqjx3t83x4ummcpmrsjjl"
+)
+
+func validNonForkTask(accounts []GenesisAccountEntry) AssembleAndUploadGenesisTask {
+	return AssembleAndUploadGenesisTask{
+		AccountBalance: "1000usei",
+		Namespace:      "default",
+		Nodes:          []GenesisNodeParam{{Name: "node-0"}},
+		Accounts:       accounts,
+	}
+}
+
+func validForkTask(accounts []GenesisAccountEntry) AssembleGenesisForkTask {
+	return AssembleGenesisForkTask{
+		SourceChainID:  "pacific-1",
+		ChainID:        "fork-1",
+		AccountBalance: "1000usei",
+		Namespace:      "default",
+		Nodes:          []GenesisNodeParam{{Name: "node-0"}},
+		Accounts:       accounts,
+	}
+}
+
+func TestAssembleAndUploadGenesisTask_ValidateAccounts(t *testing.T) {
+	cases := []struct {
+		name     string
+		accounts []GenesisAccountEntry
+		wantErr  string
+	}{
+		{name: "no accounts", accounts: nil},
+		{name: "valid single", accounts: []GenesisAccountEntry{{Address: validSeiAddr1, Balance: "1usei"}}},
+		{name: "valid multiple", accounts: []GenesisAccountEntry{{Address: validSeiAddr1, Balance: "1usei"}, {Address: validSeiAddr2, Balance: "2usei"}}},
+		{name: "missing address", accounts: []GenesisAccountEntry{{Balance: "1usei"}}, wantErr: "missing required field Address"},
+		{name: "missing balance", accounts: []GenesisAccountEntry{{Address: validSeiAddr1}}, wantErr: "missing required field Balance"},
+		{name: "wrong hrp", accounts: []GenesisAccountEntry{{Address: "cosmos1zg69v7y6hn00qy352euf40x77qfrg4ncjur58y", Balance: "1usei"}}, wantErr: `hrp "cosmos"`},
+		{name: "bad checksum", accounts: []GenesisAccountEntry{{Address: "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzpz", Balance: "1usei"}}, wantErr: "address"},
+		{name: "not bech32", accounts: []GenesisAccountEntry{{Address: "junk", Balance: "1usei"}}, wantErr: "address"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validNonForkTask(tc.accounts).Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error: got %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAssembleAndUploadGenesisTask_ToTaskRequest_OmitsEmpty(t *testing.T) {
+	req := validNonForkTask(nil).ToTaskRequest()
+	if req.Params == nil {
+		t.Fatal("Params nil")
+	}
+	if _, present := (*req.Params)["accounts"]; present {
+		t.Errorf("nil accounts should omit field; got: %+v", *req.Params)
+	}
+}
+
+func TestAssembleAndUploadGenesisTask_ToTaskRequest_SerializesAccounts(t *testing.T) {
+	accs := []GenesisAccountEntry{{Address: validSeiAddr1, Balance: "1000usei"}}
+	req := validNonForkTask(accs).ToTaskRequest()
+	if req.Type != TaskTypeAssembleGenesis {
+		t.Errorf("Type: got %q, want %q", req.Type, TaskTypeAssembleGenesis)
+	}
+	got, ok := (*req.Params)["accounts"].([]interface{})
+	if !ok || len(got) != 1 {
+		t.Fatalf("accounts: %+v", (*req.Params)["accounts"])
+	}
+	entry := got[0].(map[string]interface{})
+	if entry["address"] != validSeiAddr1 || entry["balance"] != "1000usei" {
+		t.Errorf("entry: got %+v", entry)
+	}
+}
+
+func TestAssembleGenesisForkTask_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*AssembleGenesisForkTask)
+		wantErr string
+	}{
+		{name: "valid", mutate: func(*AssembleGenesisForkTask) {}},
+		{name: "missing SourceChainID", mutate: func(t *AssembleGenesisForkTask) { t.SourceChainID = "" }, wantErr: "SourceChainID"},
+		{name: "missing ChainID", mutate: func(t *AssembleGenesisForkTask) { t.ChainID = "" }, wantErr: "ChainID"},
+		{name: "missing AccountBalance", mutate: func(t *AssembleGenesisForkTask) { t.AccountBalance = "" }, wantErr: "AccountBalance"},
+		{name: "missing Namespace", mutate: func(t *AssembleGenesisForkTask) { t.Namespace = "" }, wantErr: "Namespace"},
+		{name: "no nodes", mutate: func(t *AssembleGenesisForkTask) { t.Nodes = nil }, wantErr: "node"},
+		{name: "bad account", mutate: func(t *AssembleGenesisForkTask) {
+			t.Accounts = []GenesisAccountEntry{{Address: "junk", Balance: "1usei"}}
+		}, wantErr: "address"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := validForkTask(nil)
+			tc.mutate(&task)
+			err := task.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error: got %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAssembleGenesisForkTask_ToTaskRequest(t *testing.T) {
+	accs := []GenesisAccountEntry{{Address: validSeiAddr1, Balance: "5usei"}}
+	req := validForkTask(accs).ToTaskRequest()
+	if req.Type != TaskTypeAssembleGenesisFork {
+		t.Errorf("Type: got %q", req.Type)
+	}
+	p := *req.Params
+	if p["sourceChainId"] != "pacific-1" || p["chainId"] != "fork-1" {
+		t.Errorf("fork-specific fields: %+v", p)
+	}
+	got := p["accounts"].([]interface{})
+	if len(got) != 1 {
+		t.Fatalf("accounts: %+v", got)
+	}
+}

--- a/sidecar/client/tasks_genesis_accounts_test.go
+++ b/sidecar/client/tasks_genesis_accounts_test.go
@@ -127,6 +127,16 @@ func TestAssembleGenesisForkTask_Validate(t *testing.T) {
 	}
 }
 
+func TestAssembleGenesisForkTask_ToTaskRequest_OmitsEmpty(t *testing.T) {
+	req := validForkTask(nil).ToTaskRequest()
+	if req.Params == nil {
+		t.Fatal("Params nil")
+	}
+	if _, present := (*req.Params)["accounts"]; present {
+		t.Errorf("nil accounts should omit field; got: %+v", *req.Params)
+	}
+}
+
 func TestAssembleGenesisForkTask_ToTaskRequest(t *testing.T) {
 	accs := []GenesisAccountEntry{{Address: validSeiAddr1, Balance: "5usei"}}
 	req := validForkTask(accs).ToTaskRequest()


### PR DESCRIPTION
## Summary

Closes the **client-side** wire surface for [sei-protocol/sei-k8s-controller#160](https://github.com/sei-protocol/sei-k8s-controller/issues/160). My prior PR #120 added `Accounts` to the **server-side** request types (`sidecar/tasks/`); this completes the symmetry by adding the field to the **client-side** typed wrappers (`sidecar/client/tasks.go`), which is what the controller imports.

## Changes

- **`AssembleAndUploadGenesisTask`** — new `Accounts []GenesisAccountEntry` field; `Validate()` strict-checks addresses; `ToTaskRequest()` serializes `accounts` when non-empty.
- **`AssembleGenesisForkTask`** — new typed wrapper. The fork task previously had only a type-string constant (`TaskTypeAssembleGenesisFork`), no typed wrapper. Mirrors `AssembleAndUploadGenesisTask` plus fork-specific `SourceChainID` + `ChainID`. Same Accounts + Validate + ToTaskRequest surface.
- **Strict address validation** via `github.com/cosmos/btcutil/bech32` (already in seictl's transitive deps; promoted to direct). Decode + checksum + `hrp == "sei"` check. Cheaper than pulling sei-cosmos's `sdk.AccAddressFromBech32` (full cosmos-sdk transitive). The sidecar still calls `sdk.AccAddressFromBech32` server-side for SDK-shape conformance.

## Test coverage

11 new test cases:
- `AssembleAndUploadGenesisTask.Validate`: 8 cases (no accounts, valid single, valid multiple, missing address, missing balance, wrong hrp, bad checksum, not bech32)
- `AssembleAndUploadGenesisTask.ToTaskRequest`: omits empty accounts; serializes populated accounts
- `AssembleGenesisForkTask.Validate`: 7 cases (valid, missing each required field, bad account)
- `AssembleGenesisForkTask.ToTaskRequest`: includes fork-specific fields + accounts

## Backwards compatibility

The new `Accounts` field is `omitempty` on the wire. Old controllers that don't set it produce the existing JSON shape; new sidecars receiving the existing shape see `nil` and early-return. Same wire-format compatibility story as #120.

## Why this PR exists

Reviewing #120 surfaced that I missed the client-side typed wrapper pattern. The controller currently maintains its own duplicate `AssembleAndUploadGenesisParams` + `toRequestParams() *map[string]any` for these tasks instead of using `client.AssembleAndUploadGenesisTask{...}.ToTaskRequest()`. With this PR landed, the controller PR (#160 follow-up) can use the typed wrappers directly and drop both the duplicate struct and a hand-rolled bech32 prefix check.

## Sequencing

1. This PR merges
2. Bump seictl to v0.0.37 (next release captures both the server-side from #120 and the client-side from this PR)
3. Controller PR for sei-k8s-controller#160 uses these typed wrappers + bumps `DefaultSidecarImage` to the v0.0.37 SHA

## Related

- sei-protocol/seictl#120 (server-side, merged)
- sei-protocol/sei-k8s-controller#160 (parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)