### PR TITLE
feat(nodedeployment): add get / list / delete verbs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/urfave/cli/v3 v3.6.1
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
+	k8s.io/cli-runtime v0.36.0
 	k8s.io/client-go v0.36.0
 	modernc.org/sqlite v1.18.1
 	sigs.k8s.io/controller-runtime v0.23.0
@@ -48,6 +49,7 @@ replace (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/RaduBerinde/axisds v0.0.0-20250419182453-5135a0650657 // indirect
@@ -155,10 +157,12 @@ require (
 	github.com/ledgerwatch/erigon-lib v0.0.0-20230210071639-db0e7ed11263 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/minio/minlz v1.0.1-0.20250507153514-87eb42fe8882 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mtibben/percent v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -912,6 +912,8 @@ github.com/creachadair/taskgroup v0.3.2 h1:zlfutDS+5XG40AOxcHDSThxKzns8Tnr9jnr6V
 github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+kq+TDlRJQ0Wbk=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
@@ -1510,6 +1512,8 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linxGnu/grocksdb v1.8.11 h1:BGol9e5gB1BrsTvOxloC88pe70TCqgrfLNwkyWW0kD8=
@@ -1587,6 +1591,8 @@ github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjU
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
+github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
+github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -2947,6 +2953,8 @@ k8s.io/apiextensions-apiserver v0.35.0 h1:3xHk2rTOdWXXJM+RDQZJvdx0yEOgC0FgQ1PlJa
 k8s.io/apiextensions-apiserver v0.35.0/go.mod h1:E1Ahk9SADaLQ4qtzYFkwUqusXTcaV2uw3l14aqpL2LU=
 k8s.io/apimachinery v0.36.0 h1:jZyPzhd5Z+3h9vJLt0z9XdzW9VzNzWAUw+P1xZ9PXtQ=
 k8s.io/apimachinery v0.36.0/go.mod h1:FklypaRJt6n5wUIwWXIP6GJlIpUizTgfo1T/As+Tyxc=
+k8s.io/cli-runtime v0.36.0 h1:HNxciQpQMMOKS0/GiUXcKDyA6J2FDILJj9NmP2BZrTg=
+k8s.io/cli-runtime v0.36.0/go.mod h1:KObkknK9Ro5LYX+1RdiKc7C8CvGg4aX+V/Zv+E8WPHA=
 k8s.io/client-go v0.36.0 h1:pOYi7C4RHChYjMiHpZSpSbIM6ZxVbRXBy7CuiIwqA3c=
 k8s.io/client-go v0.36.0/go.mod h1:ZKKcpwF0aLYfkHFCjillCKaTK/yBkEDHTDXCFY6AS9Y=
 k8s.io/component-base v0.35.0 h1:+yBrOhzri2S1BVqyVSvcM3PtPyx5GUxCK2tinZz1G94=

--- a/internal/snd/snd.go
+++ b/internal/snd/snd.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	GVK        = schema.GroupVersionKind{Group: "sei.io", Version: "v1alpha1", Kind: "SeiNodeDeployment"}
+	ListGVK    = schema.GroupVersionKind{Group: "sei.io", Version: "v1alpha1", Kind: "SeiNodeDeploymentList"}
 	FieldOwner = client.FieldOwner("seictl")
 )
 
@@ -21,6 +22,12 @@ func New() *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(GVK)
 	return obj
+}
+
+func NewList() *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(ListGVK)
+	return list
 }
 
 // Apply server-side-applies obj as the seictl FieldManager, mutating

--- a/nodedeployment/cmd.go
+++ b/nodedeployment/cmd.go
@@ -16,5 +16,8 @@ var Cmd = cli.Command{
 	Usage:   "Manage SeiNodeDeployment custom resources via embedded presets",
 	Commands: []*cli.Command{
 		&applyCmd,
+		&getCmd,
+		&listCmd,
+		&deleteCmd,
 	},
 }

