### PR TITLE
feat(onboard): provision per-engineer Flux wiring + workspace branch

### DIFF
--- a/cluster/internal/githubpr/githubpr.go
+++ b/cluster/internal/githubpr/githubpr.go
@@ -90,6 +90,88 @@ func isUntrackedOrEmpty(line string) bool {
 	return line[0] == '?' && line[1] == '?'
 }
 
+// SeedBranchOptions drives PushSeedBranch.
+type SeedBranchOptions struct {
+	RepoPath      string
+	Branch        string
+	BaseBranch    string
+	CommitMessage string
+	Files         map[string][]byte
+}
+
+// SeedBranchResult names the branch ref pushed to origin.
+type SeedBranchResult struct {
+	Branch string
+	Ref    string
+}
+
+// PushSeedBranch creates Branch off origin/BaseBranch, writes Files,
+// commits, and pushes to origin. Returns the local current branch to
+// whatever it was on entry. Idempotent: if origin/Branch already
+// exists, it skips the seed and returns the existing ref.
+func PushSeedBranch(opts SeedBranchOptions) (*SeedBranchResult, error) {
+	if opts.BaseBranch == "" {
+		opts.BaseBranch = "main"
+	}
+	if _, err := runIn(opts.RepoPath, "git", "fetch", "origin", opts.BaseBranch); err != nil {
+		return nil, fmt.Errorf("git fetch origin %s: %w", opts.BaseBranch, err)
+	}
+	if exists, err := remoteBranchExists(opts.RepoPath, opts.Branch); err != nil {
+		return nil, err
+	} else if exists {
+		return &SeedBranchResult{Branch: opts.Branch, Ref: "refs/heads/" + opts.Branch}, nil
+	}
+
+	prev, err := runIn(opts.RepoPath, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	prevBranch := strings.TrimSpace(string(prev))
+
+	if err := refuseLossyCheckout(opts.RepoPath, opts.Branch); err != nil {
+		return nil, err
+	}
+	if _, err := runIn(opts.RepoPath, "git", "checkout", "-B", opts.Branch, "origin/"+opts.BaseBranch); err != nil {
+		return nil, fmt.Errorf("git checkout seed branch: %w", err)
+	}
+
+	addArgs := []string{"add"}
+	for path, body := range opts.Files {
+		full := filepath.Join(opts.RepoPath, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, body, 0o644); err != nil {
+			return nil, fmt.Errorf("write %s: %w", full, err)
+		}
+		addArgs = append(addArgs, path)
+	}
+	if _, err := runIn(opts.RepoPath, "git", addArgs...); err != nil {
+		return nil, fmt.Errorf("git add seed: %w", err)
+	}
+	if _, err := runIn(opts.RepoPath, "git", "commit", "-m", opts.CommitMessage); err != nil {
+		return nil, fmt.Errorf("git commit seed: %w", err)
+	}
+	if _, err := runIn(opts.RepoPath, "git", "push", "-u", "origin", opts.Branch); err != nil {
+		return nil, fmt.Errorf("git push seed: %w", err)
+	}
+
+	if prevBranch != "" && prevBranch != "HEAD" && prevBranch != opts.Branch {
+		if _, err := runIn(opts.RepoPath, "git", "checkout", prevBranch); err != nil {
+			return nil, fmt.Errorf("git checkout %s: %w", prevBranch, err)
+		}
+	}
+	return &SeedBranchResult{Branch: opts.Branch, Ref: "refs/heads/" + opts.Branch}, nil
+}
+
+func remoteBranchExists(repoPath, branch string) (bool, error) {
+	out, err := runIn(repoPath, "git", "ls-remote", "--heads", "origin", branch)
+	if err != nil {
+		return false, fmt.Errorf("git ls-remote origin %s: %w", branch, err)
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
 // CreatePR branches, writes files, commits, pushes, and opens a PR.
 // Idempotent against a prior partial run: a remote branch with an open
 // PR returns that PR's URL with no further mutation.

--- a/cluster/internal/githubpr/githubpr.go
+++ b/cluster/internal/githubpr/githubpr.go
@@ -90,7 +90,6 @@ func isUntrackedOrEmpty(line string) bool {
 	return line[0] == '?' && line[1] == '?'
 }
 
-// SeedBranchOptions drives PushSeedBranch.
 type SeedBranchOptions struct {
 	RepoPath      string
 	Branch        string
@@ -99,16 +98,12 @@ type SeedBranchOptions struct {
 	Files         map[string][]byte
 }
 
-// SeedBranchResult names the branch ref pushed to origin.
 type SeedBranchResult struct {
 	Branch string
 	Ref    string
 }
 
-// PushSeedBranch creates Branch off origin/BaseBranch, writes Files,
-// commits, and pushes to origin. Returns the local current branch to
-// whatever it was on entry. Idempotent: if origin/Branch already
-// exists, it skips the seed and returns the existing ref.
+// PushSeedBranch is idempotent against an existing origin/Branch.
 func PushSeedBranch(opts SeedBranchOptions) (*SeedBranchResult, error) {
 	if opts.BaseBranch == "" {
 		opts.BaseBranch = "main"

--- a/cluster/internal/onboardmanifests/onboardmanifests.go
+++ b/cluster/internal/onboardmanifests/onboardmanifests.go
@@ -1,16 +1,20 @@
 // Package onboardmanifests generates the engineer cell's Kustomize
 // resources for `seictl onboard`.
 //
-// v1 ships three files: namespace, bare ServiceAccount (the K8s anchor
-// for Pod Identity), and the kustomization that wires them together.
-// No Role / RoleBinding — engineers operate as cluster-admin via SSO
-// today; per-engineer scoped K8s identity is tracked at
+// v1 ships namespace, bare workload ServiceAccount (the K8s anchor for
+// Pod Identity), the per-engineer Flux GitRepository + Kustomization
+// that watches the workspace branch, the in-namespace flux-reconciler
+// SA + admin RoleBinding (security boundary; see sei-protocol/seictl#130),
+// and the kustomization that wires them together. No engineer Role /
+// RoleBinding for human identity — engineers operate as cluster-admin
+// via SSO today; per-engineer scoped K8s identity is tracked at
 // sei-protocol/seictl#80.
 //
-// The ServiceAccount carries no eks.amazonaws.com/role-arn annotation
-// — that's IRSA's pattern, not Pod Identity. EKS Pod Identity binds
-// server-side via (cluster, namespace, serviceAccount); annotating the
-// SA is at best a no-op and at worst misleading to readers.
+// The workload ServiceAccount carries no eks.amazonaws.com/role-arn
+// annotation — that's IRSA's pattern, not Pod Identity. EKS Pod
+// Identity binds server-side via (cluster, namespace, serviceAccount);
+// annotating the SA is at best a no-op and at worst misleading to
+// readers.
 package onboardmanifests
 
 import (
@@ -33,12 +37,21 @@ type File struct {
 	Content []byte
 }
 
-// Generate returns the three engineer-cell files at their target
-// platform-repo paths (`clusters/harbor/engineers/<alias>/...`).
+var cellTemplates = []string{
+	"namespace.yaml",
+	"workload-service-account.yaml",
+	"flux-gitrepository.yaml",
+	"flux-kustomization.yaml",
+	"flux-rbac.yaml",
+	"kustomization.yaml",
+}
+
+// Generate returns the engineer-cell files at their target platform-repo
+// paths (`clusters/harbor/engineers/<alias>/...`).
 func Generate(cell Cell) ([]File, error) {
 	dir := fmt.Sprintf("clusters/harbor/engineers/%s/", cell.Alias)
-	out := make([]File, 0, 3)
-	for _, name := range []string{"namespace.yaml", "workload-service-account.yaml", "kustomization.yaml"} {
+	out := make([]File, 0, len(cellTemplates))
+	for _, name := range cellTemplates {
 		body, err := render(name, cell)
 		if err != nil {
 			return nil, fmt.Errorf("render %s: %w", name, err)

--- a/cluster/internal/onboardmanifests/onboardmanifests.go
+++ b/cluster/internal/onboardmanifests/onboardmanifests.go
@@ -1,20 +1,5 @@
 // Package onboardmanifests generates the engineer cell's Kustomize
 // resources for `seictl onboard`.
-//
-// v1 ships namespace, bare workload ServiceAccount (the K8s anchor for
-// Pod Identity), the per-engineer Flux GitRepository + Kustomization
-// that watches the workspace branch, the in-namespace flux-reconciler
-// SA + admin RoleBinding (security boundary; see sei-protocol/seictl#130),
-// and the kustomization that wires them together. No engineer Role /
-// RoleBinding for human identity — engineers operate as cluster-admin
-// via SSO today; per-engineer scoped K8s identity is tracked at
-// sei-protocol/seictl#80.
-//
-// The workload ServiceAccount carries no eks.amazonaws.com/role-arn
-// annotation — that's IRSA's pattern, not Pod Identity. EKS Pod
-// Identity binds server-side via (cluster, namespace, serviceAccount);
-// annotating the SA is at best a no-op and at worst misleading to
-// readers.
 package onboardmanifests
 
 import (
@@ -46,8 +31,6 @@ var cellTemplates = []string{
 	"kustomization.yaml",
 }
 
-// Generate returns the engineer-cell files at their target platform-repo
-// paths (`clusters/harbor/engineers/<alias>/...`).
 func Generate(cell Cell) ([]File, error) {
 	dir := fmt.Sprintf("clusters/harbor/engineers/%s/", cell.Alias)
 	out := make([]File, 0, len(cellTemplates))

--- a/cluster/internal/onboardmanifests/onboardmanifests_test.go
+++ b/cluster/internal/onboardmanifests/onboardmanifests_test.go
@@ -5,17 +5,20 @@ import (
 	"testing"
 )
 
-func TestGenerate_ReturnsThreeFilesAtExpectedPaths(t *testing.T) {
+func TestGenerate_ReturnsAllCellFilesAtExpectedPaths(t *testing.T) {
 	files, err := Generate(Cell{Alias: "bdc", Namespace: "eng-bdc"})
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	if len(files) != 3 {
-		t.Fatalf("files: got %d, want 3", len(files))
+	if len(files) != 6 {
+		t.Fatalf("files: got %d, want 6", len(files))
 	}
 	want := map[string]bool{
 		"clusters/harbor/engineers/bdc/namespace.yaml":                false,
 		"clusters/harbor/engineers/bdc/workload-service-account.yaml": false,
+		"clusters/harbor/engineers/bdc/flux-gitrepository.yaml":       false,
+		"clusters/harbor/engineers/bdc/flux-kustomization.yaml":       false,
+		"clusters/harbor/engineers/bdc/flux-rbac.yaml":                false,
 		"clusters/harbor/engineers/bdc/kustomization.yaml":            false,
 	}
 	for _, f := range files {
@@ -59,11 +62,19 @@ func TestGenerate_ServiceAccountHasNoIRSAAnnotation(t *testing.T) {
 	}
 }
 
-func TestGenerate_KustomizationReferencesBoth(t *testing.T) {
+func TestGenerate_KustomizationReferencesAllResources(t *testing.T) {
 	files, _ := Generate(Cell{Alias: "bdc", Namespace: "eng-bdc"})
-	k := contentFor(t, files, "kustomization.yaml")
-	if !strings.Contains(k, "namespace.yaml") || !strings.Contains(k, "workload-service-account.yaml") {
-		t.Errorf("kustomization missing resource refs: %s", k)
+	k := contentFor(t, files, "/kustomization.yaml")
+	for _, want := range []string{
+		"namespace.yaml",
+		"workload-service-account.yaml",
+		"flux-gitrepository.yaml",
+		"flux-kustomization.yaml",
+		"flux-rbac.yaml",
+	} {
+		if !strings.Contains(k, want) {
+			t.Errorf("cell kustomization missing resource %q in:\n%s", want, k)
+		}
 	}
 }
 

--- a/cluster/internal/onboardmanifests/templates/flux-gitrepository.yaml
+++ b/cluster/internal/onboardmanifests/templates/flux-gitrepository.yaml
@@ -1,0 +1,16 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: eng-{{.Alias}}-workspace
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/managed-by: flux
+    tide.sei.io/cell-type: personal
+    tide.sei.io/owner: {{.Alias}}
+spec:
+  interval: 1m
+  url: ssh://git@github.com/sei-protocol/platform.git
+  ref:
+    branch: eng-{{.Alias}}-workspace
+  secretRef:
+    name: flux-system

--- a/cluster/internal/onboardmanifests/templates/flux-kustomization.yaml
+++ b/cluster/internal/onboardmanifests/templates/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: eng-{{.Alias}}-workspace
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/managed-by: flux
+    tide.sei.io/cell-type: personal
+    tide.sei.io/owner: {{.Alias}}
+spec:
+  interval: 5m
+  path: clusters/harbor/eng/{{.Alias}}
+  prune: true
+  serviceAccountName: flux-reconciler
+  sourceRef:
+    kind: GitRepository
+    name: eng-{{.Alias}}-workspace
+  targetNamespace: {{.Namespace}}

--- a/cluster/internal/onboardmanifests/templates/flux-rbac.yaml
+++ b/cluster/internal/onboardmanifests/templates/flux-rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-reconciler
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/managed-by: flux
+    tide.sei.io/cell-type: personal
+    tide.sei.io/owner: {{.Alias}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-reconciler-admin
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/managed-by: flux
+    tide.sei.io/cell-type: personal
+    tide.sei.io/owner: {{.Alias}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: flux-reconciler
+    namespace: {{.Namespace}}

--- a/cluster/internal/onboardmanifests/templates/kustomization.yaml
+++ b/cluster/internal/onboardmanifests/templates/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - workload-service-account.yaml
+  - flux-gitrepository.yaml
+  - flux-kustomization.yaml
+  - flux-rbac.yaml
 commonLabels:
   tide.sei.io/cell-type: personal
   tide.sei.io/owner: {{.Alias}}

--- a/cluster/onboard.go
+++ b/cluster/onboard.go
@@ -37,11 +37,12 @@ type OnboardResult struct {
 	ConfigPath string `json:"configPath"`
 	// Idempotent re-runs omit unchanged files (e.g. an aggregator entry
 	// already present in the resources list).
-	GeneratedFiles []string      `json:"generatedFiles"`
-	Branch         string        `json:"branch,omitempty"`
-	PRURL          string        `json:"prUrl,omitempty"`
-	AWSResources   []AWSResource `json:"awsResources"`
-	DryRun         bool          `json:"dryRun"`
+	GeneratedFiles  []string      `json:"generatedFiles"`
+	Branch          string        `json:"branch,omitempty"`
+	WorkspaceBranch string        `json:"workspaceBranch,omitempty"`
+	PRURL           string        `json:"prUrl,omitempty"`
+	AWSResources    []AWSResource `json:"awsResources"`
+	DryRun          bool          `json:"dryRun"`
 }
 
 // AWSResource action ∈ {create, exists, would-create}.
@@ -69,6 +70,7 @@ type onboardDeps struct {
 	checkGHAuth      func() error
 	checkClean       func(repoPath string) error
 	createPR         func(opts githubpr.Options) (*githubpr.Result, error)
+	pushSeedBranch   func(opts githubpr.SeedBranchOptions) (*githubpr.SeedBranchResult, error)
 	discoverRepo     func(start string) (string, error)
 	writeConfig      func(path string, c config.Config) *clioutput.Error
 }
@@ -84,6 +86,7 @@ var defaultOnboardDeps = onboardDeps{
 	checkGHAuth:      githubpr.CheckAuth,
 	checkClean:       githubpr.CheckCleanTree,
 	createPR:         githubpr.CreatePR,
+	pushSeedBranch:   githubpr.PushSeedBranch,
 	discoverRepo:     githubpr.DiscoverRepo,
 	writeConfig:      config.Write,
 }
@@ -203,6 +206,12 @@ func runOnboard(ctx context.Context, in onboardInput, out io.Writer, deps onboar
 		}
 	}
 
+	workspaceBranch := "eng-" + in.Alias + "-workspace"
+	workspaceSeedPath := fmt.Sprintf("clusters/harbor/eng/%s/.gitkeep", in.Alias)
+	if !in.NoPR {
+		generatedPaths = append(generatedPaths, workspaceSeedPath)
+	}
+
 	res := OnboardResult{
 		Alias:          in.Alias,
 		Namespace:      namespace,
@@ -211,8 +220,24 @@ func runOnboard(ctx context.Context, in onboardInput, out io.Writer, deps onboar
 		AWSResources:   awsArtifactsToResources(iamArts, piArt),
 		DryRun:         dryRun,
 	}
+	if !in.NoPR {
+		res.WorkspaceBranch = workspaceBranch
+	}
 
 	if in.Apply && !in.NoPR {
+		seedRes, serr := deps.pushSeedBranch(githubpr.SeedBranchOptions{
+			RepoPath:      repoPath,
+			Branch:        workspaceBranch,
+			BaseBranch:    "main",
+			CommitMessage: fmt.Sprintf("chore(eng/%s): seed workspace branch", in.Alias),
+			Files:         map[string][]byte{workspaceSeedPath: []byte("\n")},
+		})
+		if serr != nil {
+			return failOnboard(out, clioutput.Newf(clioutput.ExitOnboard, clioutput.CatPRCreateFailed,
+				"seed workspace branch: %v", serr))
+		}
+		res.WorkspaceBranch = seedRes.Branch
+
 		body, berr := renderPRBody(in.Alias, scope, generatedPaths)
 		if berr != nil {
 			return failOnboard(out, clioutput.Newf(clioutput.ExitOnboard, clioutput.CatPRCreateFailed,

--- a/cluster/onboard_test.go
+++ b/cluster/onboard_test.go
@@ -72,6 +72,9 @@ func onboardStubs(t *testing.T) (onboardDeps, string, string) {
 		createPR: func(opts githubpr.Options) (*githubpr.Result, error) {
 			return &githubpr.Result{Branch: opts.Branch, URL: "https://github.com/example/pr/1"}, nil
 		},
+		pushSeedBranch: func(opts githubpr.SeedBranchOptions) (*githubpr.SeedBranchResult, error) {
+			return &githubpr.SeedBranchResult{Branch: opts.Branch, Ref: "refs/heads/" + opts.Branch}, nil
+		},
 		discoverRepo: func(string) (string, error) { return repoPath, nil },
 		writeConfig:  config.Write,
 	}
@@ -109,17 +112,26 @@ func TestRunOnboard_DryRunEmitsWouldCreate(t *testing.T) {
 	if _, statErr := os.Stat(cfgPath); statErr == nil {
 		t.Errorf("config file written on dry-run at %s", cfgPath)
 	}
-	if len(data.GeneratedFiles) != 4 {
-		t.Errorf("generated files: got %d, want 4 (3 cell + aggregator)", len(data.GeneratedFiles))
+	if len(data.GeneratedFiles) != 8 {
+		t.Errorf("generated files: got %d, want 8 (6 cell + aggregator + workspace seed)", len(data.GeneratedFiles))
 	}
-	var sawAggregator bool
+	var sawAggregator, sawWorkspaceSeed bool
 	for _, p := range data.GeneratedFiles {
 		if p == "clusters/harbor/engineers/kustomization.yaml" {
 			sawAggregator = true
 		}
+		if p == "clusters/harbor/eng/bdc/.gitkeep" {
+			sawWorkspaceSeed = true
+		}
 	}
 	if !sawAggregator {
 		t.Errorf("aggregator path missing from generated files: %v", data.GeneratedFiles)
+	}
+	if !sawWorkspaceSeed {
+		t.Errorf("workspace seed path missing from generated files: %v", data.GeneratedFiles)
+	}
+	if data.WorkspaceBranch != "eng-bdc-workspace" {
+		t.Errorf("workspace branch: got %q, want eng-bdc-workspace", data.WorkspaceBranch)
 	}
 }
 


### PR DESCRIPTION
Closes sei-protocol/seictl#130.

## Summary

After this lands, `seictl onboard --apply` is one PR end-to-end. Today the onboarding PR creates namespace + RBAC + IAM but stops short — the per-engineer Flux `Kustomization` watching `eng-<alias>-workspace` doesn't exist, and engineers can `git push` to their workspace branch all day with no reconciliation. Manual platform-team handoff fills the gap. This PR closes it.

## What's added

**Three new manifest templates** under `cluster/internal/onboardmanifests/templates/`:
- `flux-gitrepository.yaml` — points at `eng-<alias>-workspace`, reuses `flux-system` deploy-key secret (verified against harbor's existing `gotk-sync.yaml`).
- `flux-kustomization.yaml` — watches `clusters/harbor/eng/<alias>`, reconciles as `flux-reconciler` SA into the `eng-<alias>` namespace.
- `flux-rbac.yaml` — `flux-reconciler` SA + **RoleBinding** (not ClusterRoleBinding) to \`admin\` ClusterRole. Namespace-scoped boundary is the load-bearing security control.

The cell \`kustomization.yaml\` aggregator now lists all three new files.

**Workspace branch creation** in \`cluster/onboard.go\`:
- Branches off main, seeds \`clusters/harbor/eng/<alias>/.gitkeep\`, pushes \`eng-<alias>-workspace\` to origin.
- Runs BEFORE the onboarding PR is opened (Flux's first reconcile after merge would fail with \"ref not found\" otherwise).
- New helper \`PushSeedBranch\` in \`cluster/internal/githubpr/githubpr.go\` — idempotent against existing \`origin/<branch>\`; restores caller's prior branch on success.

**Envelope schema** — additive \`WorkspaceBranch string\` on \`OnboardResult\` (\`omitempty\`). Dry-run emits the planned branch + planned seed file in \`GeneratedFiles\`. No schema break for legacy callers.

## Verification

- \`GOWORK=off go build ./cluster/...\` clean.
- \`GOWORK=off go test ./cluster/internal/onboardmanifests/ ./cluster/\` clean.
- \`kubectl --context harbor get gitrepository -n flux-system flux-system -o yaml\` confirmed the existing \`secretRef.name: flux-system\` + SSH URL pattern.

## Acceptance criteria from #130

- [x] Single PR with all six manifests (namespace + RBAC + SA + GitRepository + Kustomization + flux-rbac).
- [x] \`eng-<alias>-workspace\` branch pushed BEFORE onboarding PR opens.
- [x] Dry-run envelope carries planned branch + planned seed file.
- [x] \`OnboardResult\` schema additive (\`omitempty\`).
- [x] Conventional-commit scope: \`feat(onboard): ...\`.

End-to-end verification (post-merge Kustomization Ready=True, malicious-manifest reject, etc.) needs a real onboarding run on harbor.

## Out of scope (per #130)

Custom narrower ClusterRole, path rename, prune tier-gating, PSA labels, configurable interval, offboard verb, existing-engineer migration — all tracked as deferred un-defer triggers in #130.