### PR TITLE
refactor(chain): drop misleading "bench-" prefix from chainID

### DIFF
--- a/cluster/chain.go
+++ b/cluster/chain.go
@@ -152,7 +152,7 @@ func runChainUp(ctx context.Context, in chainUpInput, deps chainDeps) (chainUpRe
 		return chainUpResult{}, clioutput.Newf(clioutput.ExitBench, clioutput.CatImageResolution, "%v", err)
 	}
 
-	chainID := fmt.Sprintf("bench-%s-%s", cfg.Alias, in.Name)
+	chainID := fmt.Sprintf("%s-%s", cfg.Alias, in.Name)
 	digestShort := shortDigest(digest)
 
 	docs, manifests, rerr := renderChainManifests(cfg.Alias, in.Name, namespace, chainID, seidImage, digestShort, in.Validators, prefunded)

--- a/cluster/chain_down.go
+++ b/cluster/chain_down.go
@@ -84,7 +84,7 @@ func runChainDown(ctx context.Context, in chainDownInput, out io.Writer, deps ch
 		return failChainDown(out, e.ExitWith(clioutput.ExitBench))
 	}
 
-	chainID := fmt.Sprintf("bench-%s-%s", cfg.Alias, in.Name)
+	chainID := fmt.Sprintf("%s-%s", cfg.Alias, in.Name)
 	selector := fmt.Sprintf("sei.io/engineer=%s,sei.io/chain-id=%s", cfg.Alias, chainID)
 
 	kc, kerr := deps.newKubeClient(kube.Options{Kubeconfig: in.Kubeconfig, Context: in.Context})

--- a/cluster/chain_down_test.go
+++ b/cluster/chain_down_test.go
@@ -42,7 +42,7 @@ func TestRunChainDown(t *testing.T) {
 		}
 		var data chainDownResult
 		_ = json.Unmarshal(env.Data, &data)
