### PR TITLE
test(client): add TestSetGenesisPeersRoundTrip

### DIFF
--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -243,6 +243,20 @@ func TestMarkReadyRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSetGenesisPeersRoundTrip(t *testing.T) {
+	task := SetGenesisPeersTask{}
+	if err := task.Validate(); err != nil {
+		t.Fatalf("Validate() = %v", err)
+	}
+	req := task.ToTaskRequest()
+	if req.Type != TaskTypeSetGenesisPeers {
+		t.Errorf("Type = %q, want %q", req.Type, TaskTypeSetGenesisPeers)
+	}
+	if req.Params != nil {
+		t.Errorf("Params = %v, want nil", req.Params)
+	}
+}
+
 func TestSnapshotRestoreValidation(t *testing.T) {
 	// SnapshotRestoreTask has no required fields — TargetHeight=0 means "use latest"
 	cases := []struct {


### PR DESCRIPTION
## Summary

Mirrors `TestMarkReadyRoundTrip` (`tasks_test.go:232-244`) — empty-struct task contract with nil `Params`. Closes the test-coverage gap flagged in cross-review of #150 (which added the `SetGenesisPeersTask` typed wrapper without a round-trip test).

## Verification

- [x] `go test ./sidecar/client/... -run RoundTrip -v` — passes
- [x] `make lint` clean
- [x] 14 lines, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)