### PR TITLE
feat(nodedeployment): add watch verb with NDJSON streaming

### DIFF
--- a/nodedeployment/cmd.go
+++ b/nodedeployment/cmd.go
@@ -19,5 +19,6 @@ var Cmd = cli.Command{
 		&getCmd,
 		&listCmd,
 		&deleteCmd,
+		&watchCmd,
 	},
 }

--- a/nodedeployment/watch.go
+++ b/nodedeployment/watch.go
@@ -1,0 +1,171 @@
+package nodedeployment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	toolswatch "k8s.io/client-go/tools/watch"
+)
+
+var sndGVR = schema.GroupVersionResource{Group: "sei.io", Version: "v1alpha1", Resource: "seinodedeployments"}
+
+// matchPhase decides whether a single SND event satisfies the --until
+// condition. Returns (true, nil) on match, (false, error) on terminal
+// Failed phase, (false, nil) otherwise so the watch keeps streaming.
+func matchPhase(obj *unstructured.Unstructured, until string) (bool, error) {
+	phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
+	if phase == until {
+		return true, nil
+	}
+	if phase == "Failed" {
+		msg, _, _ := unstructured.NestedString(obj.Object, "status", "plan", "failedTaskDetail", "error")
+		if msg == "" {
+			msg = "(no failedTaskDetail.error on status.plan)"
+		}
+		return false, fmt.Errorf("terminal Failed phase: %s", msg)
+	}
+	return false, nil
+}
+
+func watchAction(ctx context.Context, c *cli.Command) error {
+	name := c.StringArg("name")
+	if name == "" {
+		emitStatus(os.Stderr, usageError("name argument required: seictl nd watch <name>"))
+		return cli.Exit("", 1)
+	}
+	until := c.String("until")
+	if until == "" {
+		emitStatus(os.Stderr, usageError("--until=<phase> is required (e.g. --until=Ready)"))
+		return cli.Exit("", 1)
+	}
+	timeout := c.Duration("timeout")
+
+	kc := loadKubeconfig(c.String("kubeconfig"), c.String("namespace"))
+	cfg, err := kc.RESTConfig()
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+	ns, err := kc.Namespace()
+	if err != nil {
+		emitStatus(os.Stderr, err)
+		return cli.Exit("", 1)
+	}
+
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		emitStatus(os.Stderr, fmt.Errorf("build dynamic client: %w", err))
+		return cli.Exit("", 1)
+	}
+	resource := dyn.Resource(sndGVR).Namespace(ns)
+	fieldSelector := "metadata.name=" + name
+	lw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			return resource.List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			return resource.Watch(ctx, opts)
+		},
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	condition := func(event watch.Event) (bool, error) {
+		if event.Type == watch.Error {
+			return false, apierrors.FromObject(event.Object)
+		}
+		obj, ok := event.Object.(*unstructured.Unstructured)
+		if !ok {
+			return false, fmt.Errorf("unexpected object type %T", event.Object)
+		}
+		if err := enc.Encode(obj.Object); err != nil {
+			return false, fmt.Errorf("encode NDJSON: %w", err)
+		}
+		return matchPhase(obj, until)
+	}
+
+	watchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	_, err = toolswatch.UntilWithSync(watchCtx, lw, &unstructured.Unstructured{}, nil, condition)
+	if err != nil {
+		// UntilWithSync returns wait.ErrWaitTimeout for both deadline
+		// and cancellation; the watchCtx error preserves which one.
+		if ctxErr := watchCtx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
+		emitStatus(os.Stderr, watchExitError(err, name, ns, until, timeout))
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+// watchExitError shapes the err that came out of UntilWithSync into a
+// metav1.Status so stderr discrimination (`jq -r .reason`) covers
+// timeout / NotFound / terminal-Failed-phase / transient API failure
+// uniformly.
+func watchExitError(err error, name, ns, until string, timeout time.Duration) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &apierrors.StatusError{ErrStatus: metav1.Status{
+			TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+			Status:   metav1.StatusFailure,
+			Reason:   metav1.StatusReasonTimeout,
+			Message:  fmt.Sprintf("watch %s/%s timed out after %s waiting for phase=%s", ns, name, timeout, until),
+			Code:     http.StatusGatewayTimeout,
+		}}
+	}
+	return err
+}
+
+var watchCmd = cli.Command{
+	Name:      "watch",
+	Usage:     "Stream SeiNodeDeployment events as NDJSON until a phase is reached",
+	ArgsUsage: "<name>",
+	Description: "Streams every SND event for <name> as one NDJSON line on " +
+		"stdout, exiting 0 when .status.phase matches --until or 1 on " +
+		"timeout, terminal Failed phase, or transient API error. " +
+		"Discrimination on stderr via metav1.Status.reason (Timeout, " +
+		"InternalError, etc.). Subsumes `kubectl wait --for=jsonpath=` " +
+		"for orchestrator scripts.",
+	Arguments: []cli.Argument{
+		&cli.StringArg{Name: "name", UsageText: "metadata.name of the SeiNodeDeployment"},
+	},
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "namespace",
+			Aliases: []string{"n"},
+			Usage:   "Target namespace (defaults to kubeconfig context or in-cluster SA)",
+		},
+		&cli.StringFlag{
+			Name:     "until",
+			Required: true,
+			Usage:    "Phase to wait for (e.g. --until=Ready). Matches .status.phase exactly.",
+		},
+		&cli.DurationFlag{
+			Name:  "timeout",
+			Value: 15 * time.Minute,
+			Usage: "Watch timeout; exits with metav1.Status reason=Timeout when exceeded",
+		},
+		&cli.StringFlag{
+			Name:    "kubeconfig",
+			Sources: cli.EnvVars("KUBECONFIG"),
+			Usage:   "Path to kubeconfig (honors KUBECONFIG colon-merge); defaults to $HOME/.kube/config or in-cluster",
+		},
+	},
+	Action: watchAction,
+}

