### PR TITLE
feat(kube): fall back to in-cluster auth when no kubeconfig context

### DIFF
--- a/cluster/internal/kube/client.go
+++ b/cluster/internal/kube/client.go
@@ -5,9 +5,12 @@
 package kube
 
 import (
+	"os"
 	"sort"
+	"strings"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 
 	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
 )
@@ -36,9 +39,26 @@ type Client struct {
 	flags *genericclioptions.ConfigFlags
 }
 
+// inClusterContextName is the synthetic context label used when a
+// Client is constructed from rest.InClusterConfig() rather than a
+// kubeconfig file. Echoed in the JSON envelope alongside ClusterServer.
+const inClusterContextName = "in-cluster"
+
+// Vars (not consts) so tests can stub the in-cluster surface.
+var (
+	inClusterConfigFn      = rest.InClusterConfig
+	inClusterNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
 // New resolves kubeconfig context + namespace into a Client. Errors
 // in this layer are kubeconfig-shape problems and map to ExitIdentity /
 // CatKubeconfigParse, not cluster reachability.
+//
+// When no kubeconfig file is present and no --context override is given,
+// New falls back to rest.InClusterConfig() so seictl can run from
+// inside a pod with a projected ServiceAccount token. The synthetic
+// Client uses ContextName="in-cluster"; ClusterServer is the apiserver
+// URL from the in-cluster config.
 func New(opts Options) (*Client, *clioutput.Error) {
 	cf := genericclioptions.NewConfigFlags(true)
 	// Leave the pointers nil when the caller didn't override, so
@@ -72,8 +92,11 @@ func New(opts Options) (*Client, *clioutput.Error) {
 		contextName = opts.Context
 	}
 	if contextName == "" {
-		return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatKubeconfigParse,
-			"no current-context in kubeconfig and no --context provided")
+		// No kubeconfig context and no override — try in-cluster auth.
+		// ConfigFlags.ToRESTConfig() falls back to in-cluster on its own
+		// for resource.Builder, so all we need to synthesize here are
+		// the descriptive fields echoed into the JSON envelope.
+		return newInClusterClient(cf, opts)
 	}
 	kctx, ok := raw.Contexts[contextName]
 	if !ok {
@@ -103,6 +126,32 @@ func New(opts Options) (*Client, *clioutput.Error) {
 		ContextName:   contextName,
 		ClusterName:   kctx.Cluster,
 		ClusterServer: cluster.Server,
+		Namespace:     ns,
+		flags:         cf,
+	}, nil
+}
+
+func newInClusterClient(cf *genericclioptions.ConfigFlags, opts Options) (*Client, *clioutput.Error) {
+	cfg, err := inClusterConfigFn()
+	if err != nil {
+		return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatKubeconfigParse,
+			"no current-context in kubeconfig and not running in a pod with a ServiceAccount")
+	}
+
+	ns := opts.Namespace
+	if ns == "" {
+		if data, ferr := os.ReadFile(inClusterNamespaceFile); ferr == nil {
+			ns = strings.TrimSpace(string(data))
+		}
+	}
+	if ns == "" {
+		ns = "default"
+	}
+
+	return &Client{
+		ContextName:   inClusterContextName,
+		ClusterName:   inClusterContextName,
+		ClusterServer: cfg.Host,
 		Namespace:     ns,
 		flags:         cf,
 	}, nil

--- a/cluster/internal/kube/client.go
+++ b/cluster/internal/kube/client.go
@@ -39,12 +39,9 @@ type Client struct {
 	flags *genericclioptions.ConfigFlags
 }
 
-// inClusterContextName is the synthetic context label used when a
-// Client is constructed from rest.InClusterConfig() rather than a
-// kubeconfig file. Echoed in the JSON envelope alongside ClusterServer.
 const inClusterContextName = "in-cluster"
 
-// Vars (not consts) so tests can stub the in-cluster surface.
+// Vars (not consts) so tests can stub.
 var (
 	inClusterConfigFn      = rest.InClusterConfig
 	inClusterNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -52,13 +49,8 @@ var (
 
 // New resolves kubeconfig context + namespace into a Client. Errors
 // in this layer are kubeconfig-shape problems and map to ExitIdentity /
-// CatKubeconfigParse, not cluster reachability.
-//
-// When no kubeconfig file is present and no --context override is given,
-// New falls back to rest.InClusterConfig() so seictl can run from
-// inside a pod with a projected ServiceAccount token. The synthetic
-// Client uses ContextName="in-cluster"; ClusterServer is the apiserver
-// URL from the in-cluster config.
+// CatKubeconfigParse, not cluster reachability. With no current-context
+// and no --context override, falls back to rest.InClusterConfig().
 func New(opts Options) (*Client, *clioutput.Error) {
 	cf := genericclioptions.NewConfigFlags(true)
 	// Leave the pointers nil when the caller didn't override, so
@@ -92,10 +84,6 @@ func New(opts Options) (*Client, *clioutput.Error) {
 		contextName = opts.Context
 	}
 	if contextName == "" {
-		// No kubeconfig context and no override — try in-cluster auth.
-		// ConfigFlags.ToRESTConfig() falls back to in-cluster on its own
-		// for resource.Builder, so all we need to synthesize here are
-		// the descriptive fields echoed into the JSON envelope.
 		return newInClusterClient(cf, opts)
 	}
 	kctx, ok := raw.Contexts[contextName]
@@ -134,8 +122,8 @@ func New(opts Options) (*Client, *clioutput.Error) {
 func newInClusterClient(cf *genericclioptions.ConfigFlags, opts Options) (*Client, *clioutput.Error) {
 	cfg, err := inClusterConfigFn()
 	if err != nil {
-		return nil, clioutput.New(clioutput.ExitIdentity, clioutput.CatKubeconfigParse,
-			"no current-context in kubeconfig and not running in a pod with a ServiceAccount")
+		return nil, clioutput.Newf(clioutput.ExitIdentity, clioutput.CatKubeconfigParse,
+			"no current-context in kubeconfig and not running in a pod with a ServiceAccount (in-cluster: %v)", err)
 	}
 
 	ns := opts.Namespace

--- a/cluster/internal/kube/client_test.go
+++ b/cluster/internal/kube/client_test.go
@@ -195,7 +195,6 @@ users: []
 `
 		path := writeFixture(t, minimal)
 		stubInCluster(t, &rest.Config{Host: "https://kubernetes.default.svc"}, nil)
-		// Point the SA namespace file at a path that does not exist.
 		oldFile := inClusterNamespaceFile
 		inClusterNamespaceFile = filepath.Join(t.TempDir(), "missing")
 		t.Cleanup(func() { inClusterNamespaceFile = oldFile })
@@ -206,6 +205,52 @@ users: []
 		}
 		if c.Namespace != "default" {
 			t.Errorf("expected default namespace; got %q", c.Namespace)
+		}
+	})
+
+	t.Run("pristine pod with no kubeconfig file falls back to in-cluster", func(t *testing.T) {
+		// clientcmd captures HOME at init; KUBECONFIG override is the only working seam.
+		t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "missing"))
+		stubInCluster(t, &rest.Config{Host: "https://kubernetes.default.svc"}, nil)
+		stubInClusterNamespace(t, "production-ns")
+
+		c, err := New(Options{})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if c.ContextName != "in-cluster" {
+			t.Errorf("expected in-cluster context; got %q", c.ContextName)
+		}
+		if c.Namespace != "production-ns" {
+			t.Errorf("namespace: %q", c.Namespace)
+		}
+	})
+
+	t.Run("explicit context override skips in-cluster fallback", func(t *testing.T) {
+		const minimal = `apiVersion: v1
+kind: Config
+contexts: []
+clusters: []
+users: []
+`
+		path := writeFixture(t, minimal)
+		called := false
+		old := inClusterConfigFn
+		inClusterConfigFn = func() (*rest.Config, error) {
+			called = true
+			return &rest.Config{Host: "https://wrong.example"}, nil
+		}
+		t.Cleanup(func() { inClusterConfigFn = old })
+
+		_, err := New(Options{Kubeconfig: path, Context: "ghost"})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if called {
+			t.Errorf("in-cluster fallback must not fire when --context is set")
+		}
+		if !strings.Contains(err.Message, "ghost") {
+			t.Errorf("expected error to mention requested context; got %q", err.Message)
 		}
 	})
 

--- a/cluster/internal/kube/client_test.go
+++ b/cluster/internal/kube/client_test.go
@@ -1,10 +1,13 @@
 package kube
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"k8s.io/client-go/rest"
 
 	"github.com/sei-protocol/seictl/cluster/internal/clioutput"
 )
@@ -42,6 +45,24 @@ func writeFixture(t *testing.T, contents string) string {
 		t.Fatalf("seed kubeconfig: %v", err)
 	}
 	return path
+}
+
+func stubInCluster(t *testing.T, cfg *rest.Config, err error) {
+	t.Helper()
+	old := inClusterConfigFn
+	inClusterConfigFn = func() (*rest.Config, error) { return cfg, err }
+	t.Cleanup(func() { inClusterConfigFn = old })
+}
+
+func stubInClusterNamespace(t *testing.T, ns string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "namespace")
+	if err := os.WriteFile(path, []byte(ns+"\n"), 0o600); err != nil {
+		t.Fatalf("seed namespace file: %v", err)
+	}
+	old := inClusterNamespaceFile
+	inClusterNamespaceFile = path
+	t.Cleanup(func() { inClusterNamespaceFile = old })
 }
 
 func TestNew(t *testing.T) {
@@ -98,7 +119,7 @@ func TestNew(t *testing.T) {
 		}
 	})
 
-	t.Run("no current-context", func(t *testing.T) {
+	t.Run("no current-context, no in-cluster", func(t *testing.T) {
 		const minimal = `apiVersion: v1
 kind: Config
 contexts: []
@@ -106,12 +127,85 @@ clusters: []
 users: []
 `
 		path := writeFixture(t, minimal)
+		stubInCluster(t, nil, errors.New("not in a cluster"))
 		_, err := New(Options{Kubeconfig: path})
 		if err == nil {
 			t.Fatalf("expected error")
 		}
 		if err.Category != clioutput.CatKubeconfigParse || err.Code != clioutput.ExitIdentity {
 			t.Errorf("got %+v", err)
+		}
+		if !strings.Contains(err.Message, "ServiceAccount") {
+			t.Errorf("error should mention ServiceAccount fallback; got %q", err.Message)
+		}
+	})
+
+	t.Run("in-cluster fallback when no current-context", func(t *testing.T) {
+		const minimal = `apiVersion: v1
+kind: Config
+contexts: []
+clusters: []
+users: []
+`
+		path := writeFixture(t, minimal)
+		stubInCluster(t, &rest.Config{Host: "https://kubernetes.default.svc"}, nil)
+		stubInClusterNamespace(t, "release-test")
+
+		c, err := New(Options{Kubeconfig: path})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if c.ContextName != "in-cluster" || c.ClusterName != "in-cluster" {
+			t.Errorf("synthetic context fields: %+v", c)
+		}
+		if c.ClusterServer != "https://kubernetes.default.svc" {
+			t.Errorf("server: %q", c.ClusterServer)
+		}
+		if c.Namespace != "release-test" {
+			t.Errorf("namespace from SA file: %q", c.Namespace)
+		}
+	})
+
+	t.Run("in-cluster fallback honors namespace override", func(t *testing.T) {
+		const minimal = `apiVersion: v1
+kind: Config
+contexts: []
+clusters: []
+users: []
+`
+		path := writeFixture(t, minimal)
+		stubInCluster(t, &rest.Config{Host: "https://kubernetes.default.svc"}, nil)
+		stubInClusterNamespace(t, "release-test")
+
+		c, err := New(Options{Kubeconfig: path, Namespace: "override-ns"})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if c.Namespace != "override-ns" {
+			t.Errorf("namespace override: got %q want override-ns", c.Namespace)
+		}
+	})
+
+	t.Run("in-cluster fallback when SA namespace file missing falls back to default", func(t *testing.T) {
+		const minimal = `apiVersion: v1
+kind: Config
+contexts: []
+clusters: []
+users: []
+`
+		path := writeFixture(t, minimal)
+		stubInCluster(t, &rest.Config{Host: "https://kubernetes.default.svc"}, nil)
+		// Point the SA namespace file at a path that does not exist.
+		oldFile := inClusterNamespaceFile
+		inClusterNamespaceFile = filepath.Join(t.TempDir(), "missing")
+		t.Cleanup(func() { inClusterNamespaceFile = oldFile })
+
+		c, err := New(Options{Kubeconfig: path})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if c.Namespace != "default" {
+			t.Errorf("expected default namespace; got %q", c.Namespace)
 		}
 	})
 


### PR DESCRIPTION
## Summary

`kube.New` today calls `genericclioptions.RawConfig()` and errors out with `no current-context in kubeconfig and no --context provided` whenever seictl is invoked from a pod (no kubeconfig file, no `KUBECONFIG` env). Every other K8s client (`kubectl`, controller-runtime, helm, flux) falls back to `rest.InClusterConfig()` automatically in this scenario — seictl is the outlier.

This change wires the same fallback into `kube.New`. When raw config has no current-context and no `--context` override is provided, attempt `rest.InClusterConfig()` before erroring. On success, synthesize a `Client` with `ContextName="in-cluster"`, `ClusterServer=cfg.Host`, and namespace resolved from `opts.Namespace` → SA namespace file → `"default"`.

`ConfigFlags.ToRESTConfig()` already falls back to in-cluster on its own for `resource.Builder`, so no plumbing change is needed for the actual API calls — only for the descriptive fields echoed into the JSON envelope (e.g. `seictl context`, `chain up`, `rpc up`).

## Why now

Discovered by the platform's release-test orchestrator (sei-protocol/platform#380 follow-up): `seictl chain up` from inside a K8s Job fails immediately with the `no current-context` envelope. The platform-side workaround (writing a synthesized kubeconfig to `$HOME/.kube/config`) was rejected in favor of fixing this here. Future K8s Job consumers of seictl (e.g. when the nightly seiload flow migrates from a GHA runner to an in-cluster Job) get in-cluster auth for free.

## Tests

- 4 new subtests cover the in-cluster path: success, namespace override, namespace from SA file, missing SA file → `"default"`.
- Existing `no current-context` test renamed and updated to stub in-cluster to error; asserts the new message mentions the ServiceAccount fallback.
- `inClusterConfigFn` and `inClusterNamespaceFile` package vars provide the test seam (`rest.InClusterConfig` hardcodes `/var/run/secrets/...` paths).

```
=== RUN   TestNew
--- PASS: TestNew/happy_path
--- PASS: TestNew/context_override_falls_back_to_default_namespace
--- PASS: TestNew/namespace_override
--- PASS: TestNew/missing_context_lists_available
--- PASS: TestNew/no_current-context,_no_in-cluster
--- PASS: TestNew/in-cluster_fallback_when_no_current-context
--- PASS: TestNew/in-cluster_fallback_honors_namespace_override
--- PASS: TestNew/in-cluster_fallback_when_SA_namespace_file_missing_falls_back_to_default
--- PASS: TestNew/malformed_kubeconfig
PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)