--- a/nodedeployment/delete.go
+++ b/nodedeployment/delete.go
@@ -1,0 +1,97 @@
+package nodedeployment
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sei-protocol/seictl/internal/snd"
+)
+
+func parseCascade(raw string) (*metav1.DeletionPropagation, error) {
+	switch raw {
+	case "", "foreground":
+		p := metav1.DeletePropagationForeground
+		return &p, nil
+	case "background":
+		p := metav1.DeletePropagationBackground
+		return &p, nil
+	case "orphan":
+		p := metav1.DeletePropagationOrphan
+		return &p, nil
+	}
+	return nil, fmt.Errorf("invalid --cascade %q (use foreground|background|orphan)", raw)
+}
+
+func deleteAction(ctx context.Context, c *cli.Command) error {
+	name := c.StringArg("name")
+	if name == "" {
+		emitStatus(os.Stderr, usageError("name argument required: seictl nd delete <name>"))
+		return cli.Exit("", 1)
+	}
+
+	cascade, err := parseCascade(c.String("cascade"))
+	if err != nil {
+		emitStatus(os.Stderr, usageError("%s", err.Error()))
+		return cli.Exit("", 1)
+	}
+
+	kc := loadKubeconfig(c.String("kubeconfig"), c.String("namespace"))
+	cfg, err := kc.RESTConfig()
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+	ns, err := kc.Namespace()
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+
+	kcli, err := newClient(cfg)
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+
+	obj := snd.New()
+	obj.SetName(name)
+	obj.SetNamespace(ns)
+	if err := kcli.Delete(ctx, obj, &client.DeleteOptions{PropagationPolicy: cascade}); err != nil {
+		emitStatus(os.Stderr, fmt.Errorf("delete SeiNodeDeployment %s/%s: %w", ns, name, err))
+		return cli.Exit("", 1)
+	}
+	fmt.Printf("seinodedeployment.sei.io/%s deleted\n", name)
+	return nil
+}
+
+var deleteCmd = cli.Command{
+	Name:      "delete",
+	Usage:     "Delete a SeiNodeDeployment by name",
+	ArgsUsage: "<name>",
+	Arguments: []cli.Argument{
+		&cli.StringArg{Name: "name", UsageText: "metadata.name of the SeiNodeDeployment"},
+	},
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "namespace",
+			Aliases: []string{"n"},
+			Usage:   "Target namespace (defaults to kubeconfig context or in-cluster SA)",
+		},
+		&cli.StringFlag{
+			Name:  "cascade",
+			Value: "foreground",
+			Usage: "Propagation policy: foreground (default) | background | orphan",
+		},
+		&cli.StringFlag{
+			Name:    "kubeconfig",
+			Sources: cli.EnvVars("KUBECONFIG"),
+			Usage:   "Path to kubeconfig (honors KUBECONFIG colon-merge); defaults to $HOME/.kube/config or in-cluster",
+		},
+	},
+	Action: deleteAction,
+}

--- a/nodedeployment/delete_test.go
+++ b/nodedeployment/delete_test.go
@@ -1,0 +1,38 @@
+package nodedeployment
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseCascade(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want metav1.DeletionPropagation
+	}{
+		{"", metav1.DeletePropagationForeground},
+		{"foreground", metav1.DeletePropagationForeground},
+		{"background", metav1.DeletePropagationBackground},
+		{"orphan", metav1.DeletePropagationOrphan},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, err := parseCascade(tc.raw)
+			if err != nil {
+				t.Fatalf("parseCascade(%q): %v", tc.raw, err)
+			}
+			if *got != tc.want {
+				t.Errorf("got %q; want %q", *got, tc.want)
+			}
+		})
+	}
+
+	for _, bad := range []string{"async", "FOREGROUND", "delete"} {
+		t.Run("bad/"+bad, func(t *testing.T) {
+			if _, err := parseCascade(bad); err == nil {
+				t.Errorf("expected error for %q", bad)
+			}
+		})
+	}
+}

--- a/nodedeployment/get.go
+++ b/nodedeployment/get.go
@@ -1,0 +1,81 @@
+package nodedeployment
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sei-protocol/seictl/internal/snd"
+)
+
+func getAction(ctx context.Context, c *cli.Command) error {
+	name := c.StringArg("name")
+	if name == "" {
+		emitStatus(os.Stderr, usageError("name argument required: seictl nd get <name>"))
+		return cli.Exit("", 1)
+	}
+
+	printer, err := makePrinter(c.String("output"))
+	if err != nil {
+		emitStatus(os.Stderr, usageError("%s", err.Error()))
+		return cli.Exit("", 1)
+	}
+
+	kc := loadKubeconfig(c.String("kubeconfig"), c.String("namespace"))
+	cfg, err := kc.RESTConfig()
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+	ns, err := kc.Namespace()
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+
+	kcli, err := newClient(cfg)
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+
+	obj := snd.New()
+	if err := kcli.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, obj); err != nil {
+		emitStatus(os.Stderr, fmt.Errorf("get SeiNodeDeployment %s/%s: %w", ns, name, err))
+		return cli.Exit("", 1)
+	}
+	if err := printer.PrintObj(obj, os.Stdout); err != nil {
+		return fmt.Errorf("print: %w", err)
+	}
+	return nil
+}
+
+var getCmd = cli.Command{
+	Name:      "get",
+	Usage:     "Read a SeiNodeDeployment by name",
+	ArgsUsage: "<name>",
+	Arguments: []cli.Argument{
+		&cli.StringArg{Name: "name", UsageText: "metadata.name of the SeiNodeDeployment"},
+	},
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "namespace",
+			Aliases: []string{"n"},
+			Usage:   "Target namespace (defaults to kubeconfig context or in-cluster SA)",
+		},
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "Output format: yaml (default) | json | name | jsonpath=<template>",
+		},
+		&cli.StringFlag{
+			Name:    "kubeconfig",
+			Sources: cli.EnvVars("KUBECONFIG"),
+			Usage:   "Path to kubeconfig (honors KUBECONFIG colon-merge); defaults to $HOME/.kube/config or in-cluster",
+		},
+	},
+	Action: getAction,
+}

