### PR TITLE
feat(shadow): emit divergence + blocks-compared metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,6 +154,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/ledgerwatch/erigon-lib v0.0.0-20230210071639-db0e7ed11263 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect

--- a/serve.go
+++ b/serve.go
@@ -45,6 +45,16 @@ var serveCmd = cli.Command{
 		snapshotBucket := os.Getenv("SEI_SNAPSHOT_BUCKET")
 		snapshotRegion := os.Getenv("SEI_SNAPSHOT_REGION")
 
+		podName := os.Getenv("HOSTNAME")
+		if podName == "" {
+			if h, err := os.Hostname(); err == nil {
+				podName = h
+			}
+		}
+		if podName == "" {
+			podName = "unknown"
+		}
+
 		for _, kv := range []struct{ name, val string }{
 			{"SEI_CHAIN_ID", chainID},
 			{"SEI_GENESIS_BUCKET", genesisBucket},
@@ -96,7 +106,7 @@ var serveCmd = cli.Command{
 			engine.TaskConfigureGenesis:         tasks.NewGenesisFetcher(homeDir, chainID, genesisBucket, genesisRegion, nil).Handler(),
 			engine.TaskConfigureStateSync:       tasks.NewStateSyncConfigurer(homeDir, nil).Handler(),
 			engine.TaskSnapshotUpload:           snapshotUploader.Handler(),
-			engine.TaskResultExport:             tasks.NewResultExporter(homeDir, nil).Handler(),
+			engine.TaskResultExport:             tasks.NewResultExporter(homeDir, chainID, podName, nil).Handler(),
 			engine.TaskAwaitCondition:           tasks.NewConditionWaiter(nil).Handler(),
 			engine.TaskGenerateIdentity:         tasks.NewIdentityGenerator(homeDir).Handler(),
 			engine.TaskGenerateGentx:            tasks.NewGentxGenerator(homeDir).Handler(),

--- a/sidecar/shadow/metrics.go
+++ b/sidecar/shadow/metrics.go
@@ -1,0 +1,35 @@
+package shadow
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	// BlocksCompared counts blocks the comparator has processed.
+	// rate(...)==0 indicates the comparator has stopped advancing — typically
+	// shadow RPC unreachable or the local node has stopped producing blocks.
+	// pod_name differentiates two shadow candidates for the same chain so
+	// alerts can route to a specific candidate image.
+	BlocksCompared = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "seictl_shadow_blocks_compared_total",
+			Help: "Total blocks compared between the shadow node and the canonical chain.",
+		},
+		[]string{"chain_id", "pod_name"},
+	)
+
+	// Divergences counts app-hash divergences detected. Increments at most
+	// once per process lifetime — the comparison loop exits on first divergence.
+	// divergence_layer is "0" for header-hash mismatch, "1" when Layer 1
+	// isolated specific tx-receipt mismatches.
+	Divergences = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "seictl_shadow_divergences_total",
+			Help: "App-hash divergences detected by the shadow comparator. Increments once per process lifetime since the loop exits on first divergence.",
+		},
+		[]string{"chain_id", "pod_name", "divergence_layer"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(BlocksCompared)
+	prometheus.MustRegister(Divergences)
+}

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -121,6 +121,7 @@ func (l *comparisonLoop) compareBlocksUpTo(ctx context.Context, latestHeight int
 			return false, sleep(ctx, l.pollInterval)
 		}
 
