### PR TITLE
docs(design): rev2 — kube-rbac-proxy for sidecar API auth

### DIFF
--- a/docs/design/in-pod-governance-signing.md
+++ b/docs/design/in-pod-governance-signing.md
@@ -3,7 +3,8 @@
 **Status:** Draft (design)
 **Scope:** Replace SSH+CLI governance signing (`slanders/seienv`) with in-pod sidecar-based signing for K8s-hosted Sei validators
 **Authors:** Brandon Chatham (platform engineer); coral round dispatched kubernetes-specialist, blockchain-developer, platform-engineer
-**Last updated:** 2026-05-11
+**Last updated:** 2026-05-12
+**Revision:** rev2 — kube-rbac-proxy adoption (supersedes rev1's in-process TokenReview middleware design)
 **Issues:** sei-protocol/sei-k8s-controller#219 (CRD), sei-protocol/seictl#162 (keyring backend), #163 (sign-tx tasks), #164 (CLI), #165 (authn)
 **Workstream:** governance flow migration — replace `seienv` (EC2 + SSH + `seid tx` shell-out) with `seictl` + sidecar
 
@@ -13,7 +14,7 @@
 
 `slanders/seienv` performs validator governance operations (`MsgVote`, `MsgSubmitProposal`, `MsgDeposit`) by SSH-ing into EC2 validator hosts and shell-ing out to `seid tx gov ...` against the host's local `~/.seid/keyring-file/`. The pattern doesn't translate to Kubernetes — pods don't have SSH, the seid container is being made distroless, and "no shells in pods" is a stated platform direction.
 
-This design replaces that pattern with **library-based signing inside the seictl sidecar container**, using the Cosmos SDK packages already in seictl's `go.mod` (`sei-cosmos/client/tx`, `sei-cosmos/crypto/keyring`). The operator-account keyring lives in a Kubernetes Secret declared on the `SeiNode` CRD, mounted **only** on the sidecar container (never on the seid main container, never on bootstrap pods). The sidecar exposes typed task types (`gov-vote`, `gov-submit-proposal`, `gov-deposit`) over its existing HTTP task API. A new `seictl gov ...` subcommand surfaces this to human operators, with K8s-native authn (TokenReview) gating mutating endpoints in the final phase.
+This design replaces that pattern with **library-based signing inside the seictl sidecar container**, using the Cosmos SDK packages already in seictl's `go.mod` (`sei-cosmos/client/tx`, `sei-cosmos/crypto/keyring`). The operator-account keyring lives in a Kubernetes Secret declared on the `SeiNode` CRD, mounted **only** on the sidecar container (never on the seid main container, never on bootstrap pods). The sidecar exposes typed task types (`gov-vote`, `gov-submit-proposal`, `gov-deposit`) over its existing HTTP task API. A new `seictl gov ...` subcommand surfaces this to human operators, with K8s-native authn (kube-rbac-proxy sidecar) gating mutating endpoints in the final phase.
 
 **Precedent is already in tree:** `sidecar/tasks/generate_gentx.go` already opens a `keyring.New(...)`, builds a Cosmos SDK tx, signs in-process, and persists the result. The genesis path uses `BackendTest`; the governance path uses `BackendFile`. Mechanics are identical; only the backend and the broadcast step differ.
 
@@ -25,7 +26,7 @@ The work is decomposed into 5 issues. Phase 1 (#219 + #162) is independent and r
 - **Library-based, not shell-out.** Use the Cosmos SDK packages directly. Preserve the "no shells in pods" architectural commitment. Avoid CLI-stdout-as-IPC fragility, version drift, and trust-boundary collapse.
 - **Typed task surface.** Three explicit task types (`gov-vote`, `gov-submit-proposal`, `gov-deposit`) — not a generic "sign-and-broadcast" with raw Msg bytes. Better validation, better audit, easier authz when authn lands.
 - **Idempotent, crash-safe.** Caller-supplied UUID dedupe at the engine, plus tx-hash persistence before broadcast at the handler — a retry after a successful broadcast NEVER produces a duplicate transaction.
-- **K8s-native trust model.** TokenReview-based authn (Phase 4), `system:serviceaccount:…` allowlist, structured audit logs.
+- **K8s-native trust model.** Authn + authz via kube-rbac-proxy sidecar (Phase 4) terminating TLS and resolving SubjectAccessReviews against standard ClusterRoles; AWS IAM Identity Center → EKS access entries → K8s RBAC for human operators.
 - **Single canonical operator tool.** `seictl gov vote ...` replaces `seienv vote ...`. Fan-out across a `SeiNodeDeployment`'s validators is a flag, not a fleet management tool.
 - **Composes with existing genesis flow.** `generate_gentx.go`'s in-process signing pattern is the precedent; the new handlers extend the same shape with `BackendFile` and broadcast.
 
@@ -34,7 +35,7 @@ The work is decomposed into 5 issues. Phase 1 (#219 + #162) is independent and r
 - **Non-governance transactions.** Staking (`MsgDelegate`, `MsgUndelegate`), distribution (`MsgWithdrawDelegatorReward`), bank (`MsgSend`), IBC — same pattern, future issues if needed.
 - **Remote signers.** TMKMS, Horcrux, Vault, AWS KMS, HSM — `OperatorKeyringSource` is a discriminated union with `Secret` as the only initial variant; siblings are reserved as comments only.
 - **EVM-side operator transactions.** Sei's Cosmos-EVM address pairing is out of scope. EVM key material, contract ownership, EVM tx submission — not addressed here.
-- **Per-SeiNode authz granularity.** Phase 4 ships a coarse allowlist of caller identities. "This SA can vote but not submit-proposal" is deferred.
+- **Per-SeiNode authz granularity.** Phase 4 ships standard ClusterRoles binding caller identities to verbs on the `seinodes/tasks` virtual subresource. "This SA can vote but not submit-proposal" is deferred.
 - **Hot keyring rotation.** Passphrase change requires pod restart in v1. `POST /v0/admin/reload-keyring` is a v1.1 conversation.
 - **Multi-tenant cluster deployment.** Phase 1-3 ship without authn; deployment posture is single-tenant operator-controlled. Multi-tenant deployment requires Phase 4 to land first.
 - **CRD-managed operator-keyring Secret lifecycle.** The controller never creates, mutates, or deletes the Secret — operators ship it via SOPS / ESO / kubectl, same model as today's `signingKey` and `nodeKey`.
@@ -44,41 +45,57 @@ The work is decomposed into 5 issues. Phase 1 (#219 + #162) is independent and r
 ### Component map
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│ Operator workstation                                             │
-│  ┌────────────┐  kubeconfig + bearer token (Phase 4)             │
-│  │ seictl gov │ ─────────────────────────┐                       │
-│  └────────────┘                          │                       │
-└──────────────────────────────────────────│───────────────────────┘
-                                           │ HTTP POST /v0/tasks
+┌──────────────────────────────────────────────────────────────────────┐
+│ Operator workstation                                                 │
+│  ┌────────────┐  AWS SSO login → EKS kubeconfig → bearer token (P4)  │
+│  │ seictl gov │ ─────────────────────────┐                           │
+│  └────────────┘                          │                           │
+└──────────────────────────────────────────│───────────────────────────┘
+                                           │ HTTPS POST :8443
+                                           │ Authorization: Bearer <SA token>
                                            ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ K8s Pod (managed by sei-k8s-controller as StatefulSet)           │
-│                                                                  │
-│  ┌──────────────────────────┐    ┌────────────────────────────┐  │
-│  │ seictl sidecar           │    │ seid main container        │  │
-│  │  (distroless)            │    │  (chain runtime)           │  │
-│  │                          │    │                            │  │
-│  │  ┌────────────────────┐  │    │ /sei/config/               │  │
-│  │  │ keyring (in-mem)   │  │    │   priv_validator_key.json  │  │
-│  │  │  opened at startup │  │    │   node_key.json            │  │
-│  │  └────────────────────┘  │    │ /sei/data/                 │  │
-│  │  /sei/keyring-file/      │    │                            │  │
-│  │   <key>.info             │    │ RPC :26657                 │  │
-│  │   <hex>.address          │    │  ◄────── localhost ────────┼──┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ K8s Pod (managed by sei-k8s-controller as StatefulSet)               │
+│                                                                      │
+│  ┌─────────────────────────────┐                                     │
+│  │ kube-rbac-proxy             │  :8443 (0.0.0.0, TLS)               │
+│  │  - terminates TLS           │ ───────► TokenReview → APIserver    │
+│  │  - TokenReview              │ ───────► SubjectAccessReview        │
+│  │  - SubjectAccessReview      │                                     │
+│  │  - sets X-Remote-User       │                                     │
+│  │  - proxies → 127.0.0.1:7777 │                                     │
+│  └──────────────┬──────────────┘                                     │
+│                 │ loopback HTTP                                      │
+│                 ▼                                                    │
+│  ┌──────────────────────────┐    ┌────────────────────────────┐      │
+│  │ seictl sidecar           │    │ seid main container        │      │
+│  │  (distroless)            │    │  (chain runtime)           │      │
+│  │  binds 127.0.0.1:7777    │    │                            │      │
+│  │                          │    │ /sei/config/               │      │
+│  │  ┌────────────────────┐  │    │   priv_validator_key.json  │      │
+│  │  │ keyring (in-mem)   │  │    │   node_key.json            │      │
+│  │  │  opened at startup │  │    │ /sei/data/                 │      │
+│  │  └────────────────────┘  │    │                            │      │
+│  │  /sei/keyring-file/      │    │ RPC :26657                 │      │
+│  │   <key>.info             │    │  ◄────── localhost ────────┼──────┘
+│  │   <hex>.address          │    │                            │
 │  └──────────────────────────┘    └────────────────────────────┘
-│        ▲                                                         │
-│        │ mount mode 0o400, sidecar only                          │
-│  ┌─────┴─────────────────────────────────────────────────────┐   │
-│  │ Secret (kubectl/SOPS/ESO) — operator-managed              │   │
-│  │   keyring-file/<key>.info                                 │   │
-│  │   keyring-file/<hex>.address                              │   │
-│  └───────────────────────────────────────────────────────────┘   │
-│  ┌───────────────────────────────────────────────────────────┐   │
-│  │ Secret (separate) — passphrase only                       │   │
-│  │   passphrase: <pw>                                        │   │
-│  └───────────────────────────────────────────────────────────┘   │
-└──────────────────────────────────────────────────────────────────┘
+│        ▲                                                             │
+│        │ mount mode 0o400, sidecar only                              │
+│  ┌─────┴─────────────────────────────────────────────────────┐       │
+│  │ Secret (kubectl/SOPS/ESO) — operator-managed              │       │
+│  │   keyring-file/<key>.info                                 │       │
+│  │   keyring-file/<hex>.address                              │       │
+│  └───────────────────────────────────────────────────────────┘       │
+│  ┌───────────────────────────────────────────────────────────┐       │
+│  │ Secret (separate) — passphrase only                       │       │
+│  │   passphrase: <pw>                                        │       │
+│  └───────────────────────────────────────────────────────────┘       │
+│  ┌───────────────────────────────────────────────────────────┐       │
+│  │ Secret (cert-manager) — TLS for kube-rbac-proxy           │       │
+│  │   tls.crt / tls.key                                       │       │
+│  └───────────────────────────────────────────────────────────┘       │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 | Component | Repo | Issue |
@@ -87,7 +104,7 @@ The work is decomposed into 5 issues. Phase 1 (#219 + #162) is independent and r
 | **B.** Sidecar keyring backend (envs, smoke test, factory) | seictl | #162 |
 | **C.** Sign-tx task family (gov-vote, gov-submit-proposal, gov-deposit) | seictl | #163 |
 | **D.** seictl `gov` CLI subcommands | seictl | #164 |
-| **E.** Sidecar authn + authz middleware (final hardening) | seictl | #165 |
+| **E.** Sidecar authn + authz via kube-rbac-proxy (seictl + sei-k8s-controller) | seictl + sei-k8s-controller | #165 |
 
 ### Trust boundary
 
@@ -107,19 +124,23 @@ sequenceDiagram
     autonumber
     participant Op as Operator<br/>(seictl CLI)
     participant K8s as K8s API server
-    participant SC as seictl sidecar
+    participant Proxy as kube-rbac-proxy<br/>(0.0.0.0:8443)
+    participant SC as seictl sidecar<br/>(127.0.0.1:7777)
     participant SD as seid<br/>(local RPC :26657)
     participant Chain as Chain
 
     Op->>K8s: GET SeiNode/<name>
     K8s-->>Op: spec + status
-    Op->>Op: resolve sidecar URL<br/>(headless Service DNS)
+    Op->>Op: resolve sidecar URL<br/>(headless Service DNS, https://...:8443)
     Op->>K8s: TokenRequest (Phase 4)
     K8s-->>Op: bearer token
-    Op->>SC: POST /v0/tasks<br/>{type:gov-vote, params, taskId:UUID}<br/>Authorization: Bearer ... (Phase 4)
-    SC->>K8s: TokenReview (Phase 4)
-    K8s-->>SC: authenticated identity
-    SC->>SC: dedupe by UUID;<br/>dispatch handler
+    Op->>Proxy: POST /v0/tasks/gov/vote<br/>{params, taskId:UUID}<br/>Authorization: Bearer ...
+    Proxy->>K8s: TokenReview
+    K8s-->>Proxy: authenticated identity
+    Proxy->>K8s: SubjectAccessReview<br/>{verb:create, resource:seinodes/tasks, subresource:gov.vote}
+    K8s-->>Proxy: allowed
+    Proxy->>SC: POST /v0/tasks/gov/vote<br/>X-Remote-User: <caller><br/>(loopback HTTP)
+    SC->>SC: dedupe by UUID;<br/>dispatch handler;<br/>record caller on task
     SC->>SD: GET /status
     SD-->>SC: node_info.network
     SC->>SC: chain-id guard:<br/>params.chainId == status.network
@@ -127,17 +148,18 @@ sequenceDiagram
     SC->>SD: ABCI /auth.Query/Account
     SD-->>SC: accountNumber, sequence
     SC->>SC: build MsgVote;<br/>tx.Factory; Sign
-    SC->>SC: compute txHash =<br/>sha256(txBytes);<br/>persist {taskId, txHash}
+    SC->>SC: compute txHash =<br/>sha256(txBytes);<br/>persist {taskId, txHash, caller}
     SC->>SD: BroadcastTxSync(txBytes)
     SD-->>SC: TxResponse{code, txHash}
     SC->>SD: poll /tx?hash=...
     SD-->>SC: txResult{height, gasUsed}
     SC->>SC: persist final result
-    Op->>SC: GET /v0/tasks/{id} (poll)
-    SC-->>Op: {status:completed, txHash, height}
+    Op->>Proxy: GET /v0/tasks/{id} (poll)
+    Proxy->>SC: GET /v0/tasks/{id}
+    SC-->>Op: {status:completed, txHash, height, caller}
 ```
 
-On crash before step 17 (broadcast), the engine restart re-runs the handler with the same UUID. The handler queries `/tx?hash=<persistedHash>`:
+On crash before step 20 (broadcast), the engine restart re-runs the handler with the same UUID. The handler queries `/tx?hash=<persistedHash>`:
 
 - If found → success; populate result from chain
 - If not found AND sequence has not advanced → safe to re-sign and re-broadcast
@@ -228,6 +250,41 @@ type PassphraseSecretRef struct {
     // +kubebuilder:default="passphrase"
     // +kubebuilder:validation:MaxLength=253
     Key string `json:"key,omitempty"`
+}
+```
+
+### Sidecar TLS CRD additions (Phase 4)
+
+Add to `api/v1alpha1/seinode_types.go` alongside the existing sidecar spec:
+
+```go
+// SidecarTLSSpec configures the kube-rbac-proxy front-end TLS for the
+// sidecar's management API. Activates the proxy container; absent means
+// the sidecar runs without the proxy and binds 0.0.0.0:7777 (Phase 1-3
+// posture).
+type SidecarTLSSpec struct {
+    // IssuerRef references a cert-manager Issuer or ClusterIssuer that
+    // signs the proxy's serving certificate. The controller emits a
+    // cert-manager Certificate resource that requests a leaf cert for
+    // the sidecar's headless Service DNS name; cert-manager populates
+    // the resulting Secret which the proxy mounts.
+    //
+    // +kubebuilder:validation:Required
+    IssuerRef CertManagerIssuerRef `json:"issuerRef"`
+}
+
+// CertManagerIssuerRef mirrors cert-manager's ObjectReference shape so the
+// CRD does not depend on the cert-manager API surface at compile time.
+type CertManagerIssuerRef struct {
+    // +kubebuilder:validation:Required
+    Name string `json:"name"`
+    // Kind is "Issuer" or "ClusterIssuer". Defaults to "Issuer".
+    // +kubebuilder:default="Issuer"
+    // +kubebuilder:validation:Enum=Issuer;ClusterIssuer
+    Kind string `json:"kind,omitempty"`
+    // Group is "cert-manager.io". Defaults so.
+    // +kubebuilder:default="cert-manager.io"
+    Group string `json:"group,omitempty"`
 }
 ```
 
@@ -386,6 +443,17 @@ case task.TaskTypeValidateOperatorKeyring:
     return validateOperatorKeyringParams(node)
 ```
 
+### Planner integration delta (Phase 4)
+
+When `spec.sidecar.tls` is set, the planner emits two additional resources before the StatefulSet apply:
+
+```go
+if needsSidecarTLS(node) { prog = append(prog, task.TaskTypeApplySidecarCertificate) }
+if needsSidecarTLS(node) { prog = append(prog, task.TaskTypeApplyRBACProxyConfigMap) }
+```
+
+`ApplySidecarCertificate` emits a `cert-manager.io/v1` Certificate naming the headless Service DNS pattern (`*.<svc>.<ns>.svc.cluster.local` plus the bare `<svc>.<ns>.svc.cluster.local`). `ApplyRBACProxyConfigMap` emits the proxy's `--config-file` ConfigMap with the `resourceAttributes` mapping (see Component E).
+
 ### Mount construction
 
 In `internal/noderesource/noderesource.go`, add constants:
@@ -532,19 +600,47 @@ func assertNoValidatorSecretsOnBootstrapPod(node *seiv1alpha1.SeiNode, spec *cor
 
 Update the single existing caller. New file `internal/task/bootstrap_resources_test.go` (or extend the existing test) to cover: signing-key volume rejection, operator-keyring volume rejection, passphrase env rejection.
 
+### Pod-network exposure (added in Phase 4)
+
+The sidecar's HTTP API is no longer exposed on the pod network directly; Phase 4 binds the sidecar to loopback and fronts it with kube-rbac-proxy. The resulting per-container port table:
+
+| Container | Bind address | Port | Protocol | Listener | Exposed via Service |
+|---|---|---|---|---|---|
+| seictl sidecar | `127.0.0.1` | 7777 | HTTP (plain) | task API | no |
+| kube-rbac-proxy | `0.0.0.0` | 8443 | HTTPS (cert-manager) | TLS terminator → loopback | yes — Service port `api` |
+| seid | `0.0.0.0` | 26656 | TCP | P2P | yes (P2P only) |
+| seid | `127.0.0.1` | 26657 | TCP | Tendermint RPC | no (intra-pod only) |
+| seid | `127.0.0.1` | 1317 | TCP | Cosmos REST | no |
+| seid | `127.0.0.1` | 8545 / 8546 | TCP | EVM JSON-RPC / WS | no |
+| seid | `127.0.0.1` | 9090 | TCP | gRPC | no |
+| seid | `127.0.0.1` | 26660 | TCP | Prometheus metrics | no |
+
+Only `8443` (proxy) and `26656` (P2P) leave the pod by design.
+
+### Service spec delta
+
+The headless Service grows one new port and renames the existing one for clarity:
+
+```go
+corev1.ServicePort{Name: "api", Port: 8443, TargetPort: intstr.FromInt(8443)}  // Phase 4: rbac-proxy HTTPS
+corev1.ServicePort{Name: "p2p", Port: 26656, TargetPort: intstr.FromInt(26656)}
+```
+
+In Phase 1-3 (no `spec.sidecar.tls`), the Service exposes `:7777` plain HTTP as today. The controller switches the port spec based on `needsSidecarTLS(node)`.
+
 ### RBAC
 
 **Existing coverage:** `+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch` on `internal/controller/node/controller.go:63` is sufficient for reading both the keyring Secret and the passphrase Secret. **No new permission needed for Phase 1.**
 
-**Phase 4 addition** (TokenReview, when #165 lands): add the marker
+### cert-manager dependency (Phase 4)
 
-```go
-// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-```
+Phase 4 requires cert-manager to be installed in the cluster. The controller's pre-flight validates that a `cert-manager.io/v1` `Issuer` (or `ClusterIssuer`) named in `spec.sidecar.tls.issuerRef` exists and is `Ready=True` before emitting the Certificate. The controller does NOT install or manage cert-manager itself.
 
-alongside the existing block (`internal/controller/node/controller.go:53-63`). Run `make manifests` to regenerate. The new rule appears in `manifests/role.yaml` automatically.
+If cert-manager is not present, `spec.sidecar.tls` admission fails: "cert-manager.io CRDs not found in cluster — install cert-manager (https://cert-manager.io/docs/) or omit spec.sidecar.tls to run with the Phase 1-3 plain-HTTP posture." There is intentionally no self-signed fallback; the bootstrap surface is small enough that operators standardize on cert-manager.
 
-**Open question:** the sidecar currently runs under `p.ServiceAccount` (the platform-wide SA from `internal/platform/platform.go:24`). For tighter blast radius on TokenReview privilege, a follow-up workstream should mint a dedicated `sei-sidecar` SA with the narrow `tokenreviews:create` grant only. Out of scope for v1; documented as a Phase 4 follow-up.
+### AutomountServiceAccountToken — clarified
+
+The sidecar pod uses kubelet's default `automountServiceAccountToken: true` so that kube-rbac-proxy can read its own SA token to construct TokenReview / SubjectAccessReview requests against the API server. (The sidecar container itself no longer makes any K8s API calls in Phase 4 — that responsibility moves to the proxy.) Future hardening could drop the projected token from the sidecar's container view via per-container `volumeMounts` exclusions, but that's deferred until a concrete blast-radius case justifies the manifest churn.
 
 ### Container security context (recommended hardening — ships with Phase 1)
 
@@ -570,7 +666,6 @@ podSpec.SecurityContext = &corev1.PodSecurityContext{
 
 Notes:
 - `ReadOnlyRootFilesystem: true` is safe — the sidecar writes only to `sidecar.db` (SQLite) under `homeDir=/sei`, which is the PVC mount (writable).
-- `automountServiceAccountToken` is currently undeclared (kubelet default `true`). **Must stay true** for Phase 4 TokenReview to work; document the dependency in a code comment.
 - Do NOT extend this hardening to the seid main container in this workstream — that's a separate, larger blast-radius change.
 
 ---
@@ -692,6 +787,29 @@ const (
     TaskTypeGovSubmitProposal  TaskType = "gov-submit-proposal"
     TaskTypeGovDeposit         TaskType = "gov-deposit"
 )
+
+// TaskClass groups task types for URL routing and authz. The class is the
+// second URL segment after /v0/tasks; the type is the third. Authz lives
+// at the class level (one ClusterRole verb per class).
+type TaskClass string
+
+const (
+    TaskClassGov TaskClass = "gov"
+)
+
+// TaskRegistration binds a (class, type) pair to its handler factory.
+type TaskRegistration struct {
+    Class   TaskClass
+    Type    TaskType
+    Factory HandlerFactory
+}
+
+var taskRegistry = []TaskRegistration{
+    {TaskClassGov, TaskTypeGovVote, newGovVoteExecution},
+    {TaskClassGov, TaskTypeGovSubmitProposal, newGovSubmitProposalExecution},
+    {TaskClassGov, TaskTypeGovDeposit, newGovDepositExecution},
+    // ... existing registrations migrated to this shape ...
+}
 ```
 
 ### Param schemas
@@ -733,6 +851,46 @@ type GovDepositParams struct {
     Memo       string `json:"memo,omitempty"`
 }
 ```
+
+### API path shape (one-way door)
+
+The sidecar's task API moves from a single `POST /v0/tasks` endpoint with the task type embedded in the body to a path-routed shape with the (class, type) pair in the URL. This is necessary for kube-rbac-proxy to enforce per-class authz against the K8s API server's SubjectAccessReview — the proxy's `resourceAttributes` config selects the verb/resource from URL segments, not from the request body.
+
+| | rev1 (one path) | rev2 (class/type in path) |
+|---|---|---|
+| Submit | `POST /v0/tasks` (type in body) | `POST /v0/tasks/<class>/<type>` |
+| Read | `GET /v0/tasks/<id>` | `GET /v0/tasks/<id>` (unchanged) |
+| List | `GET /v0/tasks` | `GET /v0/tasks` (unchanged) |
+| Examples | `POST /v0/tasks` `{type:gov-vote, ...}` | `POST /v0/tasks/gov/vote` `{...}` |
+
+Routing sketch (`sidecar/server/server.go`):
+
+```go
+mux.HandleFunc("POST /v0/tasks/{class}/{type}", func(w http.ResponseWriter, r *http.Request) {
+    class := TaskClass(r.PathValue("class"))
+    typ   := TaskType(r.PathValue("type"))
+    reg, ok := lookupRegistration(class, typ)
+    if !ok {
+        writeError(w, http.StatusNotFound, "unknown task class/type")
+        return
+    }
+    // ... decode params, submit to engine ...
+})
+```
+
+This shape is a **one-way door**: once shipped, third-party operator tooling will encode URL patterns. Reverting to a body-routed shape would break authz at the proxy boundary. A future need for `<verb>` (e.g. `gov-vote/dry-run`) is handled additively via query param `?action=dry-run`, not by extending the path.
+
+### Caller attribution on the task record
+
+When kube-rbac-proxy authn/authz passes, it sets `X-Remote-User: <username>` on the proxied request. The sidecar reads this header on the loopback ingress and persists the caller alongside the task record:
+
+```go
+caller := r.Header.Get("X-Remote-User")
+// trust derives from the bind-127.0.0.1 invariant — see Component E
+task.CreatedBy = caller
+```
+
+Caller is exposed on `GET /v0/tasks/{id}` and surfaced by the CLI's rendered output. Audit logs include `caller` on every mutating request.
 
 ### Shared signing helper
 
@@ -956,8 +1114,9 @@ The codec is shared with `generate_gentx.go`'s pattern (`makeCodec()` returns a 
   "accountNumber": 17,
   "chainId":       "pacific-1",
   "msgType":       "/cosmos.gov.v1beta1.MsgVote",
-  "broadcastedAt": "2026-05-11T...",
-  "includedAt":    "2026-05-11T...",
+  "broadcastedAt": "2026-05-12T...",
+  "includedAt":    "2026-05-12T...",
+  "createdBy":     "<X-Remote-User from rbac-proxy>",
   // task-type-specific extension:
   "proposalId":    123                         // for gov-vote and gov-deposit
 }
@@ -968,11 +1127,11 @@ Minimum required: `{txHash, code, height, rawLog}`. The rest are operator-debug-
 ### OpenAPI schema update
 
 Update `sidecar/api/openapi.yaml`:
-1. Add `gov-vote`, `gov-submit-proposal`, `gov-deposit` to the task type enum
-2. Add per-type param schema components
-3. Add the result schema under the task result component
-4. Add a `securitySchemes: bearerAuth` declaration (Phase 4 will wire it; declare now for forward-compat)
-5. Add a top-level note: "Sign-tx tasks ship unauthenticated in Phase 1-3; see issue #165 for the authn enablement plan."
+- Replace the single `POST /v0/tasks` endpoint with the path-routed shape: `POST /v0/tasks/gov/vote`, `POST /v0/tasks/gov/submit-proposal`, `POST /v0/tasks/gov/deposit`. Per-type param schema components.
+- Add the result schema under the task result component, including `createdBy`.
+- Add `securitySchemes: bearerAuth` and apply to all mutating operations; document that authn is enforced by kube-rbac-proxy at the cluster boundary, not in-process.
+- Add a top-level note: "Sign-tx tasks ship unauthenticated in Phase 1-3; see issue #165 for the kube-rbac-proxy enablement plan."
+- Drop any rev1 references to in-process TokenReview / `SEI_AUTHZ_*` env vars.
 
 ### Client SDK helpers
 
@@ -984,7 +1143,7 @@ func (c *SidecarClient) SubmitGovSubmitProposalTask(ctx context.Context, taskID 
 func (c *SidecarClient) SubmitGovDepositTask(ctx context.Context, taskID string, p GovDepositParams) (*Task, error)
 ```
 
-Each thin wrapper around `SubmitTask` with the right type and params.
+Each thin wrapper around the right `POST /v0/tasks/<class>/<type>` endpoint.
 
 ### Pre-authn warning notice
 
@@ -995,12 +1154,15 @@ Until Phase 4 authn lands, each new handler file carries a top-of-file comment:
 //
 // This handler accepts sign-and-broadcast requests over the sidecar's HTTP
 // API, which is unauthenticated in Phase 1-3 of the governance-flow workstream.
-// Any caller with network reach to port 7777 can submit governance txs as
-// the validator's operator account. This is comparable to the seienv+SSH
-// status-quo trust scope (anyone with the SSH key has equivalent power)
-// but the K8s network blast radius is wider.
+// The sidecar binds 0.0.0.0:7777 in Phase 1-3; any caller with network reach
+// to that port can submit governance txs as the validator's operator account.
+// This is comparable to the seienv+SSH status-quo trust scope (anyone with
+// the SSH key has equivalent power) but the K8s network blast radius is wider.
 //
-// Phase 4 (#165) installs TokenReview-based authn on mutating endpoints.
+// Phase 4 (#165) fronts the sidecar with a kube-rbac-proxy sidecar container
+// that terminates TLS on 0.0.0.0:8443, runs TokenReview + SubjectAccessReview
+// against the cluster API server, and proxies to the sidecar bound on
+// 127.0.0.1:7777. The sidecar then trusts X-Remote-User on the loopback ingress.
 // REMOVE THIS NOTICE when #165 lands.
 ```
 
@@ -1042,30 +1204,63 @@ seictl gov vote 5 yes --deployment <SNDeployment-name> [--threads N]
 
 ### Sidecar discovery
 
+The CLI resolves the sidecar URL from the target SeiNode's headless Service. Phase 4 returns `https://...:8443`; Phase 1-3 returns `http://...:7777`. The toggle is whether the SeiNode has `spec.sidecar.tls` set:
+
 ```go
-// Pseudo-code
-func resolveSidecarURL(ctx context.Context, kc kubernetes.Interface, dyn dynamic.Interface, name, ns string) (string, error) {
+func resolveSidecarURL(ctx context.Context, dyn dynamic.Interface, name, ns string) (string, error) {
     obj, err := dyn.Resource(seinodeGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
     if err != nil { return "", err }
-    // Resolve headless Service DNS for this SeiNode's StatefulSet pod-0:
-    //   <name>-0.<name>.<ns>.svc.cluster.local:7777
-    return fmt.Sprintf("http://%s-0.%s.%s.svc.cluster.local:7777", name, name, ns), nil
+    tlsConfigured, _, _ := unstructured.NestedMap(obj.Object, "spec", "sidecar", "tls")
+    host := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local", name, name, ns)
+    if tlsConfigured != nil {
+        return fmt.Sprintf("https://%s:8443", host), nil
+    }
+    return fmt.Sprintf("http://%s:7777", host), nil
 }
 ```
 
-Operators running seictl from outside the cluster can override via `--sidecar-url` or use `kubectl port-forward` separately. The default in-cluster pattern is the recommended path.
+Operators running seictl from outside the cluster override via `--sidecar-url`, or use `kubectl port-forward` separately. The default in-cluster pattern is the recommended path.
 
 ### Authentication (Phase 4)
 
-Stub for Phase 4: when `SEI_AUTHZ_ENABLED=true` is observed on the target sidecar (via `GET /v0/status`), the CLI mints a token:
+Phase 4 uses the operator's kubeconfig as the source of truth for credentials. seictl invokes `client-go`'s standard rest-config loader, which automatically resolves bearer tokens from exec credential plugins (AWS `aws eks get-token`, GKE `gke-gcloud-auth-plugin`, OIDC `kubectl-oidc_login`, etc.). The resolved token is presented on the outgoing request:
 
 ```go
-tr, err := kc.CoreV1().ServiceAccounts(ns).CreateToken(ctx, saName, &authnv1.TokenRequest{}, metav1.CreateOptions{})
+restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+    loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
 if err != nil { return err }
-req.Header.Set("Authorization", "Bearer "+tr.Status.Token)
+// restCfg.BearerToken (or .ExecProvider) supplies the credential for HTTPS calls.
+tr, err := rest.TransportFor(restCfg)
+if err != nil { return err }
+httpClient := &http.Client{Transport: tr}
 ```
 
-Until Phase 4 ships, the CLI skips this step. The sidecar's `SEI_AUTHZ_ENABLED` flag controls whether the auth check is enforced server-side, so the CLI can be auth-aware ahead of time without breaking Phase 1-3 deployments.
+The TLS root CA for verifying the proxy's serving certificate comes from the cert-manager `Issuer` chain. The CLI prefers, in order:
+1. `--sidecar-ca-file <path>` if provided
+2. The `ConfigMap`/`Secret` named in the SeiNode's `spec.sidecar.tls.issuerRef` that exposes the trust root
+3. The system CA bundle (sufficient when the Issuer chains to a public root)
+
+If none verifies, the CLI errors with a clear remediation hint; it does NOT fall back to `InsecureSkipVerify`. There is no in-tree mTLS path for v1.
+
+### AWS SSO operator flow
+
+The expected human-operator flow on AWS-managed EKS:
+
+```
+$ aws sso login --profile validator-operator
+Successfully logged into Start URL: https://<org>.awsapps.com/start
+
+$ aws eks update-kubeconfig --name <cluster> --profile validator-operator
+Added new context arn:aws:eks:...:cluster/<cluster> to ~/.kube/config
+
+$ seictl gov vote 5 yes --validator val-0 --namespace sei-validators
+# client-go invokes `aws eks get-token` via the kubeconfig exec credential
+# plugin; the resulting bearer token is presented to kube-rbac-proxy; the
+# proxy verifies it via TokenReview against EKS, then runs SubjectAccessReview;
+# the request is forwarded to the sidecar with X-Remote-User set.
+```
+
+The mapping from AWS IAM principal to K8s identity is handled by EKS access entries (Path A); see Component E.
 
 ### Output
 
@@ -1073,9 +1268,10 @@ Default `--wait=true`: poll `GET /v0/tasks/{id}` until terminal, render result:
 
 ```
 $ seictl gov vote 5 yes --validator my-validator
-Submitted task abc-123 to my-validator-0...:7777
+Submitted task abc-123 to https://my-validator-0...:8443
 Waiting for inclusion ...
 ✓ tx 0xB7E2... included at height 1234567 (code=0, gasUsed=142318)
+  as: arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_ValidatorOperator/brandon
 ```
 
 Fan-out fan-in renders a table:
@@ -1090,6 +1286,10 @@ val-2             abc-125    failed     -          -         -        (chainId m
 
 Non-zero exit on any failure (operator triages from the table).
 
+### CLI output addition
+
+Phase 4 adds an `as: <identity>` line to single-validator rendered output (above) and a separate `--show-caller` flag for fan-out mode that adds a `CALLER` column to the table. The identity is whatever the kube-rbac-proxy resolved and persisted as `createdBy` on the task — typically the full `arn:aws:sts::.../AWSReservedSSO_*` SSO assumed-role ARN on EKS.
+
 ### Idempotent retry
 
 `--task-id <uuid>` lets an operator retry safely: same UUID → engine dedupe → same outcome. If absent, the CLI generates and prints the UUID so a retry is trivial.
@@ -1100,128 +1300,348 @@ New `docs/gov.md` mirroring the structure of `slanders/seienv/cheatsheet.md`'s g
 
 ---
 
-## Component E — Authn + authz middleware (seictl sidecar, Phase 4)
+## Component E — Authn + authz via kube-rbac-proxy (seictl + sei-k8s-controller)
 
-### Middleware shape
+### Why kube-rbac-proxy
 
-New file `sidecar/server/auth.go`. Wraps the existing mux in `NewServer`:
+The rev1 design landed authn + a static-allowlist authz layer inside the seictl sidecar binary (in-process TokenReview middleware + `SEI_AUTHZ_ALLOWED_CALLERS` env var). Reconsideration during the Phase 4 design pass surfaced three load-bearing problems:
+
+1. **Authz drift.** A static comma-separated env var is the wrong shape for a K8s-native authz layer — there's no `kubectl auth can-i`, no RoleBinding audit trail, no standard mechanism for granting operator humans the same privileges as the controller SA.
+2. **Cross-repo coupling.** Every authz change requires a sidecar rebuild + redeploy. Cluster operators expect to grant/revoke access via `kubectl apply` against ClusterRoleBinding manifests, not by editing controller env vars.
+3. **No AWS integration story.** Human-operator access (AWS SSO → EKS) has no clean path in the env-allowlist model. The `system:serviceaccount:...` shape isn't what `aws eks get-token` produces.
+
+[kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy) is the standard K8s solution for this problem. It runs as a sidecar container, terminates TLS, validates incoming bearer tokens via TokenReview, runs SubjectAccessReview against the cluster's RBAC, and proxies authenticated/authorized requests to a backend (here, the seictl sidecar on loopback). Adoption is widespread (kube-state-metrics, kube-prometheus-stack, OperatorHub) and the operational model maps directly to K8s RBAC.
+
+### Architecture
+
+```
+                                ┌──────────────────────────────────────┐
+                                │ K8s API server                       │
+                                │  /apis/authentication.k8s.io         │
+                                │  /apis/authorization.k8s.io          │
+                                └──────────────────────────────────────┘
+                                              ▲           ▲
+                                              │ TokenReview / SAR
+                                              │
+┌──────────────────────────────────────────────┼──────────┴───────────────┐
+│ SeiNode pod                                  │                          │
+│                                              │                          │
+│  ┌──────────────────────────┐                │                          │
+│  │ kube-rbac-proxy          │ ◄────────  HTTPS :8443 (TLS, cert-manager)│
+│  │                          │ ───────────────┘                          │
+│  │  /v0/* → SAR config      │                                           │
+│  │   verb=create/get/list   │                                           │
+│  │   resource=seinodes/tasks│                                           │
+│  │   subresource=gov.vote   │                                           │
+│  │                          │                                           │
+│  │  passes X-Remote-User    │                                           │
+│  │  passes X-Remote-Group   │ ───► HTTP loopback                        │
+│  └──────────────────────────┘                                           │
+│             │                                                           │
+│             ▼ 127.0.0.1:7777                                            │
+│  ┌──────────────────────────┐                                           │
+│  │ seictl sidecar           │                                           │
+│  │  binds 127.0.0.1 only    │                                           │
+│  │  trusts X-Remote-User    │                                           │
+│  │  on loopback ingress     │                                           │
+│  └──────────────────────────┘                                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Auth flow
+
+1. CLI presents `Authorization: Bearer <token>` to `https://<pod>:8443/v0/tasks/gov/vote`.
+2. kube-rbac-proxy strips and validates via `POST /apis/authentication.k8s.io/v1/tokenreviews`.
+3. On authenticated success, the proxy maps the URL path to `(group, resource, subresource, verb)` via its `resourceAttributes` config, runs `POST /apis/authorization.k8s.io/v1/subjectaccessreviews`, and proceeds only if `status.allowed=true`.
+4. The proxy adds `X-Remote-User`, `X-Remote-Group` (multi-valued), and `X-Remote-Extra-*` headers to the proxied request.
+5. The proxy forwards to `http://127.0.0.1:7777` over loopback. The sidecar reads `X-Remote-User`, records it on the task, and serves the request.
+6. Read-only endpoints (`GET /v0/tasks*`, `/v0/healthz`, `/v0/livez`) are configured `--allow-paths` / `--ignore-paths` in the proxy so they bypass SAR.
+
+### URL convention
+
+`POST /v0/tasks/<class>/<type>` (defined in Component C). Class drives the SAR `subresource`:
+
+| Path | SAR verb | SAR resource | SAR subresource |
+|---|---|---|---|
+| `POST /v0/tasks/gov/vote` | `create` | `seinodes/tasks` | `gov.vote` |
+| `POST /v0/tasks/gov/submit-proposal` | `create` | `seinodes/tasks` | `gov.submitproposal` |
+| `POST /v0/tasks/gov/deposit` | `create` | `seinodes/tasks` | `gov.deposit` |
+| `GET /v0/tasks` | (bypass) | — | — |
+| `GET /v0/tasks/{id}` | (bypass) | — | — |
+
+The `seinodes/tasks` "resource" is a virtual subresource — there's no real K8s resource by that name. SAR doesn't require one to exist; it's a label that ClusterRoles can grant. Using `seinodes/tasks` (rather than something CRD-specific) keeps the authz surface stable across SeiNode kind extensions.
+
+### resourceAttributes config
+
+The proxy ConfigMap (`<seinode>-rbac-proxy-config`) the controller emits:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-validator-rbac-proxy-config
+  namespace: sei-validators
+data:
+  config.yaml: |
+    authorization:
+      rewrites:
+        byHTTPPath:
+          path: "/v0/tasks/{class}/{type}"
+      resourceAttributes:
+        apiGroup: "sei.network"
+        resource: "seinodes/tasks"
+        subresource: "{class}.{type}"
+        namespace: "sei-validators"
+        name: "my-validator"
+        verb: "create"
+      allowedPaths:
+        - "/v0/healthz"
+        - "/v0/livez"
+        - "/v0/metrics"
+        - "/v0/tasks"           # GET list bypass
+        - "/v0/tasks/*"         # GET by-id bypass; mutating POST handled by resourceAttributes above
+```
+
+(The exact `allowedPaths` vs. `ignorePaths` mechanics depend on kube-rbac-proxy version — pin a recent release and verify the read-bypass path during Phase 4 implementation.)
+
+### TLS cert source
+
+The proxy serves TLS on `:8443`. The certificate comes from a cert-manager `Issuer` or `ClusterIssuer` referenced via `spec.sidecar.tls.issuerRef` on the SeiNode (see Component A). The controller emits a `Certificate` resource:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-validator-sidecar-tls
+  namespace: sei-validators
+spec:
+  secretName: my-validator-sidecar-tls
+  duration: 2160h          # 90 days
+  renewBefore: 360h        # 15 days
+  issuerRef:
+    name: <from spec.sidecar.tls.issuerRef.name>
+    kind: <Issuer|ClusterIssuer>
+    group: cert-manager.io
+  commonName: my-validator.sei-validators.svc.cluster.local
+  dnsNames:
+    - my-validator.sei-validators.svc.cluster.local
+    - my-validator-0.my-validator.sei-validators.svc.cluster.local
+```
+
+The `Issuer` itself is operator-owned — cluster operators choose self-signed-CA, internal CA, ACME, or a managed CA backend as appropriate. The controller is PCA-agnostic; the only assumption is `cert-manager.io/v1` API availability.
+
+### Pod-spec additions
+
+The controller adds two items when `spec.sidecar.tls` is set:
 
 ```go
-type authMiddleware struct {
-    inner   http.Handler
-    client  kubernetes.Interface
-    allowed map[string]struct{}
-    log     *seilog.Logger
+// Container
+proxyContainer := corev1.Container{
+    Name:  "kube-rbac-proxy",
+    Image: "quay.io/brancz/kube-rbac-proxy:v0.19.0",
+    Args: []string{
+        "--secure-listen-address=0.0.0.0:8443",
+        "--upstream=http://127.0.0.1:7777/",
+        "--config-file=/etc/kube-rbac-proxy/config.yaml",
+        "--tls-cert-file=/etc/tls/tls.crt",
+        "--tls-private-key-file=/etc/tls/tls.key",
+        "--logtostderr=true",
+        "--v=2",
+    },
+    Ports: []corev1.ContainerPort{{Name: "api", ContainerPort: 8443, Protocol: corev1.ProtocolTCP}},
+    VolumeMounts: []corev1.VolumeMount{
+        {Name: "rbac-proxy-config", MountPath: "/etc/kube-rbac-proxy", ReadOnly: true},
+        {Name: "sidecar-tls",       MountPath: "/etc/tls",             ReadOnly: true},
+    },
+    SecurityContext: &corev1.SecurityContext{
+        RunAsNonRoot:             ptr.To(true),
+        RunAsUser:                ptr.To[int64](65532),
+        AllowPrivilegeEscalation: ptr.To(false),
+        ReadOnlyRootFilesystem:   ptr.To(true),
+        Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+        SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+    },
 }
 
-var publicPaths = map[string]struct{}{
-    "/v0/healthz": {}, "/v0/livez": {}, "/v0/metrics": {},
-}
-
-func (a *authMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-    if _, public := publicPaths[r.URL.Path]; public {
-        a.inner.ServeHTTP(w, r)
-        return
-    }
-    // Read-only task endpoints (GET /v0/tasks*) are unauthenticated.
-    if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v0/tasks") {
-        a.inner.ServeHTTP(w, r)
-        return
-    }
-
-    reqID := uuid.NewString()
-    start := time.Now()
-    tok := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-    if tok == "" || tok == r.Header.Get("Authorization") {
-        a.audit(reqID, "", r, http.StatusUnauthorized, start)
-        writeError(w, http.StatusUnauthorized, "bearer token required")
-        return
-    }
-    tr, err := a.client.AuthenticationV1().TokenReviews().Create(r.Context(),
-        &authnv1.TokenReview{Spec: authnv1.TokenReviewSpec{Token: tok}}, metav1.CreateOptions{})
-    if err != nil || !tr.Status.Authenticated {
-        a.audit(reqID, "", r, http.StatusUnauthorized, start)
-        writeError(w, http.StatusUnauthorized, "token review failed")
-        return
-    }
-    caller := tr.Status.User.Username
-    if _, ok := a.allowed[caller]; !ok {
-        a.audit(reqID, caller, r, http.StatusForbidden, start)
-        writeError(w, http.StatusForbidden, "caller not permitted")
-        return
-    }
-    r = r.WithContext(context.WithValue(r.Context(), callerCtxKey{}, caller))
-    rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
-    a.inner.ServeHTTP(rw, r)
-    a.audit(reqID, caller, r, rw.status, start)
+// Volumes
+volumes := []corev1.Volume{
+    {Name: "rbac-proxy-config", VolumeSource: corev1.VolumeSource{
+        ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{
+            Name: node.Name + "-rbac-proxy-config",
+        }},
+    }},
+    {Name: "sidecar-tls", VolumeSource: corev1.VolumeSource{
+        Secret: &corev1.SecretVolumeSource{SecretName: node.Name + "-sidecar-tls", DefaultMode: ptr.To[int32](0o400)},
+    }},
 }
 ```
 
-Wire in `NewServer`:
+### Sidecar bind change
+
+`sidecar/server/server.go` binds the listener based on env:
 
 ```go
-var handler http.Handler = mux
-if os.Getenv("SEI_AUTHZ_ENABLED") == "true" {
-    handler = newAuthMiddleware(mux, kubeClient, parseAllowedCallers(os.Getenv("SEI_AUTHZ_ALLOWED_CALLERS")), log)
+addr := "0.0.0.0:7777"
+if os.Getenv("SEI_SIDECAR_LOOPBACK_ONLY") == "true" {
+    addr = "127.0.0.1:7777"
 }
-return &http.Server{Handler: handler, ...}
+listener, err := net.Listen("tcp", addr)
 ```
 
-### TokenReview client
+The controller injects `SEI_SIDECAR_LOOPBACK_ONLY=true` on the sidecar container when `spec.sidecar.tls` is set. Phase 1-3 (no TLS spec) leaves it unset and the sidecar binds `0.0.0.0:7777` as today.
 
-`kubernetes.NewForConfig(rest.InClusterConfig())` — pure Go, no CGO, distroless-compatible. Reads SA token from `/var/run/secrets/kubernetes.io/serviceaccount/token`. The sidecar's pod must have `automountServiceAccountToken: true` (currently kubelet default; will be made explicit in Component A's hardening).
+### Header reading
 
-Cache TokenReview results for 30s keyed on a SHA-256 of the bearer token to bound K8s API server load.
-
-### Allowlist
-
-`SEI_AUTHZ_ALLOWED_CALLERS` — comma-separated list of caller identities:
-
-```
-system:serviceaccount:sei-k8s-controller-system:sei-k8s-controller-manager,
-system:serviceaccount:operator-tools:gov-operator
-```
-
-Empty allowlist = fail-closed (deny all mutations).
-
-Authz model is intentionally coarse-grained in v1: any allowed caller can submit any task type. Per-task-type policy is a v1.1 conversation.
-
-### Audit logging
-
-Every authenticated request emits a structured `seilog` line:
-
-```json
-{
-  "msg":         "sidecar.api.mutation",
-  "event":       "sidecar.api.mutation",
-  "caller":      "system:serviceaccount:sei-k8s-controller-system:sei-k8s-controller-manager",
-  "method":      "POST",
-  "path":        "/v0/tasks",
-  "request_id":  "abc-123-...",
-  "result":      200,
-  "latency_ms":  47,
-  "task_type":   "gov-vote"
+```go
+// CallerFromRequest extracts the kube-rbac-proxy-injected identity headers
+// from a request that arrived on the loopback ingress.
+//
+// SECURITY POSTURE — DO NOT REMOVE
+// Trusting X-Remote-* is sound ONLY because the sidecar listener binds
+// 127.0.0.1 in Phase 4 (SEI_SIDECAR_LOOPBACK_ONLY=true). The Linux kernel
+// guarantees that loopback traffic never leaves the network namespace;
+// the only way to reach 127.0.0.1:7777 is to be inside the pod's net ns,
+// which means being kube-rbac-proxy (or a malicious sibling container,
+// which is a broader compromise that all loopback-trust patterns share).
+// If the bind ever regresses to 0.0.0.0 without removing this trust, an
+// off-pod attacker can spoof X-Remote-User. Asserted at startup; see
+// the bind check in serve.go and the e2e test in
+// sidecar/server/auth_test.go.
+func CallerFromRequest(r *http.Request) string {
+    return r.Header.Get("X-Remote-User")
 }
 ```
 
-`task_type` is added in a second log line emitted after the task type is parsed from the request body. For Phase 4 v1, two log lines per mutating request (one at auth-time with no task_type, one at handler-dispatch with task_type) is acceptable; collapse to one line in a follow-up.
+### RBAC manifests
+
+Two standard ClusterRoles ship with the controller chart. Operators bind them to identities via ClusterRoleBinding manifests.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sei-validator-governance-operator
+rules:
+  - apiGroups: ["sei.network"]
+    resources: ["seinodes/tasks"]
+    resourceNames: []   # unrestricted in v1; per-validator narrowing is operator-driven
+    verbs: ["create", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sei-validator-lifecycle-controller
+rules:
+  - apiGroups: ["sei.network"]
+    resources: ["seinodes/tasks"]
+    verbs: ["create", "get", "list"]
+```
+
+Example bindings:
+
+```yaml
+# Bind the sei-k8s-controller's own SA so it can submit non-gov lifecycle tasks.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sei-k8s-controller-tasks
+subjects:
+  - kind: ServiceAccount
+    name: sei-k8s-controller-manager
+    namespace: sei-k8s-controller-system
+roleRef:
+  kind: ClusterRole
+  name: sei-validator-lifecycle-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+# Bind an SSO-derived group for human operators.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: governance-operators-binding
+subjects:
+  - kind: Group
+    name: validator-governance-operators
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: sei-validator-governance-operator
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### AWS IAM Identity Center → EKS integration (Path A: EKS access entries)
+
+For AWS-managed EKS clusters, the recommended (and only documented) path maps IAM Identity Center permission sets to K8s RBAC via EKS access entries.
+
+Setup:
+
+1. **Permission set in IAM Identity Center.** Create a `ValidatorOperator` permission set with an inline policy granting `eks:DescribeCluster` on the target cluster ARN. No other AWS-side permissions required.
+2. **EKS access entry.** For each cluster, create an access entry mapping the SSO-provisioned IAM role to a K8s username + groups:
+   ```
+   aws eks create-access-entry \
+     --cluster-name <cluster> \
+     --principal-arn arn:aws:iam::<acct>:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_ValidatorOperator_<hash> \
+     --kubernetes-groups validator-governance-operators \
+     --type STANDARD
+   ```
+3. **ClusterRoleBinding** (above) binds the `validator-governance-operators` group to the `sei-validator-governance-operator` ClusterRole.
+
+The flow at request time:
+
+```
+aws sso login --profile validator-operator
+  → SSO issues an AssumeRoleWithSAML credential
+aws eks get-token --cluster-name <cluster>
+  → returns a signed EKS-flavored token whose subject is the SSO role
+client-go presents the token to kube-rbac-proxy
+  → kube-rbac-proxy → API server TokenReview
+    → API server resolves the access entry → username + groups
+  → kube-rbac-proxy → API server SubjectAccessReview
+    → groups match validator-governance-operators → ClusterRole allows
+  → proxy forwards to sidecar with X-Remote-User + X-Remote-Group set
+```
+
+The username surfaced as `X-Remote-User` is the full assumed-role ARN; this is what shows up in the CLI's `as: <identity>` line and in the sidecar's audit log.
 
 ### Phased rollout
 
-1. Phase 4 lands the middleware with `SEI_AUTHZ_ENABLED=false` default; existing controller flows are unaffected.
-2. Operators upgrade their controller manifest to inject `SEI_AUTHZ_ENABLED=true` + `SEI_AUTHZ_ALLOWED_CALLERS=<controller-SA>` on the sidecar container.
-3. Phase 5 (separate work): controller-side seictl-CLI updates to mint and present tokens by default.
-4. Remove the pre-authn warning notices from Component C's handlers and the README.
+| Phase | sidecar bind | proxy installed? | TLS | Authn | Authz | Caller attribution |
+|---|---|---|---|---|---|---|
+| 1-3 (today) | `0.0.0.0:7777` plain HTTP | no | none | none | none | none |
+| 4 (#165) | `127.0.0.1:7777` plain HTTP | yes (sidecar container) | cert-manager `:8443` | TokenReview at proxy | SubjectAccessReview at proxy | `X-Remote-User` recorded on task |
 
-### RBAC for the sidecar SA
+The Phase 4 transition is per-SeiNode and opt-in: setting `spec.sidecar.tls` flips the bind, adds the proxy container, and emits the Certificate + ConfigMap. SeiNodes without `spec.sidecar.tls` continue on the Phase 1-3 posture until operators migrate them. There is no hidden defaulting; the operator chooses by adding the field.
 
-Single new permission via kubebuilder marker on the controller:
+### Removal of the rev1 design
 
-```go
-// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+When Phase 4 lands, the following rev1 surfaces are deleted (not deprecated):
+
+- `sidecar/server/auth.go` middleware (in-process TokenReview + allowlist)
+- `SEI_AUTHZ_ENABLED` and `SEI_AUTHZ_ALLOWED_CALLERS` env vars
+- The TokenReview cache logic
+- Pre-authn warning notices in Component C handler files and the README
+
+The controller's `+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create` marker also goes away — the controller's own SA no longer needs `tokenreviews:create`. That permission moves to the proxy's own SA.
+
+### RBAC for the proxy's own SA
+
+The kube-rbac-proxy container runs under a per-SeiNode (or chart-shared) SA with two cluster-level permissions:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sei-rbac-proxy
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
 ```
 
-Run `make manifests` to regenerate `manifests/role.yaml`. Follow-up workstream: split the sidecar's SA from the controller-manager's SA for blast-radius isolation.
+A `ClusterRoleBinding` from this role to the proxy's SA ships with the controller chart. The seictl sidecar's SA no longer needs either of these.
 
 ---
 
@@ -1229,31 +1649,79 @@ Run `make manifests` to regenerate `manifests/role.yaml`. Follow-up workstream: 
 
 ### Trust boundary summary
 
-| Component | Has signing key? | Has node key? | Has operator keyring? |
-|---|---|---|---|
-| Operator laptop | No (Phase 4: bearer token only) | No | No |
-| seid main container | **Yes** (consensus) | **Yes** (P2P) | No |
-| seictl sidecar | No | No | **Yes** (governance) |
-| Bootstrap pod | No | No | No |
+| Component | Has signing key? | Has node key? | Has operator keyring? | Has K8s SA token? | Can authn/authz incoming requests? |
+|---|---|---|---|---|---|
+| Operator laptop | No (Phase 4: bearer token from kubeconfig exec credential) | No | No | No (uses kubeconfig identity) | n/a (client) |
+| seid main container | **Yes** (consensus) | **Yes** (P2P) | No | Yes (kubelet default) | n/a (no exposed mgmt API) |
+| seictl sidecar | No | No | **Yes** (governance) | Yes (kubelet default; unused in Phase 4) | No (trusts `X-Remote-User` from loopback) |
+| kube-rbac-proxy | No | No | No | Yes (used for TokenReview / SAR) | **Yes** (authoritative authn/authz front door) |
+| Bootstrap pod | No | No | No | Yes (kubelet default) | n/a (no exposed mgmt API) |
 
 Key separation rationale:
 - A compromised seid binary signs blocks (consensus key) but cannot vote on proposals (no operator keyring).
-- A compromised sidecar can vote/propose but cannot sign blocks or impersonate the P2P peer.
+- A compromised sidecar can vote/propose but cannot sign blocks or impersonate the P2P peer. It also cannot authenticate callers — that authority lives in a different container.
 - A compromised bootstrap pod runs `seid start --halt-height` with no on-chain identity; cannot sign anything.
+- A compromised kube-rbac-proxy can fabricate `X-Remote-User`, but it cannot directly sign — it would have to convince the sidecar to invoke a sign handler, which is still subject to the chain-confusion guard, idempotency dedupe, and audit logging. The blast radius is "the proxy can submit any task as any identity," not "the proxy can mint blocks."
 
 This is materially stronger than seienv's "operator account key on every EC2 host that runs seid" model.
+
+### Loopback-binding trust model
+
+The Phase 4 design rests on a single load-bearing invariant: **the seictl sidecar's management listener binds `127.0.0.1` and never `0.0.0.0` whenever it is configured to trust `X-Remote-User` from inbound requests**. If that invariant breaks, an off-pod attacker with cluster network reach can spoof any caller identity by setting the header themselves.
+
+Threat: loopback is shared at the pod-network-namespace level. Any container inside the same pod can `connect(127.0.0.1:7777)` and present a forged `X-Remote-User`. This is fine in the current pod composition (sidecar + seid + proxy + a possible init container), all of which are first-party images. It would NOT be fine if an arbitrary user-supplied sidecar were ever co-tenant in the pod — none is, and `SeiNode.spec` deliberately gives no surface to inject one.
+
+Mitigations:
+
+1. **Bind check at startup.** The sidecar reads its own listen address and refuses to start if `SEI_SIDECAR_LOOPBACK_ONLY=true` resolved to a non-loopback bind (e.g., due to a malformed override). The check is an assertion, not a config hint.
+2. **No `hostNetwork`.** The pod-spec builder hard-codes `hostNetwork: false` (it's not configurable). With `hostNetwork: true`, `127.0.0.1:7777` would be node-loopback and reachable from any other pod scheduled on that node — catastrophic.
+3. **shareProcessNamespace stays false** for separate reasons (see "Deferred" subsection below).
+4. **E2E test.** Phase 4 includes a regression test that: (a) starts the pod, (b) curls `https://<pod>:8443/v0/tasks/gov/vote` with a forged `X-Remote-User: kubernetes-admin` header and no bearer token, (c) asserts 401 from the proxy, (d) curls `http://<pod>:7777` from outside the pod and asserts connection refused.
 
 ### SSH-to-K8s trust scope comparison
 
 | Aspect | seienv (today) | sidecar (Phase 1-3) | sidecar (Phase 4) |
 |---|---|---|---|
-| Who can sign | Anyone with the SSH key | Anyone with network reach to pod:7777 | Anyone with a bearer token whose identity is in the allowlist |
-| Network blast radius | Reachable from operator subnet | Reachable from any in-cluster pod | Authenticated identity required; cluster network reach is necessary but not sufficient |
-| Key custody | Operator laptop SSH key + EC2 host keyring | Pod-mounted Secret only | Same |
-| Caller attribution | SSH user (`ubuntu`); shared key | None (anonymous) | TokenReview-validated identity |
-| Audit trail | EC2 `auth.log` + `seid` stdout on host | sidecar engine task store (no caller) | Structured audit log per mutating request |
+| Who can sign | Anyone with the SSH key | Anyone with network reach to pod:7777 | Anyone whose `aws sso login` → EKS access entry → ClusterRoleBinding chain authorizes `create seinodes/tasks/gov.*` |
+| Network blast radius | Reachable from operator subnet | Reachable from any in-cluster pod | TLS terminator at `:8443` requires valid bearer token + SAR-allowed identity; cluster network reach is necessary but far from sufficient |
+| Key custody | Operator laptop SSH key + EC2 host keyring | Pod-mounted Secret only | Same (pod-mounted Secret only); operator-side credential is the AWS SSO session, never long-lived |
+| Caller attribution | SSH user (`ubuntu`); shared key | None (anonymous) | Full assumed-role ARN from EKS access entry; persisted on the task record and emitted in structured audit logs |
+| Audit trail | EC2 `auth.log` + `seid` stdout on host | sidecar engine task store (no caller) | kube-rbac-proxy access log (per request) + sidecar audit log (per mutation) + task store `createdBy` |
+| Authz revocation | Rotate the SSH key | n/a | `kubectl delete clusterrolebinding ...` or revoke the SSO permission-set assignment in IAM Identity Center |
 
-**Phase 1-3 ships with comparable trust scope to today** (cluster network reach instead of SSH key). Phase 4 materially improves on the baseline.
+**Phase 1-3 ships with comparable trust scope to today** (cluster network reach instead of SSH key). Phase 4 materially improves on every row — most notably revocation, which moves from "rotate the key and redeploy seienv config" to a single `kubectl` command or an SSO console click.
+
+### What kube-rbac-proxy does NOT protect
+
+The proxy gates the sidecar's management HTTP API surface and nothing else. It is not a general pod-perimeter firewall. The following co-tenant ports remain reachable via their own protocols and are explicitly not protected by Phase 4 authn/authz:
+
+| Port | Protocol | Exposed via | Authn at this layer? | Notes |
+|---|---|---|---|---|
+| `26656` | Tendermint P2P | Service (P2P) | node-key handshake (not human authn) | chain-protocol surface; out of scope |
+| `26657` | Tendermint RPC | loopback only | none (binds 127.0.0.1) | not exposed off-pod by default |
+| `1317` | Cosmos REST | loopback only | none | not exposed off-pod by default |
+| `8545` / `8546` | EVM JSON-RPC / WS | loopback only | none | Sei dual-stack; not exposed off-pod by default |
+| `9090` | Cosmos gRPC | loopback only | none | not exposed off-pod by default |
+| `26660` | Prometheus metrics | loopback only | none | scraped via in-cluster Prometheus, which has its own auth story |
+
+If an operator exposes any of these off-pod (custom Service, NodePort, etc.), kube-rbac-proxy does NOT protect them. That's a separate decision and a separate authn story (Tendermint RPC has its own JWT module if needed; EVM RPC has nothing built in).
+
+Boundary statement: the proxy exists to gate the management API surface that the sidecar adds to a SeiNode pod — the `/v0/tasks/...` endpoints that submit signed transactions or mutate task state. The chain's own protocols (P2P, RPC, JSON-RPC, gRPC) have their own trust models and are explicitly out of scope for this design. Hardening those surfaces is independent and tracked separately if/when the platform exposes them.
+
+### AWS IAM Identity Center threat model
+
+Phase 4 introduces AWS SSO as the operator-credential issuance path on EKS clusters. Compromise scenarios:
+
+| Scenario | Blast radius | Mitigation |
+|---|---|---|
+| Compromised operator laptop with active SSO session | Whatever the SSO permission set authorizes, for the remaining session TTL (default 8h). EKS access entry → ClusterRoleBinding gates which K8s identities the role maps to. | SSO session TTL cap; require MFA on SSO; revoke permission-set assignment in IAM Identity Center |
+| Compromised IAM Identity Center directory user | The user's permission-set assignments, until directory account is disabled. | Standard IAM Identity Center directory hygiene; out of scope here |
+| Compromised AWS root in the cluster account | Total. Attacker can rewrite access entries, mint EKS tokens, edit ClusterRoleBindings. | Out of scope — AWS account compromise is a per-account incident-response problem |
+| Compromised K8s admin (`system:masters`) | Total within the cluster. Can sign anything via direct kubectl exec on the sidecar pod. | This is the standard K8s admin trust assumption; Phase 4 doesn't try to defend against it |
+| Compromised `kube-rbac-proxy` container image | Per-pod: attacker can fabricate `X-Remote-User` for any incoming request, but is still bound by the sidecar's chain-confusion guard, idempotency dedupe, and keyring presence. Cannot exfiltrate the operator keyring (no mount). | Pin proxy image digest; supply-chain provenance; cosign / sigstore verification at admission time (cluster-level concern) |
+| Stolen SSO refresh token (in browser/cookie) | Allows fresh SSO logins until revoked. Same as "compromised laptop with active session" effectively. | Short SSO session TTL; immediate revocation via IAM Identity Center on incident |
+
+The single most important defensive property: **revocation is a single `kubectl delete` or SSO console click**, not a key rotation. This is the structural argument for moving off seienv-style shared SSH keys.
 
 ### Container security context (re-stated)
 
@@ -1265,11 +1733,21 @@ Tightened in Component A as part of Phase 1:
 - `capabilities.drop: [ALL]`
 - `seccompProfile: RuntimeDefault`
 - Pod-level `fsGroup: 65532` (required so non-root sidecar can read 0o400 Secret mounts)
-- `automountServiceAccountToken: true` (kubelet default; documented dependency)
+- `automountServiceAccountToken: true` (kubelet default; required so the rbac-proxy container can read the projected SA token)
+
+The kube-rbac-proxy container ships with the same security context (Component E).
 
 ### Slashing risk
 
-Governance-tx signing is **not** double-sign-able in the consensus sense — voting twice on the same proposal is rejected by the chain (proposer-vote uniqueness), not slashed. The chain-confusion guard prevents cross-chain signature exposure. The chief remaining operational risk is "submit-proposal with wrong upgrade height" which is a manual-input bug, not a protocol-level slashing event.
+Governance-tx signing is **not** double-sign-able in the consensus sense — voting twice on the same proposal is rejected by the chain (proposer-vote uniqueness), not slashed. The chain-confusion guard prevents cross-chain signature exposure. The chief remaining operational risk is "submit-proposal with wrong upgrade height" which is a manual-input bug, not a protocol-level slashing event. Phase 4's caller attribution makes such operator errors investigable after the fact — the audit log records which SSO-derived identity submitted the bad proposal, so the operator team can triage without guessing.
+
+### Deferred: shareProcessNamespace / sidecar-seid UID separation
+
+`shareProcessNamespace` is currently unset (kubelet default `false`) on SeiNode pods. With it `true`, every container in the pod would see every other container's processes — the sidecar could `ptrace` the seid process or read its memory, which would defeat the entire signing-key/operator-keyring boundary that this design rests on. The runtime guard for "is `shareProcessNamespace` false" is currently implicit (we never set it true); making it an asserted hard-no is tracked in `sei-protocol/sei-k8s-controller#221`.
+
+Related and also deferred to #221: the sidecar and seid containers currently both run with UIDs the pod-spec builder picks (`65532` for the hardened sidecar; whatever the seid image uses for seid main). Aligning these explicitly so kernel-level UID separation is documented and asserted rather than implicit is part of the same workstream.
+
+These items remain Phase 4-adjacent rather than Phase 4-blocking: the kube-rbac-proxy adoption doesn't depend on them, and the loopback-binding trust model holds without them under the current pod composition. They're called out here so the reader understands that "co-tenant container compromise" remains a residual risk dimension that #221 closes separately.
 
 ---
 
@@ -1386,12 +1864,46 @@ Phase 3 (depends on #163, ~1 week):
 
 **Genesis-network validation gate** between Phase 3 and Phase 4: deploy a fresh genesis network using the existing `SeiNodeDeployment` genesis-ceremony machinery, exercise the full submit-proposal → vote → upgrade flow end-to-end. Confirm idempotency on simulated sidecar crashes mid-broadcast. This is the gate before opening the surface to real mainnet validators.
 
-Phase 4 (final hardening, ~1 week):
-- **#165** (seictl): TokenReview-based authn middleware, audit logging, RBAC additions in the controller for `tokenreviews:create`, seictl CLI token minting, removal of pre-authn warning notices
+Phase 4 (final hardening, ~1-2 weeks; work spans both repos):
+- **#165** (seictl + sei-k8s-controller):
+  - seictl side: URL path refactor `POST /v0/tasks/<class>/<type>`; sidecar binds `127.0.0.1:7777` when `SEI_SIDECAR_LOOPBACK_ONLY=true`; reads `X-Remote-User` from loopback ingress and records caller attribution on the task; CLI honors HTTPS sidecar URL + bearer token from kubeconfig; removal of pre-authn warning notices.
+  - sei-k8s-controller side: `SidecarTLSSpec` CRD field; pod-spec emits the kube-rbac-proxy container with cert-manager-issued TLS; emits the Certificate resource and the rbac-proxy ConfigMap; Service grows the `:8443` port; standard ClusterRoles (`sei-validator-governance-operator`, `sei-validator-lifecycle-controller`) ship in the chart; AWS IAM Identity Center → EKS access entries integration documented.
 
 ---
 
 ## Alternatives considered
+
+### In-process TokenReview middleware (originally-designed model)
+
+The rev1 design landed authn inside the seictl sidecar binary: an `authMiddleware` wrapped the mux, called `TokenReviews().Create(...)` against the API server, and checked the result against a static comma-separated env-var allowlist (`SEI_AUTHZ_ALLOWED_CALLERS`). Audit logging was an in-process structured log emitter.
+
+**Rejected** in favor of kube-rbac-proxy because:
+
+| Dimension | In-process middleware | kube-rbac-proxy | pods/proxy | APIService | Istio AuthN |
+|---|---|---|---|---|---|
+| Authn surface | Custom Go code in sidecar | Standard `kube-rbac-proxy` binary | API server proxies (built-in) | Aggregated API server (built-in) | Service mesh |
+| Authz surface | Static env-var allowlist | K8s RBAC (ClusterRole/Binding) | K8s RBAC | K8s RBAC | Istio policies (separate) |
+| AWS SSO integration | None (would need bespoke work) | Native via EKS access entries | Native (uses API server) | Native | Bespoke |
+| `kubectl auth can-i` | No | Yes | Yes | Yes | No |
+| Cross-repo coupling | High (every authz change rebuilds sidecar) | Low (chart-managed manifests) | Medium | High | Low |
+| Operational maturity | Bespoke | Widely adopted in K8s ecosystem | Built-in but rarely used for app-mgmt APIs | Heavyweight; aggregated-API ceremony | Widely adopted but heavyweight for one API |
+| Cluster prerequisites | None | cert-manager | None | None | Istio |
+| Per-call cost | 1× TokenReview (in-process cache) | 1× TokenReview + 1× SAR (proxy cache) | 1× TokenReview + 1× SAR at API server | 1× TokenReview + 1× SAR at API server | mTLS handshake |
+| Audit trail | sidecar log only | proxy log + sidecar log + K8s audit log | K8s audit log | K8s audit log | Istio telemetry |
+
+kube-rbac-proxy wins on every dimension the rev1 design left to follow-on work: AWS SSO integration, standard RBAC, revocation UX, `kubectl auth can-i` support. The single new prerequisite (cert-manager) is satisfied by every cluster we operate in. Other options were considered and dropped:
+
+- **`pods/proxy`**: routes through the API server's pod proxy. Avoids the cert-manager dep but couples request latency to API server load, doesn't support arbitrary URL shapes cleanly (path encoding gymnastics), and the audit trail is split across the API server's audit log and the sidecar's. Loses on UX (operators have to type `kubectl proxy` flows or use the API server URL directly).
+- **APIService aggregation**: heavyweight. Requires running a TLS-fronted API service registered with the aggregator, full apimachinery surface in the sidecar. Worthwhile if we wanted the sidecar to look like a first-class K8s resource type with `kubectl get tasks` semantics; we don't.
+- **Istio AuthN**: assumes the cluster runs Istio. We don't mandate Istio, and Phase 4 should not be the wedge that introduces it.
+
+### Removal of `SEI_AUTHZ_*` env vars
+
+The rev1 design wired authz via two env vars on the seictl sidecar:
+- `SEI_AUTHZ_ENABLED=true|false`
+- `SEI_AUTHZ_ALLOWED_CALLERS=system:serviceaccount:ns:sa,...`
+
+These are deleted in rev2, not deprecated. There is no migration path — the env vars never appeared in a released chart, and rev2 ships before rev1 lands in production. Cluster operators upgrading from a pre-rev2 dev build remove the env-var injection from their controller manifest in the same change that adds `spec.sidecar.tls` to their SeiNodes.
 
 ### Shell-out to seid binary in shared PVC
 
@@ -1438,21 +1950,21 @@ Considered: cache `(accountNumber, sequence)` in the engine store; reuse on retr
 
 ### mTLS for sidecar authn (Phase 4)
 
-Considered: client-cert-based mTLS instead of TokenReview.
+Considered: client-cert-based mTLS instead of bearer-token-fronted-by-rbac-proxy.
 
 **Rejected** for v1 because:
-- TokenReview is K8s-native and operator-tooling-native (`kubectl create token` is the operator UX)
-- mTLS imposes cert rotation overhead and PKI surface that K8s already provides via SA tokens
-- TokenReview is additively replaceable if mTLS becomes desired later
+- mTLS imposes cert rotation overhead on every operator workstation; SSO bearer tokens have a clean issuance + rotation story via existing AWS SSO + EKS plumbing.
+- Bearer-token authn at kube-rbac-proxy is K8s-native and operator-tooling-native (`kubectl create token`, `aws eks get-token`, kubeconfig exec credential plugins all just work).
+- mTLS is additively introducible later if a concrete use case demands it (e.g., service-to-service flows where bearer tokens don't fit).
 
 ### Per-SeiNode SAs
 
 Considered: controller mints a dedicated SA per SeiNode for blast-radius isolation.
 
 **Deferred** to a future workstream because:
-- Single shared `p.ServiceAccount` is sufficient for the coarse allowlist authz of Phase 4
-- Per-SeiNode SAs need their own RBAC machinery in the controller, more cluster-level objects, namespacing decisions
-- Not needed until multi-tenant clusters or per-validator authz becomes a requirement
+- Phase 4 already separates the proxy SA from the sidecar SA from the controller SA, which is the most operationally relevant isolation.
+- Per-SeiNode SAs need their own RBAC machinery in the controller, more cluster-level objects, namespacing decisions.
+- Not needed until multi-tenant clusters or per-validator authz becomes a requirement.
 
 ### Single Secret for keyring + passphrase
 
@@ -1469,25 +1981,28 @@ Two separate Secrets is operationally a small cost; architecturally it preserves
 
 ## Open questions
 
-- **TokenReview cache TTL.** 30s is the recommended default. Worth load-testing in Phase 4 against expected operator-tool call rates.
+- **cert-manager mandate vs. self-signed fallback.** Phase 4 currently refuses to enable TLS without a cert-manager `Issuer`. Revisit if airgapped or single-node operator deployments surface as a real use case; the cleanest extension is an `Issuer` of `kind: SelfSignedIssuer` from cert-manager itself, but that still requires cert-manager.
+- **IAM Identity Center OIDC integration path.** An alternative to EKS access entries is configuring the cluster to trust IAM Identity Center's OIDC issuer directly. Defer until a concrete cluster setup requires it; current recommendation is Path A (access entries) only.
+- **URL path third segment shape.** The current rev2 shape is `/v0/tasks/<class>/<type>` with no per-type verb segment. If a future task family needs `<verb>` (e.g. `gov-vote/dry-run`), the additive escape hatch is a query param `?action=dry-run`, not a fourth path segment — extending the path would require revisiting kube-rbac-proxy's `resourceAttributes` rewrites.
+- **AWS IAM Identity Center session TTL recommendation.** IAM Identity Center's default permission-set session is 8 hours. Should the validator-operator permission set cap at 4 hours? Tradeoff is operator UX (re-login frequency) vs. blast-radius window on a compromised laptop. Open for review with the security team.
 - **Test backend allowlist.** Should `SEI_KEYRING_BACKEND=test` be allowed in production? Recommendation: refuse if `SEI_CHAIN_ID` matches a known mainnet pattern (e.g., `pacific-1`, `arctic-1`). Implementation detail for #162 reviewers.
 - **`UpgradeInfo` semantics for binary handoff.** Sei-specific: does the chain consume `Plan.Info` to download new binaries (e.g., via cosmovisor)? Confirm and document the expected format (URL? structured JSON?) in `docs/gov.md`.
 - **Fan-out concurrency model.** The CLI's `--threads` flag is a hard cap; should there be a per-validator timeout to prevent one stuck sidecar from stalling the whole fan-out?
-- **Phase 4 sidecar SA migration.** Today `p.ServiceAccount` is shared; Phase 4 adds `tokenreviews:create` to it. Migration to a dedicated `sei-sidecar` SA is a follow-up — tracked separately or rolled into Phase 4? Default recommendation: separate follow-up, after Phase 4 has been operationally validated.
 
 ---
 
 ## References
 
 ### Coral session
-This design synthesizes a coral round (2026-05-11) with kubernetes-specialist, blockchain-developer, and platform-engineer specialists.
+This design synthesizes a coral round (2026-05-11) with kubernetes-specialist, blockchain-developer, and platform-engineer specialists; rev2 incorporates a follow-up coral round (2026-05-12) with kubernetes-specialist and security-specialist on the Phase 4 authn architecture.
 
 ### GitHub issues
 - sei-protocol/sei-k8s-controller#219 — CRD `validator.operatorKeyring`
+- sei-protocol/sei-k8s-controller#221 — `shareProcessNamespace` assertion + UID separation (deferred)
 - sei-protocol/seictl#162 — Sidecar production keyring backend
 - sei-protocol/seictl#163 — Sidecar sign-tx task family
 - sei-protocol/seictl#164 — seictl gov CLI subcommands
-- sei-protocol/seictl#165 — Sidecar authn middleware
+- sei-protocol/seictl#165 — Sidecar authn via kube-rbac-proxy
 
 ### Code references
 - `sei-protocol/seictl` — sidecar repo
@@ -1524,8 +2039,16 @@ This design synthesizes a coral round (2026-05-11) with kubernetes-specialist, b
 - Default sign mode: `SIGN_MODE_DIRECT`
 - Gov module shape: v1beta1 (not v1 — Sei has not migrated)
 
+### External references
+- kube-rbac-proxy: https://github.com/brancz/kube-rbac-proxy
+- cert-manager: https://cert-manager.io/docs/
+- AWS EKS access entries: https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html
+- AWS IAM Identity Center: https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html
+- K8s RBAC documentation: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+
 ---
 
 ## Changelog
 
 - 2026-05-11 — Initial draft (coral synthesis)
+- 2026-05-12 — rev2: replace in-process TokenReview middleware (Component E) with kube-rbac-proxy sidecar pattern. URL path refactor (`/v0/tasks/<class>/<type>`). Sidecar binds 127.0.0.1; rbac-proxy fronts on 0.0.0.0:8443 with cert-manager-issued TLS. Caller attribution via X-Remote-User headers. AWS IAM Identity Center → EKS access entries → K8s RBAC. shareProcessNamespace gap remains in #221, reasserted in Security posture. SEI_AUTHZ_ENABLED/SEI_AUTHZ_ALLOWED_CALLERS env vars deleted (not deprecated).


### PR DESCRIPTION
## Summary

Revises the in-pod governance signing design (rev1 merged in #166) to replace the originally-designed in-process TokenReview middleware (Component E) with the canonical **kube-rbac-proxy** sidecar pattern.

The rev1 design landed authn + a static-allowlist authz layer inside the seictl sidecar binary (`SEI_AUTHZ_ENABLED` / `SEI_AUTHZ_ALLOWED_CALLERS`). The team's directive: auth should not live in the sidecar process at all — by the time a request crosses into the sidecar's handler, it should already be authenticated and authorized.

## Architecture change

**rev1:**
```
caller → sidecar:7777 → in-process middleware (TokenReview + env allowlist) → handler
```

**rev2:**
```
caller → kube-rbac-proxy:8443 (TLS, TokenReview + SubjectAccessReview)
       → seictl sidecar 127.0.0.1:7777 (loopback only)
       → handler reads X-Remote-User, dispatches task
```

Auth is fully K8s-native: standard `ClusterRole` + `ClusterRoleBinding` against virtual `sidecartasks.sei.io/<class>/<type>` resources. Operators manage permissions via standard `kubectl`/GitOps. Audit comes from the K8s API server's audit log (`TokenReview` + `SubjectAccessReview` recorded per call) plus a structured sidecar log line per task plus a `submittedBy` field on the task record.

## What changes

| Change | Where | Impact |
|---|---|---|
| URL path refactor | Component C | `POST /v0/tasks/<class>/<type>` instead of body-typed. Proxy maps path to SAR resource attributes. |
| Sidecar binds loopback | Component E | `127.0.0.1:7777` only. Trust model rests on this. |
| kube-rbac-proxy container added | Component A | New container in the SeiNode pod spec. Cert-manager-issued TLS. |
| Caller attribution | Component C | `submittedBy`, `submittedAt`, `submittedByGroups` from `X-Remote-User` headers. |
| AWS IAM Identity Center integration | Component E + D | `aws sso login` → `aws eks get-token` → bearer flows transparently. EKS access entries map IAM principals to K8s groups. |
| `SEI_AUTHZ_*` env vars deleted | Component E | Not deprecated — deleted entirely. The CLI/operator-facing path no longer has an in-process auth toggle. |
| `SidecarTLSSpec` CRD field | Component A | New optional field on `ValidatorSpec.SidecarTLS` referencing a cert-manager Issuer. |
| Phase 4 scope spans both repos | Implementation sequencing | seictl (URL refactor + bind + headers) + sei-k8s-controller (pod-spec + Certificate + ConfigMap + Service). |
| P2P explicit non-scope | Security posture | New subsection: CometBFT P2P / RPC / EVM JSON-RPC / gRPC do NOT route through the proxy. Chain-protocol auth is the chain's job. |

## Why now

The user's framing surfaced two principles rev1 missed:
1. **Sidecar should be auth-free.** Layered auth is confusing; an attack on the middleware is a bypass. kube-rbac-proxy externalizes the trust decision to a hardened single-purpose binary.
2. **K8s RBAC is the right authz surface.** Env-var allowlists aren't GitOps-native; AWS SSO users can't naturally map onto them; per-task-class granularity becomes RBAC verbs/resources for free.

The rev1 design is referenced as the FIRST "Alternative considered" with the trade-off table (in-process / kube-rbac-proxy / pods/proxy / APIService / Istio).

## Test plan

- [ ] Render check on GitHub (architecture diagrams, tables, code blocks all display correctly)
- [ ] Confirm `SEI_AUTHZ_*` references only appear in explicit "deletion documentation" sections (Alternatives + Removal-of-rev1 + changelog) — already verified by grep
- [ ] Confirm Phase 4 description is consistent across Implementation sequencing, Component E phased rollout, Component C pre-authn warning notice
- [ ] Confirm "P2P out of scope" boundary statement is unambiguous
- [ ] Verify the AWS IAM Identity Center → EKS access entries flow matches the team's existing kubeconfig patterns

## Follow-ups

After this merges, three issue bodies need to be updated to reflect rev2:
- sei-protocol/seictl#165 — full rewrite (kube-rbac-proxy + URL refactor + RBAC manifests, dual-repo scope)
- sei-protocol/seictl#163 — URL path note added (caller attribution shape)
- sei-protocol/seictl#164 — proxy target + AWS SSO flow note

Will fire those updates after this PR merges so the issues reference the merged rev2 doc rather than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change, but it materially alters the proposed security/auth architecture (kube-rbac-proxy + cert-manager + RBAC) and API shape (`/v0/tasks/<class>/<type>`), so reviewers should sanity-check the new assumptions and rollout plan.
> 
> **Overview**
> Updates the in-pod governance signing design doc to **rev2**, replacing the proposed in-process `TokenReview` + env allowlist with a **kube-rbac-proxy sidecar** that terminates TLS on `:8443` and enforces authn/authz via `TokenReview` + `SubjectAccessReview` against standard Kubernetes RBAC.
> 
> Specifies knock-on design changes: the sidecar task submission API becomes **path-routed** (`POST /v0/tasks/<class>/<type>`) to support proxy authz mapping, the seictl sidecar binds `127.0.0.1:7777` behind the proxy, and task records/CLI output gain **caller attribution** via `X-Remote-User`. It also documents new Phase 4 CRD/ops requirements like `spec.sidecar.tls` (cert-manager `IssuerRef`), controller-emitted `Certificate`/proxy `ConfigMap`, Service port changes, and an AWS SSO → EKS access entries → RBAC flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f27659b3b98ea45bb68bd055d015c41dc80026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->