### PR TITLE
feat(chain): add --prefund flag to chain up

### DIFF
--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -287,7 +287,7 @@ func renderManifests(alias, name, namespace, chainID, seidImage, digestShort str
 		"RPC_COUNT":              strconv.Itoa(rpcCount),
 		"JOB_DEADLINE_SECONDS":   strconv.Itoa(durationMin * 60),
 		"PART_OF":                benchPartOf,
-		"GENESIS_ACCOUNTS_BLOCK": "", // bench doesn't expose --prefund yet
+		"GENESIS_ACCOUNTS_BLOCK": "",
 	}
 
 	chainYAML, e := renderEmbedded("chain.yaml", vars)

--- a/cluster/bench.go
+++ b/cluster/bench.go
@@ -276,17 +276,18 @@ func loadConfig(pathFn func() (string, error)) (*config.Config, *clioutput.Error
 func renderManifests(alias, name, namespace, chainID, seidImage, digestShort string,
 	validators, rpcCount, durationMin int) ([][]byte, []render.ManifestRef, *clioutput.Error) {
 	vars := map[string]string{
-		"CHAIN_ID":             chainID,
-		"NAMESPACE":            namespace,
-		"ENGINEER_ALIAS":       alias,
-		"NAME":                 name,
-		"SEID_IMAGE":           seidImage,
-		"SEILOAD_IMAGE":        defaultSeiloadImage,
-		"IMAGE_DIGEST_SHORT":   digestShort,
-		"VALIDATOR_COUNT":      strconv.Itoa(validators),
-		"RPC_COUNT":            strconv.Itoa(rpcCount),
-		"JOB_DEADLINE_SECONDS": strconv.Itoa(durationMin * 60),
-		"PART_OF":              benchPartOf,
+		"CHAIN_ID":               chainID,
+		"NAMESPACE":              namespace,
+		"ENGINEER_ALIAS":         alias,
+		"NAME":                   name,
+		"SEID_IMAGE":             seidImage,
+		"SEILOAD_IMAGE":          defaultSeiloadImage,
+		"IMAGE_DIGEST_SHORT":     digestShort,
+		"VALIDATOR_COUNT":        strconv.Itoa(validators),
+		"RPC_COUNT":              strconv.Itoa(rpcCount),
+		"JOB_DEADLINE_SECONDS":   strconv.Itoa(durationMin * 60),
+		"PART_OF":                benchPartOf,
+		"GENESIS_ACCOUNTS_BLOCK": "", // bench doesn't expose --prefund yet
 	}
 
 	chainYAML, e := renderEmbedded("chain.yaml", vars)

--- a/cluster/chain.go
+++ b/cluster/chain.go
@@ -45,9 +45,8 @@ type chainUpResult struct {
 	AppliedAt         *time.Time           `json:"appliedAt,omitempty"`
 }
 
-// PrefundedAccount echoes a --prefund entry back in the envelope so
-// downstream consumers (release-test, fuzzers, etc.) can read funded
-// addresses from the same source of truth that rendered the manifest.
+// Echoed in the chain up envelope so consumers don't track funded
+// addresses out-of-band from the rendered manifest.
 type PrefundedAccount struct {
 	Address string `json:"address"`
 	Balance string `json:"balance"`
@@ -226,9 +225,8 @@ func deriveChainEndpoints(chainID, namespace string) Endpoints {
 	}
 }
 
-// parsePrefundFlags parses repeated --prefund addr=balance entries.
-// Strict bech32 validation is deferred to the controller's planner;
-// here we just enforce the addr=balance shape and non-empty values.
+// Strict bech32 validation lives in the controller's planner — this
+// only enforces the addr=balance shape.
 func parsePrefundFlags(raw []string) ([]PrefundedAccount, *clioutput.Error) {
 	if len(raw) == 0 {
 		return nil, nil
@@ -248,9 +246,7 @@ func parsePrefundFlags(raw []string) ([]PrefundedAccount, *clioutput.Error) {
 	return out, nil
 }
 
-// renderGenesisAccountsBlock returns either an empty string (no
-// prefund) or a YAML `accounts:` list ready to substitute into
-// chain.yaml under `genesis:` (4-space outer indent).
+// Indentation is hand-tuned to chain.yaml's `genesis:` 4-space context.
 func renderGenesisAccountsBlock(accounts []PrefundedAccount) string {
 	if len(accounts) == 0 {
 		return ""

--- a/cluster/chain.go
+++ b/cluster/chain.go
@@ -192,7 +192,7 @@ func runChainUp(ctx context.Context, in chainUpInput, deps chainDeps) (chainUpRe
 
 func renderChainManifests(alias, name, namespace, chainID, seidImage, digestShort string, validators int, prefunded []PrefundedAccount) ([][]byte, []render.ManifestRef, *clioutput.Error) {
 	vars := map[string]string{
-		"CHAIN_ID":              chainID,
+		"CHAIN_ID":               chainID,
 		"NAMESPACE":              namespace,
 		"ENGINEER_ALIAS":         alias,
 		"NAME":                   name,

--- a/cluster/chain.go
+++ b/cluster/chain.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v3"
@@ -31,22 +32,32 @@ type Endpoints struct {
 }
 
 type chainUpResult struct {
-	ChainID     string               `json:"chainId"`
-	Name        string               `json:"name"`
-	Namespace   string               `json:"namespace"`
-	ImageRef    string               `json:"imageRef"`
-	ImageDigest string               `json:"imageDigest"`
-	Validators  int                  `json:"validators"`
-	Endpoints   Endpoints            `json:"endpoints"`
-	DryRun      bool                 `json:"dryRun"`
-	Manifests   []render.ManifestRef `json:"manifests"`
-	AppliedAt   *time.Time           `json:"appliedAt,omitempty"`
+	ChainID           string               `json:"chainId"`
+	Name              string               `json:"name"`
+	Namespace         string               `json:"namespace"`
+	ImageRef          string               `json:"imageRef"`
+	ImageDigest       string               `json:"imageDigest"`
+	Validators        int                  `json:"validators"`
+	Endpoints         Endpoints            `json:"endpoints"`
+	PrefundedAccounts []PrefundedAccount   `json:"prefundedAccounts,omitempty"`
+	DryRun            bool                 `json:"dryRun"`
+	Manifests         []render.ManifestRef `json:"manifests"`
+	AppliedAt         *time.Time           `json:"appliedAt,omitempty"`
+}
+
+// PrefundedAccount echoes a --prefund entry back in the envelope so
+// downstream consumers (release-test, fuzzers, etc.) can read funded
+// addresses from the same source of truth that rendered the manifest.
+type PrefundedAccount struct {
+	Address string `json:"address"`
+	Balance string `json:"balance"`
 }
 
 type chainUpInput struct {
 	Image      string
 	Name       string
 	Validators int
+	Prefund    []string
 	Apply      bool
 	Kubeconfig string
 	Context    string
@@ -80,6 +91,7 @@ var ChainCmd = cli.Command{
 				&cli.StringFlag{Name: "image", Required: true, Usage: "ECR image ref"},
 				&cli.StringFlag{Name: "name", Required: true, Usage: "Chain name"},
 				&cli.IntFlag{Name: "validators", Required: true, Usage: "Validator count (1-21)"},
+				&cli.StringSliceFlag{Name: "prefund", Usage: "Fund a non-validator account at genesis (repeat for multiple): --prefund sei1...=1000000000usei"},
 				&cli.BoolFlag{Name: "apply", Usage: "Server-side apply the rendered manifest"},
 			),
 			Action: func(ctx context.Context, command *cli.Command) error {
@@ -87,6 +99,7 @@ var ChainCmd = cli.Command{
 					Image:      command.String("image"),
 					Name:       command.String("name"),
 					Validators: int(command.Int("validators")),
+					Prefund:    command.StringSlice("prefund"),
 					Apply:      command.Bool("apply"),
 					Kubeconfig: command.String("kubeconfig"),
 					Context:    command.String("context"),
@@ -122,6 +135,10 @@ func runChainUp(ctx context.Context, in chainUpInput, deps chainDeps) (chainUpRe
 	if e := validate.Validators(in.Validators); e != nil {
 		return chainUpResult{}, e.ExitWith(clioutput.ExitBench)
 	}
+	prefunded, perr := parsePrefundFlags(in.Prefund)
+	if perr != nil {
+		return chainUpResult{}, perr
+	}
 	namespace := cfg.Namespace
 	if _, callerErr := deps.getCaller(ctx); callerErr != nil {
 		return chainUpResult{}, callerErr
@@ -139,21 +156,22 @@ func runChainUp(ctx context.Context, in chainUpInput, deps chainDeps) (chainUpRe
 	chainID := fmt.Sprintf("bench-%s-%s", cfg.Alias, in.Name)
 	digestShort := shortDigest(digest)
 
-	docs, manifests, rerr := renderChainManifests(cfg.Alias, in.Name, namespace, chainID, seidImage, digestShort, in.Validators)
+	docs, manifests, rerr := renderChainManifests(cfg.Alias, in.Name, namespace, chainID, seidImage, digestShort, in.Validators, prefunded)
 	if rerr != nil {
 		return chainUpResult{}, rerr
 	}
 
 	res := chainUpResult{
-		ChainID:     chainID,
-		Name:        in.Name,
-		Namespace:   namespace,
-		ImageRef:    in.Image,
-		ImageDigest: digest,
-		Validators:  in.Validators,
-		Endpoints:   deriveChainEndpoints(chainID, namespace),
-		DryRun:      !in.Apply,
-		Manifests:   manifests,
+		ChainID:           chainID,
+		Name:              in.Name,
+		Namespace:         namespace,
+		ImageRef:          in.Image,
+		ImageDigest:       digest,
+		Validators:        in.Validators,
+		Endpoints:         deriveChainEndpoints(chainID, namespace),
+		PrefundedAccounts: prefunded,
+		DryRun:            !in.Apply,
+		Manifests:         manifests,
 	}
 
 	if in.Apply {
@@ -172,16 +190,17 @@ func runChainUp(ctx context.Context, in chainUpInput, deps chainDeps) (chainUpRe
 	return res, nil
 }
 
-func renderChainManifests(alias, name, namespace, chainID, seidImage, digestShort string, validators int) ([][]byte, []render.ManifestRef, *clioutput.Error) {
+func renderChainManifests(alias, name, namespace, chainID, seidImage, digestShort string, validators int, prefunded []PrefundedAccount) ([][]byte, []render.ManifestRef, *clioutput.Error) {
 	vars := map[string]string{
-		"CHAIN_ID":           chainID,
-		"NAMESPACE":          namespace,
-		"ENGINEER_ALIAS":     alias,
-		"NAME":               name,
-		"SEID_IMAGE":         seidImage,
-		"IMAGE_DIGEST_SHORT": digestShort,
-		"VALIDATOR_COUNT":    strconv.Itoa(validators),
-		"PART_OF":            "seictl",
+		"CHAIN_ID":              chainID,
+		"NAMESPACE":              namespace,
+		"ENGINEER_ALIAS":         alias,
+		"NAME":                   name,
+		"SEID_IMAGE":             seidImage,
+		"IMAGE_DIGEST_SHORT":     digestShort,
+		"VALIDATOR_COUNT":        strconv.Itoa(validators),
+		"PART_OF":                "seictl",
+		"GENESIS_ACCOUNTS_BLOCK": renderGenesisAccountsBlock(prefunded),
 	}
 	chainYAML, e := renderEmbedded("chain.yaml", vars)
 	if e != nil {
@@ -205,6 +224,46 @@ func deriveChainEndpoints(chainID, namespace string) Endpoints {
 	return Endpoints{
 		TendermintRpc: []string{fmt.Sprintf("http://%s:%d", host, seiconfig.PortRPC)},
 	}
+}
+
+// parsePrefundFlags parses repeated --prefund addr=balance entries.
+// Strict bech32 validation is deferred to the controller's planner;
+// here we just enforce the addr=balance shape and non-empty values.
+func parsePrefundFlags(raw []string) ([]PrefundedAccount, *clioutput.Error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]PrefundedAccount, 0, len(raw))
+	for _, entry := range raw {
+		eq := strings.IndexByte(entry, '=')
+		if eq <= 0 || eq == len(entry)-1 {
+			return nil, clioutput.Newf(clioutput.ExitBench, clioutput.CatValidation,
+				"--prefund %q: expected addr=balance", entry)
+		}
+		out = append(out, PrefundedAccount{
+			Address: entry[:eq],
+			Balance: entry[eq+1:],
+		})
+	}
+	return out, nil
+}
+
+// renderGenesisAccountsBlock returns either an empty string (no
+// prefund) or a YAML `accounts:` list ready to substitute into
+// chain.yaml under `genesis:` (4-space outer indent).
+func renderGenesisAccountsBlock(accounts []PrefundedAccount) string {
+	if len(accounts) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("\n    accounts:")
+	for _, a := range accounts {
+		sb.WriteString("\n      - address: ")
+		sb.WriteString(a.Address)
+		sb.WriteString("\n        balance: ")
+		sb.WriteString(a.Balance)
+	}
+	return sb.String()
 }
 
 func failChainUp(out io.Writer, e *clioutput.Error) error {

--- a/cluster/chain_prefund_test.go
+++ b/cluster/chain_prefund_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
 )
 
@@ -130,6 +132,11 @@ func TestRunChainUp_PrefundFlow(t *testing.T) {
 			if !strings.Contains(body, want) {
 				t.Errorf("rendered body missing %q\n%s", want, body)
 			}
+		}
+		// Catch indent drift if chain.yaml's `genesis:` is ever re-nested.
+		var parsed any
+		if err := yaml.Unmarshal(docs[0], &parsed); err != nil {
+			t.Errorf("rendered manifest is not valid YAML: %v", err)
 		}
 	})
 

--- a/cluster/chain_prefund_test.go
+++ b/cluster/chain_prefund_test.go
@@ -1,0 +1,164 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
+)
+
+const validSeiPrefund = "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9"
+
+func TestParsePrefundFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   []string
+		want    []PrefundedAccount
+		wantErr string
+	}{
+		{name: "nil", input: nil},
+		{name: "empty", input: []string{}},
+		{name: "single", input: []string{"sei1abc=1000usei"}, want: []PrefundedAccount{{Address: "sei1abc", Balance: "1000usei"}}},
+		{name: "multiple", input: []string{"sei1abc=1usei", "sei1def=2usei,3uatom"}, want: []PrefundedAccount{
+			{Address: "sei1abc", Balance: "1usei"},
+			{Address: "sei1def", Balance: "2usei,3uatom"},
+		}},
+		{name: "missing equals", input: []string{"sei1abc"}, wantErr: "expected addr=balance"},
+		{name: "empty addr", input: []string{"=1usei"}, wantErr: "expected addr=balance"},
+		{name: "empty balance", input: []string{"sei1abc="}, wantErr: "expected addr=balance"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePrefundFlags(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error: got %q, want substring %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len: got %d, want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d]: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRenderGenesisAccountsBlock(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if got := renderGenesisAccountsBlock(nil); got != "" {
+			t.Errorf("nil → got %q, want empty", got)
+		}
+	})
+
+	t.Run("single", func(t *testing.T) {
+		got := renderGenesisAccountsBlock([]PrefundedAccount{{Address: "sei1abc", Balance: "1000usei"}})
+		want := "\n    accounts:\n      - address: sei1abc\n        balance: 1000usei"
+		if got != want {
+			t.Errorf("single:\ngot  %q\nwant %q", got, want)
+		}
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		got := renderGenesisAccountsBlock([]PrefundedAccount{
+			{Address: "sei1abc", Balance: "1usei"},
+			{Address: "sei1def", Balance: "2usei"},
+		})
+		// Two entries should produce two indented list items.
+		if !strings.Contains(got, "      - address: sei1abc") || !strings.Contains(got, "      - address: sei1def") {
+			t.Errorf("multiple: got %q", got)
+		}
+	})
+}
+
+func TestRunChainUp_PrefundFlow(t *testing.T) {
+	t.Run("envelope echoes prefunded accounts", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runChainUpCmd(context.Background(), chainUpInput{
+			Image:      "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Name:       "qa",
+			Validators: 4,
+			Prefund:    []string{validSeiPrefund + "=1000000000usei"},
+		}, &buf, stubChainDeps(t, "bdc"))
+		if err != nil {
+			t.Fatalf("runChainUpCmd: %v\n%s", err, buf.String())
+		}
+
+		var env clioutput.Envelope
+		if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+			t.Fatalf("envelope: %v", err)
+		}
+		var data chainUpResult
+		_ = json.Unmarshal(env.Data, &data)
+
+		if len(data.PrefundedAccounts) != 1 {
+			t.Fatalf("PrefundedAccounts: got %d, want 1", len(data.PrefundedAccounts))
+		}
+		if data.PrefundedAccounts[0].Address != validSeiPrefund {
+			t.Errorf("address: got %q", data.PrefundedAccounts[0].Address)
+		}
+	})
+
+	t.Run("rendered manifest contains genesis.accounts list", func(t *testing.T) {
+		docs, _, err := renderChainManifests("bdc", "qa", "eng-bdc", "bench-bdc-qa",
+			"img@sha256:0", "0123456789ab", 4,
+			[]PrefundedAccount{{Address: validSeiPrefund, Balance: "1000usei"}})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if len(docs) != 1 {
+			t.Fatalf("expected 1 doc, got %d", len(docs))
+		}
+		body := string(docs[0])
+		for _, want := range []string{
+			"accounts:",
+			"- address: " + validSeiPrefund,
+			"balance: 1000usei",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("rendered body missing %q\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("rendered manifest omits accounts when no prefund", func(t *testing.T) {
+		docs, _, err := renderChainManifests("bdc", "qa", "eng-bdc", "bench-bdc-qa",
+			"img@sha256:0", "0123456789ab", 4, nil)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		// Match the rendered spec field, not the template's leading comment.
+		if strings.Contains(string(docs[0]), "    accounts:") {
+			t.Errorf("nil prefund should omit accounts; got:\n%s", string(docs[0]))
+		}
+	})
+
+	t.Run("rejects malformed prefund", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runChainUpCmd(context.Background(), chainUpInput{
+			Image:      "189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:v1",
+			Name:       "qa",
+			Validators: 4,
+			Prefund:    []string{"no-equals-sign"},
+		}, &buf, stubChainDeps(t, "bdc"))
+		if err == nil {
+			t.Fatalf("expected error, got %s", buf.String())
+		}
+		if !strings.Contains(buf.String(), "addr=balance") {
+			t.Errorf("error body: got %s", buf.String())
+		}
+	})
+}

--- a/cluster/chain_prefund_test.go
+++ b/cluster/chain_prefund_test.go
@@ -77,7 +77,6 @@ func TestRenderGenesisAccountsBlock(t *testing.T) {
 			{Address: "sei1abc", Balance: "1usei"},
 			{Address: "sei1def", Balance: "2usei"},
 		})
-		// Two entries should produce two indented list items.
 		if !strings.Contains(got, "      - address: sei1abc") || !strings.Contains(got, "      - address: sei1def") {
 			t.Errorf("multiple: got %q", got)
 		}

--- a/cluster/chain_test.go
+++ b/cluster/chain_test.go
@@ -79,6 +79,9 @@ func TestRunChainUp(t *testing.T) {
 		if len(data.Endpoints.EvmJsonRpc) != 0 {
 			t.Errorf("evmJsonRpc should be empty for chain up (validators don't serve EVM RPC); got %v", data.Endpoints.EvmJsonRpc)
 		}
+		if bytes.Contains(buf.Bytes(), []byte("prefundedAccounts")) {
+			t.Errorf("envelope should omit prefundedAccounts when no --prefund passed: %s", buf.String())
+		}
 
 		if len(data.Manifests) != 1 {
 			t.Fatalf("expected 1 manifest (validator SND only); got %d", len(data.Manifests))

--- a/cluster/chain_test.go
+++ b/cluster/chain_test.go
@@ -213,7 +213,7 @@ func TestRunChainUp(t *testing.T) {
 			Validators: 4,
 		}, &buf, stubChainDeps(t, "bdc"))
 
-		docs, _, err := renderChainManifests("bdc", "qa", "eng-bdc", "bench-bdc-qa", "img@sha256:0", "0123456789ab", 4)
+		docs, _, err := renderChainManifests("bdc", "qa", "eng-bdc", "bench-bdc-qa", "img@sha256:0", "0123456789ab", 4, nil)
 		if err != nil {
 			t.Fatalf("render: %v", err)
 		}

--- a/cluster/templates/chain.yaml
+++ b/cluster/templates/chain.yaml
@@ -1,6 +1,7 @@
 # Source: sei-protocol/platform autobake/templates/seinodedeployment.yaml
 # Vars: CHAIN_ID, NAMESPACE, ENGINEER_ALIAS, NAME, SEID_IMAGE,
-#       IMAGE_DIGEST_SHORT, VALIDATOR_COUNT, PART_OF
+#       IMAGE_DIGEST_SHORT, VALIDATOR_COUNT, PART_OF,
+#       GENESIS_ACCOUNTS_BLOCK (empty or pre-indented `accounts:` block)
 apiVersion: sei.io/v1alpha1
 kind: SeiNodeDeployment
 metadata:
@@ -23,7 +24,7 @@ spec:
     type: InPlace
   genesis:
     chainId: ${CHAIN_ID}
-    stakingAmount: "10000000usei"
+    stakingAmount: "10000000usei"${GENESIS_ACCOUNTS_BLOCK}
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary

Closes the seictl-side bottleneck for the release-test workstream (qa-testing harness running on harbor against ephemeral chains). Adds a repeatable `--prefund <addr>=<balance>` flag to `seictl chain up`:

```
seictl chain up --image $IMG --name qa --validators 4 \
                --prefund sei1...=1000000000usei
```

The flag's entries flow into the rendered `SeiNodeDeployment`'s `spec.genesis.accounts[]`, which the controller's planner now honors end-to-end (post [sei-k8s-controller#160](https://github.com/sei-protocol/sei-k8s-controller/issues/160) / [#162](https://github.com/sei-protocol/sei-k8s-controller/pull/162)). Future consumers ([platform#235](https://github.com/sei-protocol/platform/issues/235)'s fuzzers, soak, chaos) get this for free; release-test is the first.

## Envelope echo

`chainUpResult` gains a `prefundedAccounts` field, `omitempty`, populated only when `--prefund` was passed:

```json
{
  "data": {
    "chainId": "bench-bdc-qa",
    "prefundedAccounts": [
      {"address": "sei1zg69v7y6hn00qy352euf40x77qfrg4nclsjzp9", "balance": "1000000000usei"}
    ]
  }
}
```

Lets the workflow read the funded address from the same source of truth that rendered the manifest, no second source-of-truth tracking required.

## Validation strategy

Per the LLD coral round: CLI enforces only the `addr=balance` shape; strict bech32 validation stays in the controller's planner (single source of truth, post-#160). The sidecar's `sdk.AccAddressFromBech32` is the final strict check at apply time.

## Implementation

- `PrefundedAccount{Address, Balance}` defined at the package level (room for bench/rpc to adopt later without redeclaring).
- `cli.StringSliceFlag`, repeatable. Parser splits at first `=`; rejects empty addr or balance.
- `chain.yaml` template grows a `${GENESIS_ACCOUNTS_BLOCK}` placeholder, empty when no `--prefund`.
- `bench.go`'s `renderManifests` passes an empty `GENESIS_ACCOUNTS_BLOCK` to satisfy the new template var (bench doesn't expose `--prefund` yet — separate workstream when a consumer asks).

## Test coverage

- Parser: nil, single, multi-denom balance (`2usei,3uatom`), malformed (missing equals, empty addr, empty balance).
- Template render: empty input → no `accounts:` block, single entry → correct YAML shape (also `yaml.Unmarshal`-asserted to catch indent drift), multiple entries.
- End-to-end via `runChainUpCmd`: envelope echo populated correctly when `--prefund` passed; envelope omits `prefundedAccounts` when not; malformed flag surfaces typed validation error.

## Backwards compatibility

The new `accounts` key on chain.yaml's `genesis:` field is optional in the CRD (`+optional`). Empty value renders no `accounts:` block at all (preserving today's wire shape). Old workflows that don't pass `--prefund` produce identical output to before.

## Related

- sei-protocol/sei-k8s-controller#160 (controller-side wiring of `Spec.Genesis.Accounts[]`)
- sei-protocol/sei-k8s-controller#162 (planner + sidecar plumbing that consumes this)
- sei-protocol/platform#235 (Phase 1 envelope this slots into)

🤖 Generated with [Claude Code](https://claude.com/claude-code)