### PR TITLE
sidecar: harden /tx?hash= discriminator and lock ctx-plumbing audit

### DIFF
--- a/sidecar/tasks/transactions.go
+++ b/sidecar/tasks/transactions.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	rpchttp "github.com/sei-protocol/sei-chain/sei-tendermint/rpc/client/http"
+	rpctypes "github.com/sei-protocol/sei-chain/sei-tendermint/rpc/jsonrpc/types"
 
 	"github.com/sei-protocol/sei-chain/sei-cosmos/client"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/codec"
@@ -103,11 +104,14 @@ func (c *sdkTxClient) QueryTx(ctx context.Context, txHashHex string) (*sdk.TxRes
 	if err != nil {
 		return nil, false, fmt.Errorf("decode tx hash %q: %w", txHashHex, err)
 	}
+	// ctx is plumbed through to the underlying http.Request via
+	// NewRequestWithContext in sei-tendermint's jsonrpc HTTP client
+	// (sei-tendermint/rpc/jsonrpc/client/http_json_client.go) —
+	// cancellation aborts the in-flight call, so the 30s tmRPCTimeout
+	// is a redundant upper bound, not the only guardrail.
 	res, err := c.clientCtx.Client.Tx(ctx, hashBytes, false)
 	if err != nil {
-		// CometBFT returns "tx not found" when the node has no record;
-		// treat any "not found" substring as found=false.
-		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+		if isTxNotFound(err) {
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("query /tx?hash=%s: %w", txHashHex, err)
@@ -124,6 +128,21 @@ func (c *sdkTxClient) QueryTx(ctx context.Context, txHashHex string) (*sdk.TxRes
 		GasUsed:   res.TxResult.GasUsed,
 	}
 	return resp, true, nil
+}
+
+// isTxNotFound discriminates "the node has no record of this tx" from
+// every other failure mode of /tx?hash=. Server-side, all handler
+// errors come back as JSON-RPC CodeInternalError (sei-tendermint's
+// MakeError, types.go:171); the "tx not found" message lands in the
+// Data field. Transport errors (DNS, connection-refused, timeout) are
+// NOT *rpctypes.RPCError, so the type assertion fences them out — a
+// DNS "host not found" cannot be confused with a missing tx.
+func isTxNotFound(err error) bool {
+	var rpcErr *rpctypes.RPCError
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+	return strings.Contains(rpcErr.Data, "not found")
 }
 
 // newSignTxInterfaceRegistry registers only the proto interfaces sign-tx

--- a/sidecar/tasks/transactions_test.go
+++ b/sidecar/tasks/transactions_test.go
@@ -1,0 +1,50 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	rpctypes "github.com/sei-protocol/sei-chain/sei-tendermint/rpc/jsonrpc/types"
+)
+
+func TestIsTxNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "server-side tx not found",
+			err:  &rpctypes.RPCError{Code: int(rpctypes.CodeInternalError), Message: "Internal error", Data: "tx (DEADBEEF) not found, err: index not enabled"},
+			want: true,
+		},
+		{
+			name: "server-side other internal error",
+			err:  &rpctypes.RPCError{Code: int(rpctypes.CodeInternalError), Message: "Internal error", Data: "kvEventSink disabled"},
+			want: false,
+		},
+		{
+			name: "wrapped RPCError still discriminates",
+			err:  fmt.Errorf("query /tx: %w", &rpctypes.RPCError{Code: int(rpctypes.CodeInternalError), Data: "tx (BEEF) not found, err: x"}),
+			want: true,
+		},
+		{
+			name: "transport error containing 'not found' is not classified as tx-not-found",
+			err:  errors.New("Get http://seid:26657/tx: dial tcp: lookup seid: no such host (not found)"),
+			want: false,
+		},
+		{
+			name: "nil err",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isTxNotFound(c.err); got != c.want {
+				t.Fatalf("isTxNotFound(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #172 items 1 and 2. Item 3 (fee_payer/granter integration assertion) ships with the gov-vote handler PR — it makes more sense alongside a handler that actually signs a tx end-to-end.

## Summary
- Replace `strings.Contains(strings.ToLower(err.Error()), \"not found\")` with a typed `*rpctypes.RPCError` discriminator (`isTxNotFound`). Transport errors are wrapped Go errors, not `*RPCError`, so `errors.As` fences them out — DNS \"host not found\" can no longer be confused with a missing tx.
- Lock the ctx-plumbing audit (item 2) in a code comment. The vendored sei-tendermint jsonrpc client uses `http.NewRequestWithContext`, so the 30s `tmRPCTimeout` from #170 is a redundant upper bound, not the only stop.

## Test plan
- [x] Unit test `TestIsTxNotFound` covers: server-side tx-not-found, other server internal error, wrapped RPCError, transport error containing \"not found\" as decoy substring, nil
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean
- [x] \`go test -race ./sidecar/tasks/...\` clean
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` reports 0 issues
- [x] Coral trio cross-review (platform / kubernetes / security) — all clean, k8s independently verified the ctx-plumbing claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested change to error classification in `QueryTx` plus a clarifying comment about context cancellation; main impact is how missing-tx vs real transport errors are handled.
> 
> **Overview**
> Tightens `QueryTx` error handling by replacing the substring-based "not found" check with a typed `*rpctypes.RPCError` discriminator (`isTxNotFound`), preventing transport/DNS errors from being misclassified as missing transactions.
> 
> Adds a unit test suite for `isTxNotFound` (including wrapped RPC errors and decoy "not found" transport messages) and documents that `ctx` cancellation propagates into the underlying Tendermint JSON-RPC HTTP request (making the existing 30s timeout a secondary bound).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec8d48d82c706724e2876f31a04acc1120b331c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->