### PR TITLE
fix(sidecar): correct snapshot key parsing and S3 path layout

### DIFF
--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -28,8 +28,12 @@ const restoreMarkerFile = ".sei-sidecar-snapshot-done"
 // The result-export task uses this to know where to start exporting.
 const SnapshotHeightFile = ".sei-sidecar-snapshot-height"
 
-// snapshotHeightRe extracts heights from S3 keys like pacific-1/200440000.tar.gz.
-var snapshotHeightRe = regexp.MustCompile(`(\d+)\.tar\.gz$`)
+// snapshotHeightRe extracts the block height from S3 snapshot keys of the form
+// <prefix>/snapshot_<height>_<chain>_<region>.tar.gz. The capture is anchored
+// between the "snapshot_" marker and the trailing "_<chain>_<region>", so
+// trailing digits in the suffix (the "1" in "eu-central-1.tar.gz") cannot be
+// misread as the height.
+var snapshotHeightRe = regexp.MustCompile(`/snapshot_(\d+)_[^/]+\.tar\.gz$`)
 
 // SnapshotRestoreRequest holds the typed parameters for the snapshot-restore task.
 // S3 bucket, region, and chain prefix are derived from the sidecar's environment.
@@ -91,7 +95,7 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 		return fmt.Errorf("snapshot-restore: targetHeight must be >= 0, got %d", targetHeight)
 	}
 
-	prefix := r.chainID + "/"
+	prefix := r.chainID + "/state-sync/"
 
 	client, err := r.clientFactory(ctx, r.region)
 	if err != nil {
@@ -111,7 +115,7 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 		}
 	} else {
 		var resolveErr error
-		snapshotKey, resolveErr = resolveLatestKey(ctx, client, r.bucket, prefix, r.region)
+		snapshotKey, resolveErr = resolveLatestKey(ctx, client, r.bucket, prefix, r.chainID, r.region)
 		if resolveErr != nil {
 			return resolveErr
 		}
@@ -164,8 +168,10 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 	return writeMarker(r.homeDir, restoreMarkerFile)
 }
 
-// resolveLatestKey reads <prefix>latest.txt and constructs the snapshot key.
-func resolveLatestKey(ctx context.Context, client seis3.TransferClient, bucket, prefix, region string) (string, error) {
+// resolveLatestKey reads <prefix>latest.txt (which contains a block height)
+// and constructs the matching snapshot key in the form
+// <prefix>snapshot_<height>_<chain>_<region>.tar.gz.
+func resolveLatestKey(ctx context.Context, client seis3.TransferClient, bucket, prefix, chainID, region string) (string, error) {
 	latestKey := prefix + "latest.txt"
 	var buf seis3.WriteAtBuffer
 	_, err := client.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
@@ -182,7 +188,7 @@ func resolveLatestKey(ctx context.Context, client seis3.TransferClient, bucket, 
 		return "", fmt.Errorf("latest.txt is empty")
 	}
 
-	return prefix + height + ".tar.gz", nil
+	return prefix + fmt.Sprintf("snapshot_%s_%s_%s.tar.gz", height, chainID, region), nil
 }
 
 // resolveKeyForHeight lists snapshot objects and returns the key with the

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
@@ -102,23 +101,14 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 		return fmt.Errorf("building S3 transfer client: %w", err)
 	}
 
-	var snapshotKey string
-	if targetHeight > 0 {
-		lister, listerErr := r.listerFactory(ctx, r.region)
-		if listerErr != nil {
-			return fmt.Errorf("building S3 lister: %w", listerErr)
-		}
-		var resolveErr error
-		snapshotKey, resolveErr = resolveKeyForHeight(ctx, lister, r.bucket, prefix, r.region, targetHeight)
-		if resolveErr != nil {
-			return resolveErr
-		}
-	} else {
-		var resolveErr error
-		snapshotKey, resolveErr = resolveLatestKey(ctx, client, r.bucket, prefix, r.chainID, r.region)
-		if resolveErr != nil {
-			return resolveErr
-		}
+	lister, err := r.listerFactory(ctx, r.region)
+	if err != nil {
+		return fmt.Errorf("building S3 lister: %w", err)
+	}
+
+	snapshotKey, err := resolveKeyForHeight(ctx, lister, r.bucket, prefix, r.region, targetHeight)
+	if err != nil {
+		return err
 	}
 
 	if snapshotKey == "" {
@@ -168,31 +158,9 @@ func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) erro
 	return writeMarker(r.homeDir, restoreMarkerFile)
 }
 
