### PR TITLE
feat(nodedeployment): --genesis-account flag + [N] list-index in --set

### DIFF
--- a/nodedeployment/apply.go
+++ b/nodedeployment/apply.go
@@ -126,11 +126,11 @@ var applyCmd = cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:  "set",
-			Usage: "Strategic-merge override, dotted path (e.g. --set spec.template.spec.image=foo). Wins on collision with discrete flags. Repeatable.",
+			Usage: "Strategic-merge override, dotted path with optional list-index suffix (e.g. --set spec.template.spec.image=foo, --set spec.genesis.accounts[0].address=sei1abc). Wins on collision with discrete flags. Repeatable.",
 		},
 		&cli.StringSliceFlag{
 			Name:  "genesis-account",
-			Usage: "Pre-fund a non-validator account at genesis: --genesis-account <address>:<balance> (e.g. --genesis-account sei1abc...:1000000000usei). Balance accepts standard cosmos coin format (comma-separated denominations). Repeatable; only valid with --preset genesis-chain.",
+			Usage: "Append a GenesisAccount to spec.genesis.accounts: --genesis-account <address>:<balance> (e.g. --genesis-account sei1abc...:1000000000usei). Balance accepts the standard cosmos coin format (comma-separated denominations). Repeatable. Requires --preset genesis-chain. --set spec.genesis.accounts[N]... overrides on collision.",
 		},
 		&cli.BoolFlag{
 			Name:  "dry-run",

--- a/nodedeployment/apply.go
+++ b/nodedeployment/apply.go
@@ -19,12 +19,13 @@ func applyAction(ctx context.Context, c *cli.Command) error {
 	}
 
 	args := renderArgs{
-		preset:    c.String("preset"),
-		name:      name,
-		namespace: c.String("namespace"),
-		chainID:   c.String("chain-id"),
-		image:     c.String("image"),
-		sets:      c.StringSlice("set"),
+		preset:          c.String("preset"),
+		name:            name,
+		namespace:       c.String("namespace"),
+		chainID:         c.String("chain-id"),
+		image:           c.String("image"),
+		sets:            c.StringSlice("set"),
+		genesisAccounts: c.StringSlice("genesis-account"),
 	}
 	if c.IsSet("replicas") {
 		args.replicas = int(c.Int("replicas"))
@@ -126,6 +127,10 @@ var applyCmd = cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "set",
 			Usage: "Strategic-merge override, dotted path (e.g. --set spec.template.spec.image=foo). Wins on collision with discrete flags. Repeatable.",
+		},
+		&cli.StringSliceFlag{
+			Name:  "genesis-account",
+			Usage: "Pre-fund a non-validator account at genesis: --genesis-account <address>:<balance> (e.g. --genesis-account sei1abc...:1000000000usei). Balance accepts standard cosmos coin format (comma-separated denominations). Repeatable; only valid with --preset genesis-chain.",
 		},
 		&cli.BoolFlag{
 			Name:  "dry-run",

--- a/nodedeployment/preset.go
+++ b/nodedeployment/preset.go
@@ -166,8 +166,14 @@ func render(args renderArgs) (*unstructured.Unstructured, error) {
 	return u, nil
 }
 
-// applySet writes a single dotted-path --set expression. List-index
-// syntax is intentionally unsupported; add when a real consumer asks.
+// applySet writes a single dotted-path --set expression. Each segment is a
+// map key, optionally suffixed with `[N]` to step into a list at index N
+// after the key. Empty intermediate maps and lists are created on demand.
+//
+// List-index rules:
+//   - idx == len(list) appends a new element (extends the list by one).
+//   - idx <  len(list) sets in place on the existing element.
+//   - idx >  len(list) errors; sparse indices are not supported.
 func applySet(root map[string]interface{}, expr string) error {
 	eq := strings.Index(expr, "=")
 	if eq < 0 {
@@ -178,16 +184,136 @@ func applySet(root map[string]interface{}, expr string) error {
 	if rawPath == "" {
 		return fmt.Errorf("empty path before '='")
 	}
-	if strings.ContainsAny(rawPath, "[]") {
-		return fmt.Errorf("list-index syntax in --set paths is not supported (path: %q); rewrite as a top-level field or file an issue with the case", rawPath)
+	// `--set foo=null` would silently set the literal string "null"; reject
+	// loudly so the user sees the gap. Field clearing is not in scope.
+	if rawVal == "null" {
+		return fmt.Errorf("value 'null' is not supported")
 	}
-	fields := strings.Split(rawPath, ".")
+	segments, err := parsePathSegments(rawPath)
+	if err != nil {
+		return err
+	}
+	return writeMap(root, segments, parseValue(rawVal))
+}
+
+// pathSegment names one step in a --set path. Every segment has a `key`
+// (the map field). If isList is set, the step also indexes into a list
+// at the value of that key (so `accounts[0]` is one segment with
+// key="accounts", isList=true, listIdx=0).
+type pathSegment struct {
+	key     string
+	isList  bool
+	listIdx int
+}
+
+// parsePathSegments splits a dotted path into segments, recognizing an
+// optional `[N]` suffix on each segment as a list index.
+func parsePathSegments(path string) ([]pathSegment, error) {
+	fields := strings.Split(path, ".")
+	out := make([]pathSegment, 0, len(fields))
 	for _, f := range fields {
 		if f == "" {
-			return fmt.Errorf("empty segment in path %q", rawPath)
+			return nil, fmt.Errorf("empty segment in path %q", path)
 		}
+		bracket := strings.Index(f, "[")
+		if bracket < 0 {
+			out = append(out, pathSegment{key: f})
+			continue
+		}
+		if !strings.HasSuffix(f, "]") {
+			return nil, fmt.Errorf("malformed segment %q in path %q: '[' without closing ']'", f, path)
+		}
+		if bracket == 0 {
+			return nil, fmt.Errorf("malformed segment %q in path %q: '[N]' without preceding key", f, path)
+		}
+		key := f[:bracket]
+		idxStr := f[bracket+1 : len(f)-1]
+		if idxStr == "" {
+			return nil, fmt.Errorf("empty list index in segment %q", f)
+		}
+		if strings.ContainsAny(idxStr, "[]") {
+			return nil, fmt.Errorf("nested list-index syntax not supported in segment %q", f)
+		}
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil {
+			return nil, fmt.Errorf("malformed list index in segment %q: %w", f, err)
+		}
+		if idx < 0 {
+			return nil, fmt.Errorf("negative list index in segment %q", f)
+		}
+		out = append(out, pathSegment{key: key, isList: true, listIdx: idx})
 	}
-	return unstructured.SetNestedField(root, parseValue(rawVal), fields...)
+	return out, nil
+}
+
+// writeMap descends one map step (segments[0].key), recursing or setting.
+func writeMap(m map[string]interface{}, segments []pathSegment, value interface{}) error {
+	if len(segments) == 0 {
+		return fmt.Errorf("internal: writeMap called with empty segments")
+	}
+	seg := segments[0]
+	rest := segments[1:]
+
+	if seg.isList {
+		var list []interface{}
+		if existing, ok := m[seg.key]; ok && existing != nil {
+			l, isList := existing.([]interface{})
+			if !isList {
+				return fmt.Errorf("path expects list at key %q but found %T", seg.key, existing)
+			}
+			list = l
+		}
+		newList, err := writeList(list, seg.listIdx, rest, value)
+		if err != nil {
+			return fmt.Errorf("at .%s[%d]: %w", seg.key, seg.listIdx, err)
+		}
+		m[seg.key] = newList
+		return nil
+	}
+
+	if len(rest) == 0 {
+		m[seg.key] = value
+		return nil
+	}
+
+	existing, ok := m[seg.key]
+	if !ok || existing == nil {
+		inner := map[string]interface{}{}
+		m[seg.key] = inner
+		return writeMap(inner, rest, value)
+	}
+	inner, isMap := existing.(map[string]interface{})
+	if !isMap {
+		return fmt.Errorf("path expects map at key %q but found %T", seg.key, existing)
+	}
+	return writeMap(inner, rest, value)
+}
+
+// writeList sets or appends at index, recursing into the element if needed.
+func writeList(list []interface{}, idx int, rest []pathSegment, value interface{}) ([]interface{}, error) {
+	if idx > len(list) {
+		return nil, fmt.Errorf("list index %d out of range (length %d); sparse indices are not supported", idx, len(list))
+	}
+	if idx == len(list) {
+		if len(rest) == 0 {
+			return append(list, value), nil
+		}
+		inner := map[string]interface{}{}
+		list = append(list, inner)
+		if err := writeMap(inner, rest, value); err != nil {
+			return nil, err
+		}
+		return list, nil
+	}
+	if len(rest) == 0 {
+		list[idx] = value
+		return list, nil
+	}
+	inner, isMap := list[idx].(map[string]interface{})
+	if !isMap {
+		return nil, fmt.Errorf("path expects map at index [%d] but found %T", idx, list[idx])
+	}
+	return list, writeMap(inner, rest, value)
 }
 
 // parseGenesisAccount parses a `<address>:<balance>` --genesis-account entry.

--- a/nodedeployment/preset.go
+++ b/nodedeployment/preset.go
@@ -12,14 +12,15 @@ import (
 )
 
 type renderArgs struct {
-	preset    string
-	name      string
-	namespace string
-	chainID   string
-	image     string
-	replicas  int
-	hasReps   bool
-	sets      []string
+	preset          string
+	name            string
+	namespace       string
+	chainID         string
+	image           string
+	replicas        int
+	hasReps         bool
+	sets            []string
+	genesisAccounts []string
 }
 
 // presetRequiredFields surfaces missing required fields as a friendly
@@ -111,6 +112,26 @@ func render(args renderArgs) (*unstructured.Unstructured, error) {
 		}
 	}
 
+	if len(args.genesisAccounts) > 0 {
+		if args.preset != "genesis-chain" {
+			return nil, usageError("--genesis-account is only valid with --preset genesis-chain")
+		}
+		accounts := make([]interface{}, 0, len(args.genesisAccounts))
+		for _, entry := range args.genesisAccounts {
+			addr, balance, parseErr := parseGenesisAccount(entry)
+			if parseErr != nil {
+				return nil, usageError("apply --genesis-account %q: %s", entry, parseErr.Error())
+			}
+			accounts = append(accounts, map[string]interface{}{
+				"address": addr,
+				"balance": balance,
+			})
+		}
+		if err := unstructured.SetNestedSlice(u.Object, accounts, "spec", "genesis", "accounts"); err != nil {
+			return nil, fmt.Errorf("apply --genesis-account: %w", err)
+		}
+	}
+
 	for _, expr := range args.sets {
 		if err := applySet(u.Object, expr); err != nil {
 			return nil, usageError("apply --set %q: %s", expr, err.Error())
@@ -167,6 +188,25 @@ func applySet(root map[string]interface{}, expr string) error {
 		}
 	}
 	return unstructured.SetNestedField(root, parseValue(rawVal), fields...)
+}
+
+// parseGenesisAccount parses a `<address>:<balance>` --genesis-account entry.
+// The balance side accepts the standard cosmos coin format (one or more
+// `<int><denom>` separated by commas — e.g. `1000usei,500uatom`).
+func parseGenesisAccount(entry string) (string, string, error) {
+	idx := strings.Index(entry, ":")
+	if idx < 0 {
+		return "", "", fmt.Errorf("missing ':' between address and balance")
+	}
+	addr := strings.TrimSpace(entry[:idx])
+	balance := strings.TrimSpace(entry[idx+1:])
+	if addr == "" {
+		return "", "", fmt.Errorf("empty address before ':'")
+	}
+	if balance == "" {
+		return "", "", fmt.Errorf("empty balance after ':'")
+	}
+	return addr, balance, nil
 }
 
 func parseValue(raw string) interface{} {

--- a/nodedeployment/preset_test.go
+++ b/nodedeployment/preset_test.go
@@ -377,7 +377,12 @@ func TestApplySet_Errors(t *testing.T) {
 		{"no-equals", "missing '='"},
 		{"=value", "empty path"},
 		{"a..b=v", "empty segment"},
-		{"a[0]=v", "list-index syntax"},
+		{"a[=v", "without closing"},
+		{"a[]=v", "empty list index"},
+		{"a[abc]=v", "malformed list index"},
+		{"a[-1]=v", "negative list index"},
+		{"[0]=v", "without preceding key"},
+		{"foo=null", "value 'null' is not supported"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.expr, func(t *testing.T) {
@@ -389,6 +394,123 @@ func TestApplySet_Errors(t *testing.T) {
 				t.Errorf("err = %q; want containing %q", err.Error(), tc.want)
 			}
 		})
+	}
+}
+
+func TestApplySet_ListIndex_AppendIntoEmptyList(t *testing.T) {
+	root := map[string]interface{}{}
+	if err := applySet(root, "spec.genesis.accounts[0].address=sei1abc"); err != nil {
+		t.Fatalf("applySet: %v", err)
+	}
+	if err := applySet(root, "spec.genesis.accounts[0].balance=1000usei"); err != nil {
+		t.Fatalf("applySet: %v", err)
+	}
+	accounts, _, _ := unstructured.NestedSlice(root, "spec", "genesis", "accounts")
+	if len(accounts) != 1 {
+		t.Fatalf("len(accounts) = %d; want 1", len(accounts))
+	}
+	a0, ok := accounts[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("accounts[0] is %T; want map", accounts[0])
+	}
+	if a0["address"] != "sei1abc" {
+		t.Errorf("accounts[0].address = %v; want sei1abc", a0["address"])
+	}
+	if a0["balance"] != "1000usei" {
+		t.Errorf("accounts[0].balance = %v; want 1000usei", a0["balance"])
+	}
+}
+
+func TestApplySet_ListIndex_AppendSequential(t *testing.T) {
+	root := map[string]interface{}{}
+	exprs := []string{
+		"spec.genesis.accounts[0].address=sei1aaa",
+		"spec.genesis.accounts[0].balance=100usei",
+		"spec.genesis.accounts[1].address=sei1bbb",
+		"spec.genesis.accounts[1].balance=200usei",
+	}
+	for _, e := range exprs {
+		if err := applySet(root, e); err != nil {
+			t.Fatalf("applySet(%q): %v", e, err)
+		}
+	}
+	accounts, _, _ := unstructured.NestedSlice(root, "spec", "genesis", "accounts")
+	if len(accounts) != 2 {
+		t.Fatalf("len(accounts) = %d; want 2", len(accounts))
+	}
+	a1 := accounts[1].(map[string]interface{})
+	if a1["address"] != "sei1bbb" || a1["balance"] != "200usei" {
+		t.Errorf("accounts[1] = %v; want {address=sei1bbb, balance=200usei}", a1)
+	}
+}
+
+func TestApplySet_ListIndex_SetOnExisting(t *testing.T) {
+	root := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"peers": []interface{}{
+						map[string]interface{}{
+							"label": map[string]interface{}{
+								"original": "value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := applySet(root, "spec.template.spec.peers[0].label.original=overridden"); err != nil {
+		t.Fatalf("applySet: %v", err)
+	}
+	peers, _, _ := unstructured.NestedSlice(root, "spec", "template", "spec", "peers")
+	p0 := peers[0].(map[string]interface{})
+	label := p0["label"].(map[string]interface{})
+	if label["original"] != "overridden" {
+		t.Errorf("peers[0].label.original = %v; want overridden", label["original"])
+	}
+}
+
+func TestApplySet_ListIndex_SparseRejected(t *testing.T) {
+	root := map[string]interface{}{}
+	err := applySet(root, "spec.accounts[2].address=foo")
+	if err == nil {
+		t.Fatalf("expected error for sparse index, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("err = %v; want containing 'out of range'", err)
+	}
+	if !strings.Contains(err.Error(), ".accounts[2]") {
+		t.Errorf("err = %v; want containing failing segment '.accounts[2]'", err)
+	}
+}
+
+func TestApplySet_ListIndex_LeafScalar(t *testing.T) {
+	root := map[string]interface{}{}
+	if err := applySet(root, "tags[0]=alpha"); err != nil {
+		t.Fatalf("applySet: %v", err)
+	}
+	if err := applySet(root, "tags[1]=beta"); err != nil {
+		t.Fatalf("applySet: %v", err)
+	}
+	tags, _, _ := unstructured.NestedSlice(root, "tags")
+	if len(tags) != 2 || tags[0] != "alpha" || tags[1] != "beta" {
+		t.Errorf("tags = %v; want [alpha beta]", tags)
+	}
+}
+
+func TestApplySet_ListIndex_TypeMismatchSurfaces(t *testing.T) {
+	root := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"accounts": "not-a-list",
+		},
+	}
+	err := applySet(root, "spec.accounts[0]=foo")
+	if err == nil {
+		t.Fatalf("expected error for non-list field, got nil")
+	}
+	if !strings.Contains(err.Error(), "expects list") {
+		t.Errorf("err = %v; want containing 'expects list'", err)
 	}
 }
 

--- a/nodedeployment/preset_test.go
+++ b/nodedeployment/preset_test.go
@@ -204,6 +204,103 @@ func TestRender_RequiredFlags(t *testing.T) {
 	}
 }
 
+func TestRender_GenesisAccountFlag(t *testing.T) {
+	got, err := render(renderArgs{
+		preset:  "genesis-chain",
+		name:    "qa-test",
+		chainID: "qa-test",
+		image:   "img:1",
+		genesisAccounts: []string{
+			"sei1abc:1000000000usei",
+			"0xdef:500000000usei,2000uusdc",
+		},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	accounts, found, _ := unstructured.NestedSlice(got.Object, "spec", "genesis", "accounts")
+	if !found || len(accounts) != 2 {
+		t.Fatalf("expected 2 accounts, got %v (found=%v)", accounts, found)
+	}
+	a0 := accounts[0].(map[string]interface{})
+	if a0["address"] != "sei1abc" {
+		t.Errorf("accounts[0].address = %v; want sei1abc", a0["address"])
+	}
+	if a0["balance"] != "1000000000usei" {
+		t.Errorf("accounts[0].balance = %v; want 1000000000usei", a0["balance"])
+	}
+	a1 := accounts[1].(map[string]interface{})
+	if a1["address"] != "0xdef" {
+		t.Errorf("accounts[1].address = %v; want 0xdef", a1["address"])
+	}
+	if a1["balance"] != "500000000usei,2000uusdc" {
+		t.Errorf("accounts[1].balance = %v; want 500000000usei,2000uusdc", a1["balance"])
+	}
+}
+
+func TestRender_GenesisAccountRejectsNonGenesisPreset(t *testing.T) {
+	_, err := render(renderArgs{
+		preset:          "rpc",
+		name:            "rpc-fleet",
+		chainID:         "pacific-1",
+		image:           "img:1",
+		genesisAccounts: []string{"sei1abc:1000usei"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "only valid with --preset genesis-chain") {
+		t.Errorf("expected 'only valid with --preset genesis-chain' error, got %v", err)
+	}
+}
+
+func TestRender_GenesisAccountSetCanOverride(t *testing.T) {
+	got, err := render(renderArgs{
+		preset:          "genesis-chain",
+		name:            "x",
+		chainID:         "c",
+		image:           "img:1",
+		genesisAccounts: []string{"sei1abc:1000usei"},
+		sets:            []string{"spec.genesis.accountBalance=2000usei"},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	accounts, _, _ := unstructured.NestedSlice(got.Object, "spec", "genesis", "accounts")
+	if len(accounts) != 1 {
+		t.Errorf("--genesis-account should still produce its entry; got len=%d", len(accounts))
+	}
+	bal, _, _ := unstructured.NestedString(got.Object, "spec", "genesis", "accountBalance")
+	if bal != "2000usei" {
+		t.Errorf("--set after --genesis-account should set accountBalance; got %q", bal)
+	}
+}
+
+func TestParseGenesisAccount_Errors(t *testing.T) {
+	cases := []struct {
+		entry string
+		want  string
+	}{
+		{"no-colon", "missing ':'"},
+		{":1000usei", "empty address"},
+		{"sei1abc:", "empty balance"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.entry, func(t *testing.T) {
+			_, err := render(renderArgs{
+				preset:          "genesis-chain",
+				name:            "x",
+				chainID:         "c",
+				image:           "img:1",
+				genesisAccounts: []string{tc.entry},
+			})
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want containing %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
 func TestRender_SetOverrides(t *testing.T) {
 	got, err := render(renderArgs{
 		preset:  "rpc",


### PR DESCRIPTION
Two related changes to `seictl nd apply` that surface CRD list fields through the CLI for the qa-testing bootstrap consumer.

## --genesis-account flag

Repeatable flag that appends to `spec.genesis.accounts`. Each entry maps to one `GenesisAccount` element on the rendered SND.

```
--genesis-account <address>:<balance>
```

The address accepts bech32 (`sei1...`) or hex (`0x...`). The balance accepts the standard cosmos coin format — one or more `<int><denom>` separated by commas.

```sh
seictl nd apply qa-test \
  --preset genesis-chain \
  --chain-id qa-test \
  --image ghcr.io/sei-protocol/seid:release-6-4 \
  --genesis-account sei1abc:1000000000usei \
  --genesis-account 0xdef:500000000usei,2000uusdc \
  -n eng-fromtherain
```

Errors:
- Used with any preset other than `genesis-chain` → `--genesis-account is only valid with --preset genesis-chain`.
- Missing `:` separator, empty address, or empty balance → parse error with the offending entry surfaced.

## [N] list-index in --set

`--set` paths now accept a `[N]` suffix on each segment. Path semantics:

- `idx == len(list)` appends a new element.
- `idx <  len(list)` sets in place on the existing element.
- `idx >  len(list)` errors with the failing segment surfaced (e.g. `at .accounts[2]: list index 2 out of range (length 0)`).
- Empty intermediate maps and lists are auto-created on demand.
- Nested `[N][M]` is rejected.

```sh
--set spec.genesis.accounts[0].address=sei1abc
--set spec.genesis.accounts[0].balance=1000usei
--set spec.template.spec.peers[0].label.selector.example.com/key=v
```

The walker uses raw type assertions on `map[string]interface{}` and `[]interface{}` rather than routing every step through `unstructured.NestedField`/`SetNestedSlice` helpers; those helpers are deepcopy-then-write and lose the auto-create-intermediates semantics this surface needs.

## Precedence

`--genesis-account` runs before `--set` in `render()`. `--set spec.genesis.accounts[N]...` overrides on collision.

## Polish

- `applySet` rejects `--set foo=null` with `value 'null' is not supported` rather than silently producing the literal string `"null"`. Field clearing is not in scope.
- Sparse-index errors include the failing segment so a multi-segment path traces back to the right input.

## Consumer

sei-protocol/qa-testing#24 needs a chain with a known funded admin mnemonic at genesis. With this PR, the qa-testing entrypoint derives its admin from a known mnemonic and pre-funds the matching address at genesis in one apply.

## Test coverage

`go test ./nodedeployment/...` passes. Added cases:

- `--genesis-account` rendering with multiple accounts; rejection on `rpc` preset; parse errors (missing colon, empty address, empty balance); `--set` strategic-merge override of `accountBalance` after `--genesis-account`.
- `--set [N]` append into empty list; sequential append; set on existing element; sparse rejection (with segment surfaced); leaf scalar values; type mismatch when an existing field isn't a list; null-value rejection; parse-error matrix.

## Coral review

product-engineer + kubernetes-specialist; both confirmed the colon-separated `<address>:<balance>` syntax and the `[N]` append/set/error semantics as the right shape, and the walker as idiomatic. All deferred items (typed `--set :int` / `:float`, `--set foo[+]=` append shorthand, JSON-literal values, nested `[N][M]`, helm-style sparse null-padding, schema-aware validation, dotted-key escape, address/balance format validation) carry un-defer triggers if a real consumer asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)