+		shadow.BlocksCompared.WithLabelValues(l.exporter.chainID, l.exporter.podName).Inc()
 		l.pageBuf = append(l.pageBuf, *result)
 
 		if result.Diverged() {
@@ -137,8 +138,15 @@ func (l *comparisonLoop) compareBlocksUpTo(ctx context.Context, latestHeight int
 }
 
 func (l *comparisonLoop) handleDivergence(ctx context.Context, result shadow.CompareResult) error {
+	layer := "0"
+	if result.DivergenceLayer != nil {
+		layer = fmt.Sprintf("%d", *result.DivergenceLayer)
+	}
+	shadow.Divergences.WithLabelValues(l.exporter.chainID, l.exporter.podName, layer).Inc()
+
 	exportLog.Info("app-hash divergence detected",
 		"height", l.height,
+		"divergence-layer", layer,
 		"shadow-app-hash", result.Layer0.ShadowAppHash,
 		"canonical-app-hash", result.Layer0.CanonicalAppHash)
 

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -51,14 +51,19 @@ type exportState struct {
 // them in compressed NDJSON pages to S3.
 type ResultExporter struct {
 	homeDir           string
+	chainID           string
+	podName           string
 	s3UploaderFactory seis3.UploaderFactory
 }
 
-func NewResultExporter(homeDir string, factory seis3.UploaderFactory) *ResultExporter {
+// NewResultExporter creates an exporter targeting the given home directory.
+// chainID and podName label shadow comparison metrics; pass empty strings
+// if the exporter is only used in non-comparison mode.
+func NewResultExporter(homeDir, chainID, podName string, factory seis3.UploaderFactory) *ResultExporter {
 	if factory == nil {
 		factory = seis3.DefaultUploaderFactory
 	}
-	return &ResultExporter{homeDir: homeDir, s3UploaderFactory: factory}
+	return &ResultExporter{homeDir: homeDir, chainID: chainID, podName: podName, s3UploaderFactory: factory}
 }
 
 func (e *ResultExporter) Handler() engine.TaskHandler {

--- a/sidecar/tasks/result_export_test.go
+++ b/sidecar/tasks/result_export_test.go
@@ -14,7 +14,10 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+	"github.com/sei-protocol/seictl/sidecar/shadow"
 )
 
 type mockResultUploader struct{}
@@ -58,7 +61,7 @@ func TestExportBootstrapFromSnapshotHeight(t *testing.T) {
 		t.Fatalf("writing snapshot height file: %v", err)
 	}
 
-	e := NewResultExporter(tmpDir, nil)
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", nil)
 	state := e.readExportState()
 
 	if state.LastExportedHeight != 198030000 {
@@ -68,7 +71,7 @@ func TestExportBootstrapFromSnapshotHeight(t *testing.T) {
 
 func TestExportBootstrapNoFiles(t *testing.T) {
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, nil)
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", nil)
 	state := e.readExportState()
 
 	if state.LastExportedHeight != 0 {
@@ -87,7 +90,7 @@ func TestExportBootstrapPreferStateFile(t *testing.T) {
 		t.Fatalf("writing snapshot height file: %v", err)
 	}
 
-	e := NewResultExporter(tmpDir, nil)
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", nil)
 	state := e.readExportState()
 
 	if state.LastExportedHeight != 200000000 {
@@ -102,7 +105,7 @@ func TestExportRPCUnavailable(t *testing.T) {
 	srv.Close()
 
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 
 	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
@@ -122,7 +125,7 @@ func TestExportRPCNon200Status(t *testing.T) {
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 
 	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
@@ -155,7 +158,7 @@ func TestExportS3UploaderFactoryError(t *testing.T) {
 		t.Fatalf("writing snapshot height file: %v", err)
 	}
 
-	e := NewResultExporter(tmpDir, failingUploaderFactory("simulated AWS error"))
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", failingUploaderFactory("simulated AWS error"))
 
 	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
@@ -181,7 +184,7 @@ func TestExportWritesStateAfterPage(t *testing.T) {
 		t.Fatalf("writing snapshot height file: %v", err)
 	}
 
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 	err := e.Export(context.Background(), ResultExportRequest{
 		Bucket:      "test-bucket",
 		Prefix:      "results",
@@ -200,7 +203,7 @@ func TestExportWritesStateAfterPage(t *testing.T) {
 
 func TestExportHandler_MissingParams(t *testing.T) {
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 	handler := e.Handler()
 
 	cases := []struct {
@@ -256,7 +259,7 @@ func TestHandlerRouting_WithCanonicalRPC_CallsExportAndCompare(t *testing.T) {
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -277,7 +280,7 @@ func TestHandlerRouting_WithoutCanonicalRPC_CallsExport(t *testing.T) {
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 
 	err := e.Handler()(context.Background(), map[string]any{
 		"bucket":      "test-bucket",
@@ -299,7 +302,10 @@ func TestExportAndCompare_DivergenceDetected(t *testing.T) {
 	defer canonicalSrv.Close()
 
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	const testPodName = "shadow-test-0"
+	e := NewResultExporter(tmpDir, "test-1", testPodName, mockResultUploaderFactory())
+
+	divergenceBefore := testutil.ToFloat64(shadow.Divergences.WithLabelValues("test-1", testPodName, "0"))
 
 	err := e.ExportAndCompare(context.Background(), ResultExportRequest{
 		Bucket:       "test-bucket",
@@ -317,6 +323,13 @@ func TestExportAndCompare_DivergenceDetected(t *testing.T) {
 	if state.LastExportedHeight != 1 {
 		t.Errorf("LastExportedHeight = %d, want 1 (diverged at first block)", state.LastExportedHeight)
 	}
+
+	if got := testutil.ToFloat64(shadow.Divergences.WithLabelValues("test-1", testPodName, "0")); got-divergenceBefore != 1 {
+		t.Errorf("seictl_shadow_divergences_total{chain_id=test-1,pod_name=%s,divergence_layer=0} delta = %v, want 1", testPodName, got-divergenceBefore)
+	}
+	if got := testutil.ToFloat64(shadow.BlocksCompared.WithLabelValues("test-1", testPodName)); got < 1 {
+		t.Errorf("seictl_shadow_blocks_compared_total{chain_id=test-1,pod_name=%s} = %v, want >= 1", testPodName, got)
+	}
 }
 
 func TestExportAndCompare_ContextCancelled(t *testing.T) {
@@ -324,7 +337,7 @@ func TestExportAndCompare_ContextCancelled(t *testing.T) {
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -345,7 +358,7 @@ func TestExportAndCompare_S3UploaderError(t *testing.T) {
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, failingUploaderFactory("AWS creds expired"))
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", failingUploaderFactory("AWS creds expired"))
 
 	err := e.ExportAndCompare(context.Background(), ResultExportRequest{
 		Bucket:       "test-bucket",
@@ -373,7 +386,7 @@ func TestExportAndCompare_ResumesFromExportState(t *testing.T) {
 		t.Fatalf("writing state: %v", err)
 	}
 
-	e := NewResultExporter(tmpDir, mockResultUploaderFactory())
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", mockResultUploaderFactory())
 	err := e.ExportAndCompare(context.Background(), ResultExportRequest{
 		Bucket:       "test-bucket",
 		Region:       "us-east-1",
@@ -400,7 +413,7 @@ func TestExportAndCompare_UploadsDivergenceReport(t *testing.T) {
 
 	recorder := &recordingUploader{}
 	tmpDir := t.TempDir()
-	e := NewResultExporter(tmpDir, func(_ context.Context, _ string) (seis3.Uploader, error) {
+	e := NewResultExporter(tmpDir, "test-1", "test-pod-0", func(_ context.Context, _ string) (seis3.Uploader, error) {
 		return recorder, nil
 	})
 

--- a/sidecar/tasks/typed_handler_integration_test.go
+++ b/sidecar/tasks/typed_handler_integration_test.go
@@ -326,7 +326,7 @@ func TestDeserialize_StateSync(t *testing.T) {
 // TestDeserialize_ResultExport verifies that the result-export handler
 // correctly deserializes the bucket, region, and optional fields.
 func TestDeserialize_ResultExport(t *testing.T) {
-	handler := NewResultExporter(t.TempDir(), nil).Handler()
+	handler := NewResultExporter(t.TempDir(), "test-1", "test-pod-0", nil).Handler()
 
 	params := map[string]any{
 		"bucket": "",


### PR DESCRIPTION
## Summary

Adds two Prometheus counters to the seictl sidecar so a shadow node in staging can be alerted on per-pod when a candidate image diverges from the canonical chain.

## Metrics

| Metric | Labels | When it increments |
|---|---|---|
| \`seictl_shadow_divergences_total\` | \`chain_id\`, \`pod_name\`, \`divergence_layer\` | When \`Comparator.CompareBlock\` detects an app-hash mismatch. At most once per process lifetime since the loop exits on first divergence. |
| \`seictl_shadow_blocks_compared_total\` | \`chain_id\`, \`pod_name\` | Per successful block comparison. |

## Why two metrics

Divergence-only would give silent-failure parity: if shadow RPC stays unreachable forever, the comparator just retries silently and \`divergences_total\` stays at 0 — looks identical to "all good." Pairing with \`blocks_compared_total\` lets ops alert on \`rate(...)==0\` to catch the wedge case.

## Why \`pod_name\` differentiator

The driving alerting strategy: multiple shadow candidates may run for the same chain (candidate-A, candidate-B). Pages need to identify which candidate to investigate. \`pod_name\` is sourced from \`HOSTNAME\` (auto-injected by kubelet, equals pod \`metadata.name\`) and threaded through \`NewResultExporter\` from \`serve.go\` — explicit constructor injection rather than reading hostname inside the metrics package.

## Suggested alerts (out of scope for this PR; will follow in platform repo)

\`\`\`
# Page — candidate diverged
expr: increase(seictl_shadow_divergences_total[10m]) > 0

# Ticket — comparator wedged without divergence
expr: rate(seictl_shadow_blocks_compared_total[10m]) == 0
  and seictl_shadow_blocks_compared_total > 0
\`\`\`

## Test plan

- [x] \`GOWORK=off go build ./...\`
- [x] \`GOWORK=off go test ./...\` — full suite green
- [x] \`TestExportAndCompare_DivergenceDetected\` extended to assert both counters fire with expected label values

## Out of scope

- ServiceMonitor / scrape config — there's no existing seictl scrape config under \`platform/clusters/prod/monitoring/\`; that's a platform-repo follow-up before the alert can fire.
- Runtime log-level toggling and other shadow tooling — separate threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)