-// resolveLatestKey reads <prefix>latest.txt (which contains a block height)
-// and constructs the matching snapshot key in the form
-// <prefix>snapshot_<height>_<chain>_<region>.tar.gz.
-func resolveLatestKey(ctx context.Context, client seis3.TransferClient, bucket, prefix, chainID, region string) (string, error) {
-	latestKey := prefix + "latest.txt"
-	var buf seis3.WriteAtBuffer
-	_, err := client.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
-		Bucket:   aws.String(bucket),
-		Key:      aws.String(latestKey),
-		WriterAt: &buf,
-	})
-	if err != nil {
-		return "", seis3.ClassifyS3Error("snapshot-restore", bucket, latestKey, region, err)
-	}
-
-	height := strings.TrimSpace(string(buf.Bytes()))
-	if height == "" {
-		return "", fmt.Errorf("latest.txt is empty")
-	}
-
-	return prefix + fmt.Sprintf("snapshot_%s_%s_%s.tar.gz", height, chainID, region), nil
-}
-
-// resolveKeyForHeight lists snapshot objects and returns the key with the
-// highest height that is <= targetHeight.
+// resolveKeyForHeight lists snapshot objects under prefix and returns the key
+// with the highest parsed height. When targetHeight > 0 it caps the search at
+// that height; targetHeight == 0 picks the highest available snapshot.
 func resolveKeyForHeight(ctx context.Context, lister seis3.ObjectLister, bucket, prefix, region string, targetHeight int64) (string, error) {
 	var bestHeight int64
 	var bestKey string
@@ -213,7 +181,10 @@ func resolveKeyForHeight(ctx context.Context, lister seis3.ObjectLister, bucket,
 				continue
 			}
 			h := parseHeightFromKey(*obj.Key)
-			if h <= 0 || h > targetHeight {
+			if h <= 0 {
+				continue
+			}
+			if targetHeight > 0 && h > targetHeight {
 				continue
 			}
 			if h > bestHeight {
@@ -229,10 +200,13 @@ func resolveKeyForHeight(ctx context.Context, lister seis3.ObjectLister, bucket,
 	}
 
 	if bestKey == "" {
-		return "", fmt.Errorf("no snapshot found at or below height %d in s3://%s/%s", targetHeight, bucket, prefix)
+		if targetHeight > 0 {
+			return "", fmt.Errorf("no snapshot found at or below height %d in s3://%s/%s", targetHeight, bucket, prefix)
+		}
+		return "", fmt.Errorf("no snapshots found in s3://%s/%s", bucket, prefix)
 	}
 
-	restoreLog.Info("resolved snapshot for target height",
+	restoreLog.Info("resolved snapshot",
 		"targetHeight", targetHeight, "snapshotHeight", bestHeight, "key", bestKey)
 	return bestKey, nil
 }

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -28,11 +28,9 @@ const restoreMarkerFile = ".sei-sidecar-snapshot-done"
 const SnapshotHeightFile = ".sei-sidecar-snapshot-height"
 
 // snapshotHeightRe extracts the block height from S3 snapshot keys of the form
-// <prefix>/snapshot_<height>_<chain>_<region>.tar.gz. The capture is anchored
-// between the "snapshot_" marker and the trailing "_<chain>_<region>", so
-// trailing digits in the suffix (the "1" in "eu-central-1.tar.gz") cannot be
-// misread as the height.
-var snapshotHeightRe = regexp.MustCompile(`/snapshot_(\d+)_[^/]+\.tar\.gz$`)
+// <chainID>/state-sync/<height>.tar.gz. The leading "/" anchor prevents the
+// regex from picking up trailing digits embedded in other path segments.
+var snapshotHeightRe = regexp.MustCompile(`/(\d+)\.tar\.gz$`)
 
 // SnapshotRestoreRequest holds the typed parameters for the snapshot-restore task.
 // S3 bucket, region, and chain prefix are derived from the sidecar's environment.

--- a/sidecar/tasks/snapshot_restore.go
+++ b/sidecar/tasks/snapshot_restore.go
@@ -80,8 +80,8 @@ func (r *SnapshotRestorer) Handler() engine.TaskHandler {
 }
 
 // Restore downloads and extracts the snapshot, skipping if the marker file exists.
-// When targetHeight > 0, it lists objects and picks the highest snapshot <= targetHeight.
-// When targetHeight == 0, it reads latest.txt for the newest snapshot.
+// It lists objects under the chain's state-sync prefix and picks the highest
+// snapshot height; when targetHeight > 0, the search is capped at that height.
 func (r *SnapshotRestorer) Restore(ctx context.Context, targetHeight int64) error {
 	if markerExists(r.homeDir, restoreMarkerFile) {
 		restoreLog.Debug("already completed, skipping")

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -142,12 +142,12 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"testchain/state-sync/snapshot_100000000_testchain_us-east-1.tar.gz": archive,
+			"testchain/state-sync/100000000.tar.gz": archive,
 		},
 	}
 	lister := &mockObjectLister{
 		keys: []string{
-			"testchain/state-sync/snapshot_100000000_testchain_us-east-1.tar.gz",
+			"testchain/state-sync/100000000.tar.gz",
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "test-bucket", "us-east-1", "testchain", mockClientFactory(client), mockListerFactory(lister))
@@ -204,7 +204,7 @@ func TestSnapshotRestoreNoMarkerOnDownloadError(t *testing.T) {
 	}
 	lister := &mockObjectLister{
 		keys: []string{
-			"c/state-sync/snapshot_100000000_c_r.tar.gz",
+			"c/state-sync/100000000.tar.gz",
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
@@ -226,11 +226,11 @@ func TestSnapshotRestoreRejectsPathTraversal(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
+			"c/state-sync/100000000.tar.gz": archive,
 		},
 	}
 	lister := &mockObjectLister{
-		keys: []string{"c/state-sync/snapshot_100000000_c_r.tar.gz"},
+		keys: []string{"c/state-sync/100000000.tar.gz"},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 0); err == nil {
@@ -246,11 +246,11 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
+			"c/state-sync/100000000.tar.gz": archive,
 		},
 	}
 	lister := &mockObjectLister{
-		keys: []string{"c/state-sync/snapshot_100000000_c_r.tar.gz"},
+		keys: []string{"c/state-sync/100000000.tar.gz"},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 0); err != nil {
@@ -277,11 +277,11 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
+			"c/state-sync/100000000.tar.gz": archive,
 		},
 	}
 	lister := &mockObjectLister{
-		keys: []string{"c/state-sync/snapshot_100000000_c_r.tar.gz"},
+		keys: []string{"c/state-sync/100000000.tar.gz"},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 0); err != nil {
@@ -305,14 +305,14 @@ func TestSnapshotRestoreWithTargetHeight(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/snapshot_99000000_c_r.tar.gz": archive,
+			"c/state-sync/99000000.tar.gz": archive,
 		},
 	}
 	lister := &mockObjectLister{
 		keys: []string{
-			"c/state-sync/snapshot_98000000_c_r.tar.gz",
-			"c/state-sync/snapshot_99000000_c_r.tar.gz",
-			"c/state-sync/snapshot_100000000_c_r.tar.gz",
+			"c/state-sync/98000000.tar.gz",
+			"c/state-sync/99000000.tar.gz",
+			"c/state-sync/100000000.tar.gz",
 			"c/state-sync/latest.txt",
 		},
 	}
@@ -335,8 +335,8 @@ func TestSnapshotRestoreTargetHeightNoMatch(t *testing.T) {
 	homeDir := t.TempDir()
 	lister := &mockObjectLister{
 		keys: []string{
-			"c/state-sync/snapshot_100000000_c_r.tar.gz",
-			"c/state-sync/snapshot_200000000_c_r.tar.gz",
+			"c/state-sync/100000000.tar.gz",
+			"c/state-sync/200000000.tar.gz",
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", nil, mockListerFactory(lister))
@@ -358,17 +358,17 @@ func TestSnapshotRestoreTargetHeightPagination(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/snapshot_99000000_c_r.tar.gz": archive,
+			"c/state-sync/99000000.tar.gz": archive,
 		},
 	}
 	// Page size of 2 forces pagination across 3 pages
 	lister := &mockObjectLister{
 		pageSize: 2,
 		keys: []string{
-			"c/state-sync/snapshot_97000000_c_r.tar.gz",
-			"c/state-sync/snapshot_98000000_c_r.tar.gz",
-			"c/state-sync/snapshot_99000000_c_r.tar.gz",
-			"c/state-sync/snapshot_100000000_c_r.tar.gz",
+			"c/state-sync/97000000.tar.gz",
+			"c/state-sync/98000000.tar.gz",
+			"c/state-sync/99000000.tar.gz",
+			"c/state-sync/100000000.tar.gz",
 			"c/state-sync/latest.txt",
 		},
 	}
@@ -402,28 +402,23 @@ func TestParseHeightFromKey(t *testing.T) {
 		want int64
 	}{
 		{
-			name: "snapshot key with chain and region suffix",
-			key:  "pacific-1/state-sync/snapshot_205082000_pacific-1_eu-central-1.tar.gz",
+			name: "canonical key parses to height",
+			key:  "pacific-1/state-sync/205082000.tar.gz",
 			want: 205082000,
 		},
 		{
-			name: "trailing region digit must not be picked up as height",
-			key:  "pacific-1/state-sync/snapshot_201525000_pacific-1_eu-central-1.tar.gz",
-			want: 201525000,
+			name: "key without slash before digits returns zero",
+			key:  "pacific-1/eu-central-1.tar.gz",
+			want: 0,
 		},
 		{
-			name: "snapshot key with single-token suffix",
-			key:  "c/state-sync/snapshot_99000000_c_r.tar.gz",
-			want: 99000000,
+			name: "long-form publisher key from before the cutover returns zero",
+			key:  "pacific-1/state-sync/snapshot_201525000_pacific-1_eu-central-1.tar.gz",
+			want: 0,
 		},
 		{
 			name: "non-snapshot tar.gz returns zero",
 			key:  "pacific-1/state-sync/some-other-file.tar.gz",
-			want: 0,
-		},
-		{
-			name: "bare height filename without snapshot prefix returns zero",
-			key:  "pacific-1/state-sync/205082000.tar.gz",
 			want: 0,
 		},
 		{

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -142,11 +142,15 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"testchain/state-sync/latest.txt": []byte("100000000"),
 			"testchain/state-sync/snapshot_100000000_testchain_us-east-1.tar.gz": archive,
 		},
 	}
-	restorer := mustNewRestorer(t, homeDir, "test-bucket", "us-east-1", "testchain", mockClientFactory(client), nil)
+	lister := &mockObjectLister{
+		keys: []string{
+			"testchain/state-sync/snapshot_100000000_testchain_us-east-1.tar.gz",
+		},
+	}
+	restorer := mustNewRestorer(t, homeDir, "test-bucket", "us-east-1", "testchain", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
@@ -179,14 +183,13 @@ func TestSnapshotRestoreSkipsWhenMarkerExists(t *testing.T) {
 	}
 }
 
-func TestSnapshotRestoreNoMarkerOnLatestTxtError(t *testing.T) {
+func TestSnapshotRestoreNoMarkerWhenBucketIsEmpty(t *testing.T) {
 	homeDir := t.TempDir()
-	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(&mockTransferClient{
-		errDefault: fmt.Errorf("access denied"),
-	}), nil)
+	lister := &mockObjectLister{keys: []string{}}
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", nil, mockListerFactory(lister))
 
 	if err := restorer.Restore(context.Background(), 0); err == nil {
-		t.Fatal("expected error on S3 failure")
+		t.Fatal("expected error when no snapshots are present")
 	}
 
 	if markerExists(homeDir, restoreMarkerFile) {
@@ -197,12 +200,14 @@ func TestSnapshotRestoreNoMarkerOnLatestTxtError(t *testing.T) {
 func TestSnapshotRestoreNoMarkerOnDownloadError(t *testing.T) {
 	homeDir := t.TempDir()
 	client := &mockTransferClient{
-		responses: map[string][]byte{
-			"c/state-sync/latest.txt": []byte("100000000"),
-		},
 		errDefault: fmt.Errorf("access denied"),
 	}
-	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	lister := &mockObjectLister{
+		keys: []string{
+			"c/state-sync/snapshot_100000000_c_r.tar.gz",
+		},
+	}
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 
 	if err := restorer.Restore(context.Background(), 0); err == nil {
 		t.Fatal("expected error on snapshot download failure")
@@ -221,11 +226,13 @@ func TestSnapshotRestoreRejectsPathTraversal(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/latest.txt": []byte("100000000"),
 			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
 		},
 	}
-	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	lister := &mockObjectLister{
+		keys: []string{"c/state-sync/snapshot_100000000_c_r.tar.gz"},
+	}
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 0); err == nil {
 		t.Fatal("expected error for path traversal attempt")
 	}
@@ -239,11 +246,13 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/latest.txt": []byte("100000000"),
 			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
 		},
 	}
-	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	lister := &mockObjectLister{
+		keys: []string{"c/state-sync/snapshot_100000000_c_r.tar.gz"},
+	}
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}
@@ -268,11 +277,13 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/state-sync/latest.txt": []byte("100000000"),
 			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
 		},
 	}
-	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
+	lister := &mockObjectLister{
+		keys: []string{"c/state-sync/snapshot_100000000_c_r.tar.gz"},
+	}
+	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
 	if err := restorer.Restore(context.Background(), 0); err != nil {
 		t.Fatalf("Restore failed: %v", err)
 	}

--- a/sidecar/tasks/snapshot_restore_test.go
+++ b/sidecar/tasks/snapshot_restore_test.go
@@ -142,8 +142,8 @@ func TestSnapshotRestoreExtractsArchive(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"testchain/latest.txt":       []byte("100000000"),
-			"testchain/100000000.tar.gz": archive,
+			"testchain/state-sync/latest.txt": []byte("100000000"),
+			"testchain/state-sync/snapshot_100000000_testchain_us-east-1.tar.gz": archive,
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "test-bucket", "us-east-1", "testchain", mockClientFactory(client), nil)
@@ -198,7 +198,7 @@ func TestSnapshotRestoreNoMarkerOnDownloadError(t *testing.T) {
 	homeDir := t.TempDir()
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/latest.txt": []byte("100000000"),
+			"c/state-sync/latest.txt": []byte("100000000"),
 		},
 		errDefault: fmt.Errorf("access denied"),
 	}
@@ -221,8 +221,8 @@ func TestSnapshotRestoreRejectsPathTraversal(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/latest.txt":       []byte("100000000"),
-			"c/100000000.tar.gz": archive,
+			"c/state-sync/latest.txt": []byte("100000000"),
+			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
@@ -239,8 +239,8 @@ func TestSnapshotRestoreCleansUpTempFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/latest.txt":       []byte("100000000"),
-			"c/100000000.tar.gz": archive,
+			"c/state-sync/latest.txt": []byte("100000000"),
+			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
@@ -268,8 +268,8 @@ func TestSnapshotRestoreWritesHeightFile(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/latest.txt":       []byte("100000000"),
-			"c/100000000.tar.gz": archive,
+			"c/state-sync/latest.txt": []byte("100000000"),
+			"c/state-sync/snapshot_100000000_c_r.tar.gz": archive,
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), nil)
@@ -294,15 +294,15 @@ func TestSnapshotRestoreWithTargetHeight(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/99000000.tar.gz": archive,
+			"c/state-sync/snapshot_99000000_c_r.tar.gz": archive,
 		},
 	}
 	lister := &mockObjectLister{
 		keys: []string{
-			"c/98000000.tar.gz",
-			"c/99000000.tar.gz",
-			"c/100000000.tar.gz",
-			"c/latest.txt",
+			"c/state-sync/snapshot_98000000_c_r.tar.gz",
+			"c/state-sync/snapshot_99000000_c_r.tar.gz",
+			"c/state-sync/snapshot_100000000_c_r.tar.gz",
+			"c/state-sync/latest.txt",
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
@@ -324,8 +324,8 @@ func TestSnapshotRestoreTargetHeightNoMatch(t *testing.T) {
 	homeDir := t.TempDir()
 	lister := &mockObjectLister{
 		keys: []string{
-			"c/100000000.tar.gz",
-			"c/200000000.tar.gz",
+			"c/state-sync/snapshot_100000000_c_r.tar.gz",
+			"c/state-sync/snapshot_200000000_c_r.tar.gz",
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", nil, mockListerFactory(lister))
@@ -347,18 +347,18 @@ func TestSnapshotRestoreTargetHeightPagination(t *testing.T) {
 
 	client := &mockTransferClient{
 		responses: map[string][]byte{
-			"c/99000000.tar.gz": archive,
+			"c/state-sync/snapshot_99000000_c_r.tar.gz": archive,
 		},
 	}
 	// Page size of 2 forces pagination across 3 pages
 	lister := &mockObjectLister{
 		pageSize: 2,
 		keys: []string{
-			"c/97000000.tar.gz",
-			"c/98000000.tar.gz",
-			"c/99000000.tar.gz",
-			"c/100000000.tar.gz",
-			"c/latest.txt",
+			"c/state-sync/snapshot_97000000_c_r.tar.gz",
+			"c/state-sync/snapshot_98000000_c_r.tar.gz",
+			"c/state-sync/snapshot_99000000_c_r.tar.gz",
+			"c/state-sync/snapshot_100000000_c_r.tar.gz",
+			"c/state-sync/latest.txt",
 		},
 	}
 	restorer := mustNewRestorer(t, homeDir, "b", "r", "c", mockClientFactory(client), mockListerFactory(lister))
@@ -381,5 +381,51 @@ func TestSnapshotRestoreNegativeTargetHeight(t *testing.T) {
 	err := restorer.Restore(context.Background(), -1)
 	if err == nil {
 		t.Fatal("expected error for negative targetHeight")
+	}
+}
+
+func TestParseHeightFromKey(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want int64
+	}{
+		{
+			name: "snapshot key with chain and region suffix",
+			key:  "pacific-1/state-sync/snapshot_205082000_pacific-1_eu-central-1.tar.gz",
+			want: 205082000,
+		},
+		{
+			name: "trailing region digit must not be picked up as height",
+			key:  "pacific-1/state-sync/snapshot_201525000_pacific-1_eu-central-1.tar.gz",
+			want: 201525000,
+		},
+		{
+			name: "snapshot key with single-token suffix",
+			key:  "c/state-sync/snapshot_99000000_c_r.tar.gz",
+			want: 99000000,
+		},
+		{
+			name: "non-snapshot tar.gz returns zero",
+			key:  "pacific-1/state-sync/some-other-file.tar.gz",
+			want: 0,
+		},
+		{
+			name: "bare height filename without snapshot prefix returns zero",
+			key:  "pacific-1/state-sync/205082000.tar.gz",
+			want: 0,
+		},
+		{
+			name: "latest.txt returns zero",
+			key:  "pacific-1/state-sync/latest.txt",
+			want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseHeightFromKey(tc.key); got != tc.want {
+				t.Errorf("parseHeightFromKey(%q) = %d, want %d", tc.key, got, tc.want)
+			}
+		})
 	}
 }

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -126,9 +126,9 @@ func (u *SnapshotUploader) Upload(ctx context.Context) error {
 		return fmt.Errorf("building S3 uploader: %w", err)
 	}
 
-	prefix := u.chainID + "/"
+	prefix := u.chainID + "/state-sync/"
 
-	archiveKey := fmt.Sprintf("%s%d.tar.gz", prefix, height)
+	archiveKey := fmt.Sprintf("%ssnapshot_%d_%s_%s.tar.gz", prefix, height, u.chainID, u.region)
 	uploadLog.Info("streaming archive to S3", "key", archiveKey)
 	if err := u.streamUpload(ctx, uploader, u.bucket, archiveKey, snapshotsDir, height); err != nil {
 		return fmt.Errorf("uploading %s: %w", archiveKey, err)

--- a/sidecar/tasks/snapshot_upload.go
+++ b/sidecar/tasks/snapshot_upload.go
@@ -128,7 +128,7 @@ func (u *SnapshotUploader) Upload(ctx context.Context) error {
 
 	prefix := u.chainID + "/state-sync/"
 
-	archiveKey := fmt.Sprintf("%ssnapshot_%d_%s_%s.tar.gz", prefix, height, u.chainID, u.region)
+	archiveKey := fmt.Sprintf("%s%d.tar.gz", prefix, height)
 	uploadLog.Info("streaming archive to S3", "key", archiveKey)
 	if err := u.streamUpload(ctx, uploader, u.bucket, archiveKey, snapshotsDir, height); err != nil {
 		return fmt.Errorf("uploading %s: %w", archiveKey, err)

--- a/sidecar/tasks/snapshot_upload_test.go
+++ b/sidecar/tasks/snapshot_upload_test.go
@@ -106,8 +106,8 @@ func TestUpload_UploadsArchiveAndLatestTxt(t *testing.T) {
 		t.Fatalf("Upload() error = %v", err)
 	}
 
-	if _, ok := mock.uploads["my-bucket/testchain/state-sync/snapshot_1000_testchain_eu-central-1.tar.gz"]; !ok {
-		t.Errorf("expected archive upload at testchain/state-sync/snapshot_1000_testchain_eu-central-1.tar.gz")
+	if _, ok := mock.uploads["my-bucket/testchain/state-sync/1000.tar.gz"]; !ok {
+		t.Error("expected archive upload at testchain/state-sync/1000.tar.gz")
 	}
 
 	latest, ok := mock.uploads["my-bucket/testchain/state-sync/latest.txt"]
@@ -156,8 +156,8 @@ func TestUpload_UploadsNewerSnapshot(t *testing.T) {
 		t.Fatalf("Upload() error = %v", err)
 	}
 
-	if _, ok := mock.uploads["my-bucket/testchain/state-sync/snapshot_2000_testchain_eu-central-1.tar.gz"]; !ok {
-		t.Errorf("expected archive upload at testchain/state-sync/snapshot_2000_testchain_eu-central-1.tar.gz")
+	if _, ok := mock.uploads["my-bucket/testchain/state-sync/2000.tar.gz"]; !ok {
+		t.Error("expected archive upload at testchain/state-sync/2000.tar.gz")
 	}
 }
 

--- a/sidecar/tasks/snapshot_upload_test.go
+++ b/sidecar/tasks/snapshot_upload_test.go
@@ -106,11 +106,11 @@ func TestUpload_UploadsArchiveAndLatestTxt(t *testing.T) {
 		t.Fatalf("Upload() error = %v", err)
 	}
 
-	if _, ok := mock.uploads["my-bucket/testchain/1000.tar.gz"]; !ok {
-		t.Error("expected archive upload at state-sync/1000.tar.gz")
+	if _, ok := mock.uploads["my-bucket/testchain/state-sync/snapshot_1000_testchain_eu-central-1.tar.gz"]; !ok {
+		t.Errorf("expected archive upload at testchain/state-sync/snapshot_1000_testchain_eu-central-1.tar.gz")
 	}
 
-	latest, ok := mock.uploads["my-bucket/testchain/latest.txt"]
+	latest, ok := mock.uploads["my-bucket/testchain/state-sync/latest.txt"]
 	if !ok {
 		t.Fatal("expected latest.txt upload")
 	}
@@ -156,8 +156,8 @@ func TestUpload_UploadsNewerSnapshot(t *testing.T) {
 		t.Fatalf("Upload() error = %v", err)
 	}
 
-	if _, ok := mock.uploads["my-bucket/testchain/2000.tar.gz"]; !ok {
-		t.Error("expected archive upload at state-sync/2000.tar.gz")
+	if _, ok := mock.uploads["my-bucket/testchain/state-sync/snapshot_2000_testchain_eu-central-1.tar.gz"]; !ok {
+		t.Errorf("expected archive upload at testchain/state-sync/snapshot_2000_testchain_eu-central-1.tar.gz")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two coupled bugs in the snapshot-restore / snapshot-upload tasks, plus a layout simplification.

### 1. Restore: regex misparsed heights

`snapshotHeightRe = (\d+)\.tar\.gz$` captured trailing digits from any path segment ending in digits. Combined with the publisher's `snapshot_<H>_<chain>_<region>.tar.gz` form, every key parsed to **height = 1** (from `eu-central-1`), tied on lex order, and the older snapshot won — silently restoring stale state regardless of `targetHeight`.

### 2. Layout: prefix and consumer/producer divergence

The restorer's prefix was `<chainID>/`; the uploader matched. The publisher actually wrote `<chainID>/state-sync/snapshot_<H>_<chain>_<region>.tar.gz`. `resolveLatestKey` constructed the filename from the **consumer's** `SEI_SNAPSHOT_REGION`, which would have failed for any cross-region read or DR-replicated bucket.

### Settled layout

```
s3://<bucket>/<chainID>/state-sync/<height>.tar.gz
```

- Chain is in the prefix.
- Region is a property of the bucket — one bucket per region, no need to encode it again in the filename.
- `state-sync/` segment is reserved for tendermint state-sync snapshots so we have room for sibling subdirs (archive, full-state, etc.) under the same chain prefix without collision.

### Fix

- Regex tightened to `/(\d+)\.tar\.gz$`. The leading `/` anchor prevents trailing digits in any other path segment from being misread as the height.
- Restorer prefix: `<chainID>/state-sync/`. Uploader emits `<chainID>/state-sync/<H>.tar.gz`.
- `resolveLatestKey` removed. Both code paths unified through `resolveKeyForHeight`, where `targetHeight==0` means "pick the highest available". Decouples consumer from producer-region naming and from latest.txt format.

### Migration property

The new regex doesn't match the old `snapshot_<H>_<chain>_<region>.tar.gz` form. So during migration, a bucket that contains both forms transparently uses only canonical keys. Old keys can be deleted post-migration with zero downtime.

## Out of scope (operator follow-up)

- Migrate `s3://prod-sei-snapshots/<chain>/<H>.tar.gz` → `s3://prod-sei-snapshots/<chain>/state-sync/<H>.tar.gz` (just adds the `state-sync/` segment).
- Migrate `s3://harbor-sei-snapshots/<chain>/state-sync/snapshot_<H>_<chain>_<region>.tar.gz` → `s3://harbor-sei-snapshots/<chain>/state-sync/<H>.tar.gz` (rename to bare-height).
- Bump seictl version + sei-k8s-controller's default sidecar image once this lands. No live consumer regression today (no SeiNode currently uses `snapshot.s3`) — strictly forward-looking risk.

## Test plan

- [x] `make lint` clean
- [x] All tests pass: 13 `TestSnapshotRestore*` + 5 `TestParseHeightFromKey` + 5 `TestUpload*` + 4 `TestPickUploadCandidate` cases (0.99s, `GOWORK=off go test ./sidecar/tasks/`)
- [x] `TestParseHeightFromKey` locks in: canonical key parses, no-slash-before-digits returns 0, long-form publisher key (clean break) returns 0, latest.txt returns 0
- [x] `TestUpload_*` pin the new uploader key format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