-		if data.ChainID != "bench-bdc-qa" {
+		if data.ChainID != "bdc-qa" {
 			t.Errorf("chainId: %q", data.ChainID)
 		}
 		if !data.DryRun {
@@ -62,13 +62,13 @@ func TestRunChainDown(t *testing.T) {
 			dryRunListFn: func(_ context.Context, _ *kube.Client, opts kube.ListOptions) ([]kube.DeleteResult, *clioutput.Error) {
 				capturedSelector = opts.LabelSelector
 				return []kube.DeleteResult{
-					{Kind: "SeiNodeDeployment", Name: "bench-bdc-qa", Namespace: "eng-bdc", Action: "would-delete"},
+					{Kind: "SeiNodeDeployment", Name: "bdc-qa", Namespace: "eng-bdc", Action: "would-delete"},
 				}, nil
 			},
 		}
 		var buf bytes.Buffer
 		_ = runChainDown(context.Background(), chainDownInput{Name: "qa", DryRun: true}, &buf, deps)
-		want := "sei.io/engineer=bdc,sei.io/chain-id=bench-bdc-qa"
+		want := "sei.io/engineer=bdc,sei.io/chain-id=bdc-qa"
 		if capturedSelector != want {
 			t.Errorf("selector: got %q, want %q", capturedSelector, want)
 		}
@@ -81,7 +81,7 @@ func TestRunChainDown(t *testing.T) {
 			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) { return &kube.Client{}, nil },
 			deleteFn: func(context.Context, *kube.Client, kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
 				return []kube.DeleteResult{
-					{Kind: "SeiNodeDeployment", Name: "bench-bdc-qa", Namespace: "eng-bdc", Action: "deleted"},
+					{Kind: "SeiNodeDeployment", Name: "bdc-qa", Namespace: "eng-bdc", Action: "deleted"},
 				}, nil
 			},
 		}
@@ -109,7 +109,7 @@ func TestRunChainDown(t *testing.T) {
 			newKubeClient: func(kube.Options) (*kube.Client, *clioutput.Error) { return &kube.Client{}, nil },
 			deleteFn: func(context.Context, *kube.Client, kube.DeleteOptions) ([]kube.DeleteResult, *clioutput.Error) {
 				return []kube.DeleteResult{
-					{Kind: "SeiNodeDeployment", Name: "bench-bdc-qa", Namespace: "eng-bdc", Action: "still-terminating"},
+					{Kind: "SeiNodeDeployment", Name: "bdc-qa", Namespace: "eng-bdc", Action: "still-terminating"},
 				}, nil
 			},
 		}

--- a/cluster/chain_test.go
+++ b/cluster/chain_test.go
@@ -59,7 +59,7 @@ func TestRunChainUp(t *testing.T) {
 		if err := json.Unmarshal(env.Data, &data); err != nil {
 			t.Fatalf("data unmarshal: %v", err)
 		}
-		if data.ChainID != "bench-bdc-qa" {
+		if data.ChainID != "bdc-qa" {
 			t.Errorf("chainId: %q", data.ChainID)
 		}
 		if data.Namespace != "eng-bdc" {
@@ -72,7 +72,7 @@ func TestRunChainUp(t *testing.T) {
 			t.Errorf("dryRun should be true")
 		}
 
-		wantTM := "http://bench-bdc-qa-internal.eng-bdc.svc.cluster.local:26657"
+		wantTM := "http://bdc-qa-internal.eng-bdc.svc.cluster.local:26657"
 		if len(data.Endpoints.TendermintRpc) != 1 || data.Endpoints.TendermintRpc[0] != wantTM {
 			t.Errorf("tendermintRpc: got %v, want [%s]", data.Endpoints.TendermintRpc, wantTM)
 		}
@@ -216,7 +216,7 @@ func TestRunChainUp(t *testing.T) {
 			Validators: 4,
 		}, &buf, stubChainDeps(t, "bdc"))
 
-		docs, _, err := renderChainManifests("bdc", "qa", "eng-bdc", "bench-bdc-qa", "img@sha256:0", "0123456789ab", 4, nil)
+		docs, _, err := renderChainManifests("bdc", "qa", "eng-bdc", "bdc-qa", "img@sha256:0", "0123456789ab", 4, nil)
 		if err != nil {
 			t.Fatalf("render: %v", err)
 		}
@@ -227,7 +227,7 @@ func TestRunChainUp(t *testing.T) {
 		for _, want := range []string{
 			"app.kubernetes.io/component: chain",
 			"sei.io/role: validator",
-			"sei.io/chain-id: bench-bdc-qa",
+			"sei.io/chain-id: bdc-qa",
 			"sei.io/engineer: bdc",
 			"sei.io/bench-name: qa",
 		} {


### PR DESCRIPTION
## Summary

`chain up` and `chain down` were prepending `bench-` to the chainID they construct (`fmt.Sprintf("bench-%s-%s", alias, name)` at `chain.go:155` and `chain_down.go:87`) — a vestige from when only `bench up` existed and chain-creation reused the bench code paths. Now that `chain up` is its own verb, the prefix misleads readers: `kubectl get snd` shows `bench-release-test-foo` for what is in fact a plain validator chain, not a benchmark workload.

Discovered via the platform release-test orchestrator (sei-protocol/platform): "are we running the benchmark target or the qa test harness?" — the answer was the qa harness, but the SND name suggested otherwise.

## Scope

Minimum-viable change:

- `cluster/chain.go:155` — drop prefix.
- `cluster/chain_down.go:87` — drop matching prefix (chain down's selector must match chain up's chainID).
- `cluster/chain_test.go` and `cluster/chain_down_test.go` — assert the new chainID shape (`{alias}-{name}`).

Intentionally **not** changed:

- `cluster/bench.go`, `cluster/bench_down.go`, `cluster/bench_list.go` — bench up/down's workload is literally a benchmark; the prefix is correct.
- `sei.io/bench-name` label in chain templates — renaming a label is a breaking change for any external selector. Worth a separate, deliberate pass.
- `cluster/internal/validate/validate.go` — the length validator still asserts `bench-{alias}-{name} ≤ 63`. Conservatively over-strict for chain up (which is now 6 chars shorter); not a correctness bug.

## Test results

```
ok  github.com/sei-protocol/seictl/cluster  1.670s
ok  github.com/sei-protocol/seictl/cluster/internal/kube  0.970s
[etc — all packages pass]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)