--- a/nodedeployment/watch_test.go
+++ b/nodedeployment/watch_test.go
@@ -1,0 +1,89 @@
+package nodedeployment
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func sndWithPhase(phase, failedErr string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "sei.io/v1alpha1",
+		"kind":       "SeiNodeDeployment",
+		"metadata":   map[string]interface{}{"name": "demo", "namespace": "nightly"},
+	}}
+	if phase != "" {
+		_ = unstructured.SetNestedField(obj.Object, phase, "status", "phase")
+	}
+	if failedErr != "" {
+		_ = unstructured.SetNestedField(obj.Object, failedErr, "status", "plan", "failedTaskDetail", "error")
+	}
+	return obj
+}
+
+func TestMatchPhase(t *testing.T) {
+	cases := []struct {
+		name      string
+		obj       *unstructured.Unstructured
+		until     string
+		wantDone  bool
+		wantError string
+	}{
+		{"match", sndWithPhase("Ready", ""), "Ready", true, ""},
+		{"no phase yet", sndWithPhase("", ""), "Ready", false, ""},
+		{"intermediate phase", sndWithPhase("Provisioning", ""), "Ready", false, ""},
+		{"failed surfaces error", sndWithPhase("Failed", "task seid-init failed: oom"), "Ready", false, "terminal Failed phase: task seid-init failed: oom"},
+		{"failed without detail", sndWithPhase("Failed", ""), "Ready", false, "(no failedTaskDetail.error on status.plan)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			done, err := matchPhase(tc.obj, tc.until)
+			if done != tc.wantDone {
+				t.Errorf("done = %v; want %v", done, tc.wantDone)
+			}
+			if tc.wantError == "" && err != nil {
+				t.Errorf("err = %v; want nil", err)
+			}
+			if tc.wantError != "" {
+				if err == nil {
+					t.Fatalf("err = nil; want containing %q", tc.wantError)
+				}
+				if !strings.Contains(err.Error(), tc.wantError) {
+					t.Errorf("err = %q; want containing %q", err.Error(), tc.wantError)
+				}
+			}
+		})
+	}
+}
+
+func TestWatchExitError_TimeoutShapedAsStatus(t *testing.T) {
+	err := watchExitError(context.DeadlineExceeded, "demo", "nightly", "Ready", 5*time.Minute)
+	var apiErr apierrors.APIStatus
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v; want APIStatus", err)
+	}
+	s := apiErr.Status()
+	if s.Reason != metav1.StatusReasonTimeout {
+		t.Errorf("reason = %q; want Timeout", s.Reason)
+	}
+	if s.Code != 504 {
+		t.Errorf("code = %d; want 504", s.Code)
+	}
+	if !strings.Contains(s.Message, "nightly/demo") || !strings.Contains(s.Message, "Ready") {
+		t.Errorf("message %q missing namespace/name/until", s.Message)
+	}
+}
+
+func TestWatchExitError_NonTimeoutPassesThrough(t *testing.T) {
+	in := errors.New("some watch error")
+	out := watchExitError(in, "demo", "nightly", "Ready", time.Minute)
+	if !errors.Is(out, in) {
+		t.Errorf("non-timeout err must pass through unchanged; got %v", out)
+	}
+}


