### PR TITLE
feat(nodedeployment): add --override flag for spec.template.spec.overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7
-	github.com/sei-protocol/sei-config v0.0.13
+	github.com/sei-protocol/sei-config v0.0.14
 	github.com/sei-protocol/seilog v0.0.3
 	github.com/urfave/cli/v3 v3.6.1
 	k8s.io/api v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1855,8 +1855,8 @@ github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQp
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:kW+yxMoSm4RvpP5VT5lFfSa+dqnOE9ZpapE2qNIJwvc=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
-github.com/sei-protocol/sei-config v0.0.13 h1:F3J6ZyQo/rBQVgmleOAWVugGD7x1l5VTgsNK9JmtWmk=
-github.com/sei-protocol/sei-config v0.0.13/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.14 h1:1KS0EteCBEsjglNEPS/8VAOA7/NDLxEuPHPZg0MvSaM=
+github.com/sei-protocol/sei-config v0.0.14/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082/go.mod h1:V0fNURAjS6A8+sA1VllegjNeSobay3oRUW5VFZd04bA=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=

--- a/nodedeployment/apply.go
+++ b/nodedeployment/apply.go
@@ -81,10 +81,8 @@ func applyAction(ctx context.Context, c *cli.Command) error {
 
 var applyCmd = cli.Command{
 	Name: "apply",
-	// urfave/cli StringSliceFlag splits values on `,` for both env-var and
-	// argv input. --set, --genesis-account, and --override all carry
-	// comma-bearing values (multi-denom coins, comma-separated TOML lists),
-	// so disable the slice-flag splitter for the whole command.
+	// urfave/cli's StringSliceFlag splits values on `,` by default,
+	// mangling multi-denom coins and TOML list values.
 	DisableSliceFlagSeparator: true,
 	Usage:                     "Render a preset and server-side-apply the resulting SeiNodeDeployment",
 	Description: "Loads the named preset, applies discrete-flag and --set " +

--- a/nodedeployment/apply.go
+++ b/nodedeployment/apply.go
@@ -80,8 +80,13 @@ func applyAction(ctx context.Context, c *cli.Command) error {
 }
 
 var applyCmd = cli.Command{
-	Name:  "apply",
-	Usage: "Render a preset and server-side-apply the resulting SeiNodeDeployment",
+	Name: "apply",
+	// urfave/cli StringSliceFlag splits values on `,` for both env-var and
+	// argv input. --set, --genesis-account, and --override all carry
+	// comma-bearing values (multi-denom coins, comma-separated TOML lists),
+	// so disable the slice-flag splitter for the whole command.
+	DisableSliceFlagSeparator: true,
+	Usage:                     "Render a preset and server-side-apply the resulting SeiNodeDeployment",
 	Description: "Loads the named preset, applies discrete-flag and --set " +
 		"overrides, and server-side-applies the result. With --dry-run, " +
 		"the apiserver validates and returns the would-be-applied CR " +

--- a/nodedeployment/apply.go
+++ b/nodedeployment/apply.go
@@ -26,6 +26,7 @@ func applyAction(ctx context.Context, c *cli.Command) error {
 		image:           c.String("image"),
 		sets:            c.StringSlice("set"),
 		genesisAccounts: c.StringSlice("genesis-account"),
+		overrides:       c.StringSlice("override"),
 	}
 	if c.IsSet("replicas") {
 		args.replicas = int(c.Int("replicas"))
@@ -131,6 +132,10 @@ var applyCmd = cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "genesis-account",
 			Usage: "Append a GenesisAccount to spec.genesis.accounts: --genesis-account <address>:<balance> (e.g. --genesis-account sei1abc...:1000000000usei). Balance accepts the standard cosmos coin format (comma-separated denominations). Repeatable. Requires --preset genesis-chain. --set spec.genesis.accounts[N]... overrides on collision.",
+		},
+		&cli.StringSliceFlag{
+			Name:  "override",
+			Usage: "Set a key in spec.template.spec.overrides: --override <toml-path>=<value> (e.g. --override evm.enabled_legacy_sei_apis=sei_getLogs,sei_getBlockByNumber). Keys are dotted TOML paths consumed by the controller's config-apply pipeline; --set cannot reach this map because its parser splits on every dot. Repeatable.",
 		},
 		&cli.BoolFlag{
 			Name:  "dry-run",

--- a/nodedeployment/preset.go
+++ b/nodedeployment/preset.go
@@ -174,10 +174,8 @@ func render(args renderArgs) (*unstructured.Unstructured, error) {
 }
 
 // applyOverride writes a single key=value pair into
-// spec.template.spec.overrides. Unlike --set, the key may contain dots
-// because the overrides map's keys are themselves dotted TOML paths
-// (e.g. "evm.enabled_legacy_sei_apis"). The first '=' separates key
-// from value; subsequent '=' characters are part of the value.
+// spec.template.spec.overrides. Keys may contain dots because the
+// overrides map's keys are themselves dotted TOML paths.
 func applyOverride(root map[string]interface{}, expr string) error {
 	eq := strings.Index(expr, "=")
 	if eq < 0 {

--- a/nodedeployment/preset.go
+++ b/nodedeployment/preset.go
@@ -21,6 +21,7 @@ type renderArgs struct {
 	hasReps         bool
 	sets            []string
 	genesisAccounts []string
+	overrides       []string
 }
 
 // presetRequiredFields surfaces missing required fields as a friendly
@@ -138,6 +139,12 @@ func render(args renderArgs) (*unstructured.Unstructured, error) {
 		}
 	}
 
+	for _, expr := range args.overrides {
+		if err := applyOverride(u.Object, expr); err != nil {
+			return nil, usageError("apply --override %q: %s", expr, err.Error())
+		}
+	}
+
 	// Reassert identity after --set so --set metadata.namespace=kube-system
 	// can't silently retarget.
 	u.SetName(args.name)
@@ -164,6 +171,32 @@ func render(args renderArgs) (*unstructured.Unstructured, error) {
 	}
 
 	return u, nil
+}
+
+// applyOverride writes a single key=value pair into
+// spec.template.spec.overrides. Unlike --set, the key may contain dots
+// because the overrides map's keys are themselves dotted TOML paths
+// (e.g. "evm.enabled_legacy_sei_apis"). The first '=' separates key
+// from value; subsequent '=' characters are part of the value.
+func applyOverride(root map[string]interface{}, expr string) error {
+	eq := strings.Index(expr, "=")
+	if eq < 0 {
+		return fmt.Errorf("missing '=' in --override expression")
+	}
+	key := expr[:eq]
+	val := expr[eq+1:]
+	if key == "" {
+		return fmt.Errorf("empty key before '='")
+	}
+	existing, _, err := unstructured.NestedStringMap(root, "spec", "template", "spec", "overrides")
+	if err != nil {
+		return fmt.Errorf("read existing overrides: %w", err)
+	}
+	if existing == nil {
+		existing = map[string]string{}
+	}
+	existing[key] = val
+	return unstructured.SetNestedStringMap(root, existing, "spec", "template", "spec", "overrides")
 }
 
 // applySet writes a single dotted-path --set expression. Each segment is a

--- a/nodedeployment/preset_test.go
+++ b/nodedeployment/preset_test.go
@@ -1,9 +1,11 @@
 package nodedeployment
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/urfave/cli/v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -572,6 +574,53 @@ func TestApplyOverride_ValueWithEquals(t *testing.T) {
 	overrides, _, _ := unstructured.NestedStringMap(root, "spec", "template", "spec", "overrides")
 	if got := overrides["chain.min_gas_prices"]; got != "0.1usei,0.5=stake" {
 		t.Errorf("value with embedded '=' not preserved: got %q", got)
+	}
+}
+
+// TestApplyCmd_FlagsDoNotSplitOnComma exercises the actual urfave/cli flag
+// parser end-to-end. urfave/cli's StringSliceFlag splits values on ','
+// unless DisableSliceFlagSeparator is set on the Command. Without this,
+// --override evm.enabled_legacy_sei_apis=a,b would arrive as ["...=a", "b"].
+// Same latent bug applied to --set (e.g. multi-denom min_gas_prices) and
+// --genesis-account (multi-denom balances). All three are guarded by the
+// command-level DisableSliceFlagSeparator: true.
+func TestApplyCmd_FlagsDoNotSplitOnComma(t *testing.T) {
+	if !applyCmd.DisableSliceFlagSeparator {
+		t.Fatal("applyCmd.DisableSliceFlagSeparator must be true; otherwise comma-bearing flag values get split by urfave/cli")
+	}
+
+	var capturedOverride, capturedSet, capturedGenesis []string
+	origAction := applyCmd.Action
+	applyCmd.Action = func(_ context.Context, c *cli.Command) error {
+		capturedOverride = c.StringSlice("override")
+		capturedSet = c.StringSlice("set")
+		capturedGenesis = c.StringSlice("genesis-account")
+		return nil
+	}
+	t.Cleanup(func() { applyCmd.Action = origAction })
+
+	err := applyCmd.Run(context.Background(), []string{
+		"apply", "qa-rpc",
+		"--preset", "rpc",
+		"--chain-id", "qa-rpc",
+		"--image", "img:1",
+		"--override", "evm.enabled_legacy_sei_apis=sei_getLogs,sei_getBlockByNumber",
+		"--set", "spec.template.spec.image=foo,bar",
+		"--genesis-account", "sei1abc:1000usei,500uatom",
+	})
+	if err != nil {
+		t.Fatalf("apply Run: %v", err)
+	}
+
+	if len(capturedOverride) != 1 ||
+		capturedOverride[0] != "evm.enabled_legacy_sei_apis=sei_getLogs,sei_getBlockByNumber" {
+		t.Errorf("--override split by parser: %v", capturedOverride)
+	}
+	if len(capturedSet) != 1 || capturedSet[0] != "spec.template.spec.image=foo,bar" {
+		t.Errorf("--set split by parser: %v", capturedSet)
+	}
+	if len(capturedGenesis) != 1 || capturedGenesis[0] != "sei1abc:1000usei,500uatom" {
+		t.Errorf("--genesis-account split by parser: %v", capturedGenesis)
 	}
 }
 

--- a/nodedeployment/preset_test.go
+++ b/nodedeployment/preset_test.go
@@ -577,13 +577,8 @@ func TestApplyOverride_ValueWithEquals(t *testing.T) {
 	}
 }
 
-// TestApplyCmd_FlagsDoNotSplitOnComma exercises the actual urfave/cli flag
-// parser end-to-end. urfave/cli's StringSliceFlag splits values on ','
-// unless DisableSliceFlagSeparator is set on the Command. Without this,
-// --override evm.enabled_legacy_sei_apis=a,b would arrive as ["...=a", "b"].
-// Same latent bug applied to --set (e.g. multi-denom min_gas_prices) and
-// --genesis-account (multi-denom balances). All three are guarded by the
-// command-level DisableSliceFlagSeparator: true.
+// urfave/cli's StringSliceFlag splits values on ',' by default;
+// this asserts the command-level guard is in place.
 func TestApplyCmd_FlagsDoNotSplitOnComma(t *testing.T) {
 	if !applyCmd.DisableSliceFlagSeparator {
 		t.Fatal("applyCmd.DisableSliceFlagSeparator must be true; otherwise comma-bearing flag values get split by urfave/cli")

--- a/nodedeployment/preset_test.go
+++ b/nodedeployment/preset_test.go
@@ -514,6 +514,88 @@ func TestApplySet_ListIndex_TypeMismatchSurfaces(t *testing.T) {
 	}
 }
 
+func TestRender_OverrideFlag(t *testing.T) {
+	got, err := render(renderArgs{
+		preset:  "rpc",
+		name:    "qa-test",
+		chainID: "qa-test",
+		image:   "img:1",
+		overrides: []string{
+			"evm.enabled_legacy_sei_apis=sei_getLogs,sei_getBlockByNumber",
+			"tx_index.indexer=kv",
+		},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	overrides, found, _ := unstructured.NestedStringMap(got.Object, "spec", "template", "spec", "overrides")
+	if !found {
+		t.Fatal("overrides map not found")
+	}
+	if got := overrides["evm.enabled_legacy_sei_apis"]; got != "sei_getLogs,sei_getBlockByNumber" {
+		t.Errorf("evm.enabled_legacy_sei_apis = %q; want %q", got, "sei_getLogs,sei_getBlockByNumber")
+	}
+	if got := overrides["tx_index.indexer"]; got != "kv" {
+		t.Errorf("tx_index.indexer = %q; want %q", got, "kv")
+	}
+}
+
+func TestApplyOverride_PreservesExistingMap(t *testing.T) {
+	root := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"overrides": map[string]interface{}{
+						"chain.moniker": "preset-default",
+					},
+				},
+			},
+		},
+	}
+	if err := applyOverride(root, "evm.enabled_legacy_sei_apis=sei_getLogs"); err != nil {
+		t.Fatalf("applyOverride: %v", err)
+	}
+	overrides, _, _ := unstructured.NestedStringMap(root, "spec", "template", "spec", "overrides")
+	if overrides["chain.moniker"] != "preset-default" {
+		t.Errorf("preset-supplied entry was clobbered: chain.moniker = %q", overrides["chain.moniker"])
+	}
+	if overrides["evm.enabled_legacy_sei_apis"] != "sei_getLogs" {
+		t.Errorf("override not written: evm.enabled_legacy_sei_apis = %q", overrides["evm.enabled_legacy_sei_apis"])
+	}
+}
+
+func TestApplyOverride_ValueWithEquals(t *testing.T) {
+	root := map[string]interface{}{}
+	if err := applyOverride(root, "chain.min_gas_prices=0.1usei,0.5=stake"); err != nil {
+		t.Fatalf("applyOverride: %v", err)
+	}
+	overrides, _, _ := unstructured.NestedStringMap(root, "spec", "template", "spec", "overrides")
+	if got := overrides["chain.min_gas_prices"]; got != "0.1usei,0.5=stake" {
+		t.Errorf("value with embedded '=' not preserved: got %q", got)
+	}
+}
+
+func TestApplyOverride_Errors(t *testing.T) {
+	cases := []struct {
+		expr string
+		want string
+	}{
+		{"no-equals", "missing '='"},
+		{"=value", "empty key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			err := applyOverride(map[string]interface{}{}, tc.expr)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want containing %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
 func TestParseValue(t *testing.T) {
 	cases := map[string]interface{}{
 		"":       "",


### PR DESCRIPTION
## Summary

The CRD's `spec.template.spec.overrides` is a `map[string]string` where keys are themselves dotted TOML paths (e.g. `evm.enabled_legacy_sei_apis`). `--set` cannot reach this map: its parser at `nodedeployment/preset.go:212` splits on every dot, so

```
--set spec.template.spec.overrides.evm.enabled_legacy_sei_apis=...
```

…builds a nested map (`overrides.evm.enabled_legacy_sei_apis`) rather than a flat key with a literal dot (`overrides["evm.enabled_legacy_sei_apis"]`).

`--override <path>=<value>` writes directly into the overrides map. The first `=` separates key from value; subsequent `=` characters are part of the value. Existing entries (preset-supplied or earlier `--override` calls) are preserved.

## Why a new flag instead of escape syntax in `--set`

`--set`'s parser is intentionally simple. Adding escape semantics ripples through every existing call site and changes the contract for a broadly-used flag. `--override` names the use case directly: "write to the strategic-merge overrides map." Operators who reach for it know what they're targeting.

## Example

```bash
seictl nd apply qa-rpc \
  --preset rpc \
  --chain-id qa-rpc \
  --image sei:1.2.3 \
  --override evm.enabled_legacy_sei_apis=sei_getLogs,sei_getBlockByNumber,sei_getBlockByHash
```

Renders:

```yaml
spec:
  template:
    spec:
      fullNode: {}
      overrides:
        evm.enabled_legacy_sei_apis: "sei_getLogs,sei_getBlockByNumber,sei_getBlockByHash"
```

## sei-config bump

Bumps `github.com/sei-protocol/sei-config` v0.0.13 → v0.0.14 for the schema field (`EVMConfig.EnabledLegacySeiApis`) and `[]string` slice-override support that motivated this flag.

## Tests

- `TestRender_OverrideFlag` — full render path, two `--override` entries land in the map.
- `TestApplyOverride_PreservesExistingMap` — preset-supplied entries survive when `--override` adds new keys.
- `TestApplyOverride_ValueWithEquals` — values containing `=` (e.g. `0.1usei,0.5=stake`) are preserved verbatim.
- `TestApplyOverride_Errors` — missing `=` and empty key both error with clear messages.

All existing tests pass unchanged.

## Out of scope

- Wiring `--override` into the nightly release-test orchestrator's `seictl nd apply ...` call. Separate platform PR after this lands and a seictl release tag is cut.
- Adding similar escape support to `--set`. The two flags target different shapes; conflating them would muddy semantics.