--- a/nodedeployment/list.go
+++ b/nodedeployment/list.go
@@ -1,0 +1,101 @@
+package nodedeployment
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sei-protocol/seictl/internal/snd"
+)
+
+func listAction(ctx context.Context, c *cli.Command) error {
+	allNS := c.Bool("all-namespaces")
+
+	printer, err := makePrinter(c.String("output"))
+	if err != nil {
+		emitStatus(os.Stderr, usageError("%s", err.Error()))
+		return cli.Exit("", 1)
+	}
+
+	var sel labels.Selector
+	if raw := c.String("selector"); raw != "" {
+		sel, err = labels.Parse(raw)
+		if err != nil {
+			emitStatus(os.Stderr, usageError("parse --selector: %s", err.Error()))
+			return cli.Exit("", 1)
+		}
+	}
+
+	kc := loadKubeconfig(c.String("kubeconfig"), c.String("namespace"))
+	cfg, err := kc.RESTConfig()
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+
+	listOpts := []client.ListOption{}
+	if !allNS {
+		ns, err := kc.Namespace()
+		if err != nil {
+			emitStatus(os.Stderr, err)
+			return cli.Exit("", 1)
+		}
+		listOpts = append(listOpts, client.InNamespace(ns))
+	}
+	if sel != nil {
+		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: sel})
+	}
+
+	kcli, err := newClient(cfg)
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+
+	list := snd.NewList()
+	if err := kcli.List(ctx, list, listOpts...); err != nil {
+		emitStatus(os.Stderr, fmt.Errorf("list SeiNodeDeployments: %w", err))
+		return cli.Exit("", 1)
+	}
+	if err := printer.PrintObj(list, os.Stdout); err != nil {
+		return fmt.Errorf("print: %w", err)
+	}
+	return nil
+}
+
+var listCmd = cli.Command{
+	Name:  "list",
+	Usage: "List SeiNodeDeployments",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "namespace",
+			Aliases: []string{"n"},
+			Usage:   "Target namespace (defaults to kubeconfig context or in-cluster SA)",
+		},
+		&cli.BoolFlag{
+			Name:    "all-namespaces",
+			Aliases: []string{"A"},
+			Usage:   "List across all namespaces; overrides --namespace",
+		},
+		&cli.StringFlag{
+			Name:    "selector",
+			Aliases: []string{"l"},
+			Usage:   "Label selector (e.g. -l env=nightly,role=validator)",
+		},
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "Output format: yaml (default) | json | name | jsonpath=<template>",
+		},
+		&cli.StringFlag{
+			Name:    "kubeconfig",
+			Sources: cli.EnvVars("KUBECONFIG"),
+			Usage:   "Path to kubeconfig (honors KUBECONFIG colon-merge); defaults to $HOME/.kube/config or in-cluster",
+		},
+	},
+	Action: listAction,
+}

--- a/nodedeployment/output.go
+++ b/nodedeployment/output.go
@@ -1,0 +1,34 @@
+package nodedeployment
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/cli-runtime/pkg/printers"
+)
+
+// makePrinter returns a printer for -o values: yaml (default), json,
+// name (kind/name), jsonpath=<template>. Anything else is a usage error
+// the caller surfaces via emitStatus.
+func makePrinter(format string) (printers.ResourcePrinter, error) {
+	switch {
+	case format == "" || format == "yaml":
+		return &printers.YAMLPrinter{}, nil
+	case format == "json":
+		return &printers.JSONPrinter{}, nil
+	case format == "name":
+		return &printers.NamePrinter{}, nil
+	case strings.HasPrefix(format, "jsonpath="):
+		tmpl := strings.TrimPrefix(format, "jsonpath=")
+		if tmpl == "" {
+			return nil, fmt.Errorf("empty jsonpath template")
+		}
+		p, err := printers.NewJSONPathPrinter(tmpl)
+		if err != nil {
+			return nil, fmt.Errorf("invalid jsonpath: %w", err)
+		}
+		return p, nil
+	default:
+		return nil, fmt.Errorf("unknown -o format %q (use yaml|json|name|jsonpath=...)", format)
+	}
+}