### PR DESCRIPTION
## Summary

PR-3 (final) of the nodedeployment CLI per [\`docs/design/nodedeployment-cli.md\`](docs/design/nodedeployment-cli.md).

\`seictl nd watch <name> --until=<phase> [--timeout=15m]\` streams SND events as one NDJSON line per event and exits 0 when \`.status.phase\` matches \`--until\`. Built on \`k8s.io/client-go/tools/watch.UntilWithSync\` (reconnect + initial sync) over the dynamic client.

## Failure shapes (all uniform \`metav1.Status\` on stderr)

- **Timeout** → \`reason=Timeout, code=504\`. \`UntilWithSync\` masks ctx errors behind \`wait.ErrWaitTimeout\`; recovered via \`watchCtx.Err()\` before shaping.
- **Terminal Failed phase** → \`matchPhase\` lifts \`.status.plan.failedTaskDetail.error\` onto stderr.
- **Transient API error** → \`apierrors.FromObject(event.Object)\` for \`watch.Error\` events.

## Verified against harbor

\`\`\`
$ seictl nd watch release-6-5 -n release-6-5 --until=Ready --timeout=10s
<one NDJSON line — initial-sync emitted the existing Ready SND>
exit: 0

$ seictl nd watch release-6-5 -n release-6-5 --until=NeverReached --timeout=3s
{
  "reason": "Timeout",
  "code": 504,
  "message": "watch release-6-5/release-6-5 timed out after 3s waiting for phase=NeverReached",
  ...
}
exit: 1
\`\`\`

## Test plan

- [x] Unit tests for \`matchPhase\` (match / no-phase / intermediate / terminal-Failed-with-detail / terminal-Failed-without-detail).
- [x] Unit tests for \`watchExitError\` (timeout shaping, non-timeout passthrough).
- [x] Live end-to-end against harbor.

## v1 complete

Three PRs landed against the design:

- PR-1 (#137) — apply + presets + scaffolding
- PR-2 (#141) — get/list/delete
- PR-3 (this) — watch

Deferred to follow-ups:

- Envtest harness for SSA round-trip (CRD vendoring + test wiring).
- \`fork-genesis\` preset (sei-protocol/seictl#134, blocked on \`sei-k8s-controller\` fork-genesis feature).
- \`.status.endpoints\` in seictl output (sei-k8s-controller#171, blocked on upstream).
- \`--until\` jsonpath / condition grammar variants (un-defer when an orchestrator asks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)