### PR TITLE
chore(deps): bump sei-config to v0.0.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7
-	github.com/sei-protocol/sei-config v0.0.12
+	github.com/sei-protocol/sei-config v0.0.13
 	github.com/sei-protocol/seilog v0.0.3
 	github.com/urfave/cli/v3 v3.6.1
 	k8s.io/api v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1855,8 +1855,8 @@ github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQp
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:kW+yxMoSm4RvpP5VT5lFfSa+dqnOE9ZpapE2qNIJwvc=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
-github.com/sei-protocol/sei-config v0.0.12 h1:pv0IIM8c4sKPoNOvUEIx0OAp+X+coDlBibHUPbBZGxI=
-github.com/sei-protocol/sei-config v0.0.12/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.13 h1:F3J6ZyQo/rBQVgmleOAWVugGD7x1l5VTgsNK9JmtWmk=
+github.com/sei-protocol/sei-config v0.0.13/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082/go.mod h1:V0fNURAjS6A8+sA1VllegjNeSobay3oRUW5VFZd04bA=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=


### PR DESCRIPTION
## Summary

Picks up sei-config v0.0.13, which adds the new `[receipt-store]` config section and archive zero-pruning defaults (sei-protocol/sei-config#11).

## What this enables

When seictl emits app.toml for archive nodes, it now writes:

```toml
[receipt-store]
backend = "pebbledb"
db-directory = ""
async-write-buffer = 100
keep-recent = 0
prune-interval-seconds = 0
tx-index-backend = "pebbledb"
```

The retention semantics are documented in sei-config#11 — `min-retain-blocks=0` is the load-bearing knob on post-#3237 sei-chain; the receipt-store keys are emitted to self-document intent.

## Test plan

- [x] `go get github.com/sei-protocol/sei-config@v0.0.13 && go mod tidy`
- [x] `go build ./...` clean
- [x] `go test ./...` clean across all sidecar packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)