### PR TITLE
chore(client): add json tags to PeerSource

### DIFF
--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -149,11 +149,11 @@ const (
 
 // PeerSource is a single peer discovery source.
 type PeerSource struct {
-	Type      PeerSourceType
-	Region    string
-	Tags      map[string]string
-	Addresses []string
-	Endpoints []string
+	Type      PeerSourceType    `json:"type"`
+	Region    string            `json:"region,omitempty"`
+	Tags      map[string]string `json:"tags,omitempty"`
+	Addresses []string          `json:"addresses,omitempty"`
+	Endpoints []string          `json:"endpoints,omitempty"`
 }
 
 // DiscoverPeersTask resolves peers from one or more sources.


### PR DESCRIPTION
## Summary

`client.PeerSource` is the only typed-wrapper field type without explicit json tags. Direct `json.Marshal(client.DiscoverPeersTask{...})` produces PascalCase keys (`Type`/`Region`/`Tags`/`Addresses`/`Endpoints`), which downstream consumers (sei-k8s-controller persisting `PlannedTask.Params.Raw` to the SND CRD) see as operator-visible cosmetic noise.

Adds the obvious tags:

```go
type PeerSource struct {
    Type      PeerSourceType    `json:"type"`
    Region    string            `json:"region,omitempty"`
    Tags      map[string]string `json:"tags,omitempty"`
    Addresses []string          `json:"addresses,omitempty"`
    Endpoints []string          `json:"endpoints,omitempty"`
}
```

## Effects

- **`kubectl get snd -o yaml`** for an SND with discover-peers tasks shows lowercase keys instead of PascalCase. Restores the shape pre-#192 (controller paramser refactor) operators are used to.
- **Persisted byte savings**: `omitempty` drops `"Addresses":null` and `"Endpoints":null` from EC2-tags peer sources (~30 bytes per source per persisted plan). Cosmetic.
- **Wire format unchanged**: `DiscoverPeersTask.ToTaskRequest()` builds Params imperatively with hard-coded lowercase keys (line 222-244). The HTTP body the sidecar sees is unaffected by struct tags.

## Mid-rollover

Pre-existing CRD `Params.Raw` bytes (PascalCase from PR #192-era controller) deserialize cleanly into the now-tagged struct via Go's case-insensitive json unmarshal — when no exact tag match is found, `encoding/json` falls back to case-insensitive comparison against the tag, so `"Type"` matches `json:"type"`. Safe.

## Verification

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./...` — all 15 packages pass
- [x] `make lint` (gofmt) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)