--- a/nodedeployment/output_test.go
+++ b/nodedeployment/output_test.go
@@ -1,0 +1,97 @@
+package nodedeployment
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func sampleSND() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "sei.io/v1alpha1",
+			"kind":       "SeiNodeDeployment",
+			"metadata":   map[string]interface{}{"name": "demo", "namespace": "nightly"},
+			"spec":       map[string]interface{}{"replicas": int64(2)},
+		},
+	}
+	return obj
+}
+
+func TestMakePrinter_Formats(t *testing.T) {
+	cases := []struct {
+		format   string
+		contains []string
+	}{
+		{"", []string{"apiVersion: sei.io/v1alpha1", "kind: SeiNodeDeployment"}},
+		{"yaml", []string{"apiVersion: sei.io/v1alpha1", "kind: SeiNodeDeployment"}},
+		{"json", []string{`"apiVersion": "sei.io/v1alpha1"`, `"kind": "SeiNodeDeployment"`}},
+		{"name", []string{"seinodedeployment.sei.io/demo"}},
+		{"jsonpath={.metadata.name}", []string{"demo"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.format, func(t *testing.T) {
+			p, err := makePrinter(tc.format)
+			if err != nil {
+				t.Fatalf("makePrinter(%q): %v", tc.format, err)
+			}
+			var buf bytes.Buffer
+			if err := p.PrintObj(sampleSND(), &buf); err != nil {
+				t.Fatalf("PrintObj: %v", err)
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("output missing %q\ngot:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+func TestMakePrinter_Errors(t *testing.T) {
+	cases := []string{"xml", "table", "jsonpath=", "jsonpath={.bad"}
+	for _, format := range cases {
+		t.Run(format, func(t *testing.T) {
+			if _, err := makePrinter(format); err == nil {
+				t.Errorf("expected error for format %q", format)
+			}
+		})
+	}
+}
+
+func TestMakePrinter_NamePrintsListItems(t *testing.T) {
+	list := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"apiVersion": "sei.io/v1alpha1",
+			"kind":       "SeiNodeDeploymentList",
+		},
+		Items: []unstructured.Unstructured{
+			{Object: map[string]interface{}{
+				"apiVersion": "sei.io/v1alpha1",
+				"kind":       "SeiNodeDeployment",
+				"metadata":   map[string]interface{}{"name": "a", "namespace": "ns1"},
+			}},
+			{Object: map[string]interface{}{
+				"apiVersion": "sei.io/v1alpha1",
+				"kind":       "SeiNodeDeployment",
+				"metadata":   map[string]interface{}{"name": "b", "namespace": "ns1"},
+			}},
+		},
+	}
+	p, err := makePrinter("name")
+	if err != nil {
+		t.Fatalf("makePrinter: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := p.PrintObj(list, &buf); err != nil {
+		t.Fatalf("PrintObj: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"seinodedeployment.sei.io/a", "seinodedeployment.sei.io/b"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PR-2 of three. Per [`docs/design/nodedeployment-cli.md`](docs/design/nodedeployment-cli.md).

- \`seictl nd get <name> [-n] [-o yaml|json|name|jsonpath=...]\` — read SND through controller-runtime; output via \`k8s.io/cli-runtime/pkg/printers\`.
- \`seictl nd list [-n] [-A] [-l selector] [-o ...]\` — list with kubectl flag conventions.
- \`seictl nd delete <name> [-n] [--cascade=foreground|background|orphan]\` — \`foreground\` default per design.

\`internal/snd\` gains \`ListGVK\` + \`NewList()\` for unstructured list machinery (deferred from PR-1's cleanliness pass).

## Verified end-to-end against harbor

\`\`\`
$ seictl nd list -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}'
release-6-5/release-6-5
release-6-5/release-6-5-rpc-0
release-6-5/release-6-5-rpc-1
release-6-5/release-6-5-rpc-2

$ seictl nd get release-6-5 -n release-6-5 -o jsonpath='{.metadata.name} replicas={.spec.replicas} phase={.status.phase}{"\n"}'
release-6-5 replicas=10 phase=Ready

$ seictl nd delete nonexistent-snd -n default
{
  "kind": "Status",
  "status": "Failure",
  "reason": "NotFound",
  "code": 404,
  ...
}
exit: 1
\`\`\`

## Test plan

- [x] Unit tests for \`makePrinter\` (yaml/json/name/jsonpath/invalid) and \`parseCascade\`.
- [x] Live get/list/delete round-trip against harbor.
- [x] Live cross-namespace listing once the orchestrator pulls in v0.0.42.

## Deferred to PR-3

- \`nd watch\` with \`client-go watch.UntilWithSync\` + \`kubectl/pkg/cmd/wait\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)