### PR TITLE
feat(sidecar): gov-vote handler (PR-B of #163)

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -122,6 +122,7 @@ var serveCmd = cli.Command{
 			engine.TaskUploadGenesisArtifacts:   tasks.NewGenesisArtifactUploader(homeDir, genesisBucket, genesisRegion, chainID, nil).Handler(),
 			engine.TaskAssembleAndUploadGenesis: tasks.NewGenesisAssembler(homeDir, genesisBucket, genesisRegion, chainID, nil, nil).Handler(),
 			engine.TaskSetGenesisPeers:          tasks.NewGenesisPeersSetter(homeDir, genesisBucket, genesisRegion, chainID, nil).Handler(),
+			engine.TaskGovVote:                  tasks.NewGovVoter(execCfg).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers, store)

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -730,10 +730,7 @@ func (t AwaitConditionTask) ToTaskRequest() TaskRequest {
 	return req
 }
 
-// GovVoteTask casts a Cosmos gov v1beta1 vote on behalf of the
-// validator's operator account. The chain's last-write-wins semantics
-// on (proposalID, voter) make repeated submissions safe at the chain
-// layer; the caller's request is treated as authoritative.
+// GovVoteTask submits a gov v1beta1 vote.
 type GovVoteTask struct {
 	ChainID    string
 	KeyName    string

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cosmos/btcutil/bech32"
 	seiconfig "github.com/sei-protocol/sei-config"
 	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seictl/sidecar/tasks"
 )
 
 const seiBech32HRP = "sei"
@@ -53,6 +55,8 @@ const (
 	TaskTypeUploadGenesisArtifacts = string(engine.TaskUploadGenesisArtifacts)
 	TaskTypeAssembleGenesis        = string(engine.TaskAssembleAndUploadGenesis)
 	TaskTypeSetGenesisPeers        = string(engine.TaskSetGenesisPeers)
+
+	TaskTypeGovVote = string(engine.TaskGovVote)
 )
 
 // Known condition and action values for AwaitConditionTask.
@@ -724,4 +728,57 @@ func (t AwaitConditionTask) ToTaskRequest() TaskRequest {
 	}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	return req
+}
+
+// GovVoteTask casts a Cosmos gov v1beta1 vote on behalf of the
+// validator's operator account. The chain's last-write-wins semantics
+// on (proposalID, voter) make repeated submissions safe at the chain
+// layer; the caller's request is treated as authoritative.
+type GovVoteTask struct {
+	ChainID    string
+	KeyName    string
+	ProposalID uint64
+	Option     string // yes | no | abstain | no_with_veto
+	Memo       string
+	Fees       string
+	Gas        uint64
+}
+
+func (t GovVoteTask) TaskType() string { return TaskTypeGovVote }
+
+func (t GovVoteTask) Validate() error {
+	if t.ChainID == "" {
+		return errors.New("gov-vote: chainId required")
+	}
+	if t.KeyName == "" {
+		return errors.New("gov-vote: keyName required")
+	}
+	if t.ProposalID == 0 {
+		return errors.New("gov-vote: proposalId required (must be > 0)")
+	}
+	if _, err := tasks.ParseVoteOption(t.Option); err != nil {
+		return fmt.Errorf("gov-vote: %w", err)
+	}
+	if t.Fees == "" {
+		return errors.New("gov-vote: fees required")
+	}
+	if t.Gas == 0 {
+		return errors.New("gov-vote: gas required (must be > 0)")
+	}
+	return nil
+}
+
+func (t GovVoteTask) ToTaskRequest() TaskRequest {
+	p := map[string]interface{}{
+		"chainId":    t.ChainID,
+		"keyName":    t.KeyName,
+		"proposalId": t.ProposalID,
+		"option":     t.Option,
+		"fees":       t.Fees,
+		"gas":        t.Gas,
+	}
+	if t.Memo != "" {
+		p["memo"] = t.Memo
+	}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
 }

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -31,6 +31,7 @@ const (
 	TaskUploadGenesisArtifacts   TaskType = "upload-genesis-artifacts"
 	TaskAssembleAndUploadGenesis TaskType = "assemble-and-upload-genesis"
 	TaskSetGenesisPeers          TaskType = "set-genesis-peers"
+	TaskGovVote                  TaskType = "gov-vote"
 )
 
 // Task is a unit of work submitted by the controller. When ID is set, the

--- a/sidecar/tasks/gov_vote.go
+++ b/sidecar/tasks/gov_vote.go
@@ -23,10 +23,9 @@ import (
 
 var govVoteLog = seilog.NewLogger("seictl", "task", "gov-vote")
 
-// GovVoteRequest is the typed parameter shape for the gov-vote task.
-// Idempotency is intentionally NOT handled here — the chain itself
-// overwrites duplicate votes (last-write-wins on the (proposalID,
-// voter) storage key), so the caller's request is authoritative.
+// GovVoteRequest holds gov-vote params. Idempotency is handled by the
+// chain — last-write-wins on (proposalID, voter); no pre-broadcast
+// chain query.
 type GovVoteRequest struct {
 	ChainID    string `json:"chainId"`
 	KeyName    string `json:"keyName"`
@@ -37,36 +36,28 @@ type GovVoteRequest struct {
 	Gas        uint64 `json:"gas"`
 }
 
-// GovVoter handles gov-vote tasks. It captures the ExecutionConfig at
-// construction so the handler closure can reach the keyring and RPC
-// client without going through engine.Engine.
+// GovVoter captures cfg by value at construction; engine.Config is
+// documented read-only after startup, so the copy is safe.
 type GovVoter struct {
 	cfg engine.ExecutionConfig
 }
 
-// NewGovVoter creates a GovVoter bound to the given config.
 func NewGovVoter(cfg engine.ExecutionConfig) *GovVoter {
 	return &GovVoter{cfg: cfg}
 }
 
-// Handler returns the engine TaskHandler for gov-vote.
+// Handler delegates to SignAndBroadcast after MsgVote construction.
 //
-// Rehydration semantics: if the sidecar crashes after BroadcastSync
-// succeeds but before the engine persists the task result, the
-// rehydration path re-runs this handler. A second tx will sign at
-// sequence+1 and broadcast; the chain's last-write-wins on
-// (proposalID, voter) keeps governance state correct, and the operator
-// pays fees twice. This is acceptable specifically because MsgVote is
-// chain-idempotent. Future sign-tx handlers MUST evaluate per-Msg
-// idempotency before copying this pattern — non-idempotent Msg types
-// (MsgSend, MsgWithdrawDelegatorReward, etc.) would double-spend.
-// Tracked in #174 for the next non-idempotent sign-tx PR.
+// Rehydration: a crash after BroadcastSync but before result persist
+// re-runs this handler. The rehydrated run signs at sequence+1 and
+// broadcasts a second tx; chain last-write-wins on (proposalID, voter)
+// keeps governance state correct and the operator pays fees twice.
+// Safe ONLY because MsgVote is chain-idempotent — non-idempotent Msg
+// types (MsgSend, MsgWithdraw…) would double-spend. Future sign-tx
+// handlers must evaluate per-Msg idempotency before reusing this shape.
 //
-// Stale-proposal handling: when params.ProposalID does not exist or is
-// in a final state, CheckTx rejects with a non-zero code and we surface
-// a Terminal error. We do NOT pre-check via chain query — that would
-// add a TOCTOU window (proposal transitions between check and
-// broadcast) and duplicate the chain's authoritative decision.
+// Stale proposals are rejected by CheckTx and surface as Terminal. We
+// do not pre-check via chain query — that opens a TOCTOU window.
 func (g *GovVoter) Handler() engine.TaskHandler {
 	return engine.TypedHandler(func(ctx context.Context, params GovVoteRequest) error {
 		msg, err := buildVoteMsg(g.cfg, params)
@@ -103,10 +94,6 @@ func (g *GovVoter) Handler() engine.TaskHandler {
 	})
 }
 
-// buildVoteMsg validates the request, resolves the voter address from
-// the keyring, and constructs the MsgVote. Split out so tests can
-// exercise the param-to-Msg translation without going through the full
-// SignAndBroadcast path.
 func buildVoteMsg(cfg engine.ExecutionConfig, params GovVoteRequest) (*govtypes.MsgVote, error) {
 	if params.ProposalID == 0 {
 		return nil, Terminal(errors.New("proposalId required (must be > 0)"))
@@ -128,11 +115,8 @@ func buildVoteMsg(cfg engine.ExecutionConfig, params GovVoteRequest) (*govtypes.
 	return govtypes.NewMsgVote(info.GetAddress(), params.ProposalID, option), nil
 }
 
-// ParseVoteOption maps the wire-format option string onto the Cosmos
-// gov v1beta1 VoteOption enum. Accepts both "no_with_veto" (canonical
-// SDK form) and "no-with-veto" (kebab-case for operator ergonomics).
-// Exported so the client SDK can reuse the same accepted set — keeping
-// client-side fast-fail and server-side authority in lockstep.
+// ParseVoteOption (gov v1beta1) is exported so client and server
+// share one accepted-option set; otherwise the two lists drift.
 func ParseVoteOption(s string) (govtypes.VoteOption, error) {
 	switch strings.ToLower(s) {
 	case "yes":

--- a/sidecar/tasks/gov_vote.go
+++ b/sidecar/tasks/gov_vote.go
@@ -1,0 +1,149 @@
+// Package tasks — gov-vote handler.
+//
+// SECURITY POSTURE NOTE — sei-protocol/seictl#163 / #165
+//
+// Reached via the sidecar's HTTP API. In Phase 1-3 the API is
+// unauthenticated; anyone with network reach can submit votes as the
+// validator's operator account. Phase 4 (#165) fronts the sidecar
+// with kube-rbac-proxy. REMOVE THIS NOTICE when #165 lands.
+
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	govtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/gov/types"
+
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
+)
+
+var govVoteLog = seilog.NewLogger("seictl", "task", "gov-vote")
+
+// GovVoteRequest is the typed parameter shape for the gov-vote task.
+// Idempotency is intentionally NOT handled here — the chain itself
+// overwrites duplicate votes (last-write-wins on the (proposalID,
+// voter) storage key), so the caller's request is authoritative.
+type GovVoteRequest struct {
+	ChainID    string `json:"chainId"`
+	KeyName    string `json:"keyName"`
+	ProposalID uint64 `json:"proposalId"`
+	Option     string `json:"option"` // yes | no | abstain | no_with_veto
+	Memo       string `json:"memo,omitempty"`
+	Fees       string `json:"fees"`
+	Gas        uint64 `json:"gas"`
+}
+
+// GovVoter handles gov-vote tasks. It captures the ExecutionConfig at
+// construction so the handler closure can reach the keyring and RPC
+// client without going through engine.Engine.
+type GovVoter struct {
+	cfg engine.ExecutionConfig
+}
+
+// NewGovVoter creates a GovVoter bound to the given config.
+func NewGovVoter(cfg engine.ExecutionConfig) *GovVoter {
+	return &GovVoter{cfg: cfg}
+}
+
+// Handler returns the engine TaskHandler for gov-vote.
+//
+// Rehydration semantics: if the sidecar crashes after BroadcastSync
+// succeeds but before the engine persists the task result, the
+// rehydration path re-runs this handler. A second tx will sign at
+// sequence+1 and broadcast; the chain's last-write-wins on
+// (proposalID, voter) keeps governance state correct, and the operator
+// pays fees twice. This is acceptable specifically because MsgVote is
+// chain-idempotent. Future sign-tx handlers MUST evaluate per-Msg
+// idempotency before copying this pattern — non-idempotent Msg types
+// (MsgSend, MsgWithdrawDelegatorReward, etc.) would double-spend.
+// Tracked in #174 for the next non-idempotent sign-tx PR.
+//
+// Stale-proposal handling: when params.ProposalID does not exist or is
+// in a final state, CheckTx rejects with a non-zero code and we surface
+// a Terminal error. We do NOT pre-check via chain query — that would
+// add a TOCTOU window (proposal transitions between check and
+// broadcast) and duplicate the chain's authoritative decision.
+func (g *GovVoter) Handler() engine.TaskHandler {
+	return engine.TypedHandler(func(ctx context.Context, params GovVoteRequest) error {
+		msg, err := buildVoteMsg(g.cfg, params)
+		if err != nil {
+			return err
+		}
+		result, err := SignAndBroadcast(ctx, g.cfg, SignAndBroadcastInput{
+			ChainID: params.ChainID,
+			KeyName: params.KeyName,
+			Msg:     msg,
+			Fees:    params.Fees,
+			Gas:     params.Gas,
+			Memo:    params.Memo,
+			TaskID:  engine.TaskIDFromContext(ctx),
+		})
+		if err != nil {
+			return err
+		}
+		inclusionStatus := "undetermined"
+		if result.IncludedAt != nil {
+			inclusionStatus = "included"
+		}
+		govVoteLog.Info("vote broadcast",
+			"taskId", engine.TaskIDFromContext(ctx),
+			"chainId", params.ChainID,
+			"keyName", params.KeyName,
+			"proposalId", params.ProposalID,
+			"option", params.Option,
+			"txHash", result.TxHash,
+			"height", result.Height,
+			"sequence", result.Sequence,
+			"inclusionStatus", inclusionStatus)
+		return nil
+	})
+}
+
+// buildVoteMsg validates the request, resolves the voter address from
+// the keyring, and constructs the MsgVote. Split out so tests can
+// exercise the param-to-Msg translation without going through the full
+// SignAndBroadcast path.
+func buildVoteMsg(cfg engine.ExecutionConfig, params GovVoteRequest) (*govtypes.MsgVote, error) {
+	if params.ProposalID == 0 {
+		return nil, Terminal(errors.New("proposalId required (must be > 0)"))
+	}
+	option, err := ParseVoteOption(params.Option)
+	if err != nil {
+		return nil, Terminal(err)
+	}
+	if cfg.Keyring == nil {
+		return nil, Terminal(errors.New("keyring not configured: set SEI_KEYRING_BACKEND/SEI_KEYRING_PASSPHRASE on the sidecar"))
+	}
+	if params.KeyName == "" {
+		return nil, Terminal(errors.New("keyName required"))
+	}
+	info, err := cfg.Keyring.Key(params.KeyName)
+	if err != nil {
+		return nil, Terminal(fmt.Errorf("keyring entry %q: %w", params.KeyName, err))
+	}
+	return govtypes.NewMsgVote(info.GetAddress(), params.ProposalID, option), nil
+}
+
+// ParseVoteOption maps the wire-format option string onto the Cosmos
+// gov v1beta1 VoteOption enum. Accepts both "no_with_veto" (canonical
+// SDK form) and "no-with-veto" (kebab-case for operator ergonomics).
+// Exported so the client SDK can reuse the same accepted set — keeping
+// client-side fast-fail and server-side authority in lockstep.
+func ParseVoteOption(s string) (govtypes.VoteOption, error) {
+	switch strings.ToLower(s) {
+	case "yes":
+		return govtypes.OptionYes, nil
+	case "no":
+		return govtypes.OptionNo, nil
+	case "abstain":
+		return govtypes.OptionAbstain, nil
+	case "no_with_veto", "no-with-veto":
+		return govtypes.OptionNoWithVeto, nil
+	default:
+		return 0, fmt.Errorf("invalid vote option %q (allowed: yes | no | abstain | no_with_veto)", s)
+	}
+}

--- a/sidecar/tasks/gov_vote_test.go
+++ b/sidecar/tasks/gov_vote_test.go
@@ -1,0 +1,134 @@
+package tasks
+
+import (
+	"errors"
+	"testing"
+
+	govtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/gov/types"
+
+	"github.com/sei-protocol/seictl/sidecar/engine"
+)
+
+func TestParseVoteOption(t *testing.T) {
+	cases := []struct {
+		in   string
+		want govtypes.VoteOption
+		err  bool
+	}{
+		{"yes", govtypes.OptionYes, false},
+		{"YES", govtypes.OptionYes, false},
+		{"no", govtypes.OptionNo, false},
+		{"abstain", govtypes.OptionAbstain, false},
+		{"no_with_veto", govtypes.OptionNoWithVeto, false},
+		{"no-with-veto", govtypes.OptionNoWithVeto, false},
+		{"NO_WITH_VETO", govtypes.OptionNoWithVeto, false},
+		{"", 0, true},
+		{"maybe", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseVoteOption(c.in)
+		if c.err {
+			if err == nil {
+				t.Errorf("ParseVoteOption(%q): want err, got %v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseVoteOption(%q): unexpected err: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseVoteOption(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBuildVoteMsg(t *testing.T) {
+	kr, addr := testKeyring(t)
+	cfg := engine.ExecutionConfig{Keyring: kr}
+
+	t.Run("happy path", func(t *testing.T) {
+		msg, err := buildVoteMsg(cfg, GovVoteRequest{
+			KeyName:    "node_admin",
+			ProposalID: 42,
+			Option:     "yes",
+		})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if msg.Voter != addr.String() {
+			t.Errorf("voter = %q, want %q", msg.Voter, addr.String())
+		}
+		if msg.ProposalId != 42 {
+			t.Errorf("proposalId = %d, want 42", msg.ProposalId)
+		}
+		if msg.Option != govtypes.OptionYes {
+			t.Errorf("option = %v, want OptionYes", msg.Option)
+		}
+		// Guard: signAndBroadcast runs ValidateBasic immediately; lock
+		// that it accepts the message we produce here.
+		if err := msg.ValidateBasic(); err != nil {
+			t.Errorf("ValidateBasic on returned msg: %v", err)
+		}
+	})
+
+	t.Run("zero proposalId is Terminal", func(t *testing.T) {
+		_, err := buildVoteMsg(cfg, GovVoteRequest{
+			KeyName:    "node_admin",
+			ProposalID: 0,
+			Option:     "yes",
+		})
+		if !IsTerminal(err) {
+			t.Fatalf("want Terminal, got %v", err)
+		}
+	})
+
+	t.Run("invalid option is Terminal", func(t *testing.T) {
+		_, err := buildVoteMsg(cfg, GovVoteRequest{
+			KeyName:    "node_admin",
+			ProposalID: 7,
+			Option:     "bogus",
+		})
+		if !IsTerminal(err) {
+			t.Fatalf("want Terminal, got %v", err)
+		}
+	})
+
+	t.Run("nil keyring is Terminal", func(t *testing.T) {
+		_, err := buildVoteMsg(engine.ExecutionConfig{}, GovVoteRequest{
+			KeyName:    "node_admin",
+			ProposalID: 7,
+			Option:     "yes",
+		})
+		if !IsTerminal(err) {
+			t.Fatalf("want Terminal, got %v", err)
+		}
+	})
+
+	t.Run("empty keyName is Terminal", func(t *testing.T) {
+		_, err := buildVoteMsg(cfg, GovVoteRequest{
+			KeyName:    "",
+			ProposalID: 7,
+			Option:     "yes",
+		})
+		if !IsTerminal(err) {
+			t.Fatalf("want Terminal, got %v", err)
+		}
+	})
+
+	t.Run("missing key in keyring is Terminal", func(t *testing.T) {
+		_, err := buildVoteMsg(cfg, GovVoteRequest{
+			KeyName:    "does-not-exist",
+			ProposalID: 7,
+			Option:     "yes",
+		})
+		if !IsTerminal(err) {
+			t.Fatalf("want Terminal, got %v", err)
+		}
+		// Make sure the underlying keyring error is preserved.
+		var terr *TerminalError
+		if !errors.As(err, &terr) || terr.Unwrap() == nil {
+			t.Fatalf("expected wrapped keyring error: %v", err)
+		}
+	})
+}

--- a/sidecar/tasks/sign_and_broadcast_test.go
+++ b/sidecar/tasks/sign_and_broadcast_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/hd"
 	"github.com/sei-protocol/sei-chain/sei-cosmos/crypto/keyring"
 	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	txtypes "github.com/sei-protocol/sei-chain/sei-cosmos/types/tx"
 	govtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/gov/types"
 
 	"github.com/sei-protocol/seictl/sidecar/engine"
@@ -27,9 +28,10 @@ type fakeTxClient struct {
 	sequence      uint64
 	accountErr    error
 
-	broadcastResp *sdk.TxResponse
-	broadcastErr  error
-	broadcasts    int
+	broadcastResp  *sdk.TxResponse
+	broadcastErr   error
+	broadcasts     int
+	lastTxBytes    []byte
 
 	// queryDefault returns canned data for any hash (mirroring production
 	// QueryTx). Nil returns not-found.
@@ -44,10 +46,11 @@ func (f *fakeTxClient) AccountNumberSequence(_ context.Context, _ sdk.AccAddress
 	return f.accountNumber, f.sequence, f.accountErr
 }
 
-func (f *fakeTxClient) BroadcastSync(_ context.Context, _ []byte) (*sdk.TxResponse, error) {
+func (f *fakeTxClient) BroadcastSync(_ context.Context, txBytes []byte) (*sdk.TxResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.broadcasts++
+	f.lastTxBytes = append(f.lastTxBytes[:0], txBytes...)
 	if f.broadcastErr != nil {
 		return nil, f.broadcastErr
 	}
@@ -269,6 +272,58 @@ func TestAccountRetrieverFailure_Propagates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "account retrieve") {
 		t.Fatalf("error should mention account retrieve, got %q", err.Error())
+	}
+}
+
+// TestSignedTxHasNoFeePayerOrGranter asserts the signed tx's AuthInfo
+// leaves fee_payer and fee_granter empty (closes seictl#172 item 3).
+// The signer-pays-its-own-fees invariant is implicit today — tx.Factory
+// never plumbs WithFeePayer — but if a future contributor wires those
+// fields, the denom whitelist tells us nothing about who's paying.
+// This test locks the invariant at the signed-bytes level.
+func TestSignedTxHasNoFeePayerOrGranter(t *testing.T) {
+	cfg, addr := newGuardCfg(t, "pacific-1")
+	tc := &fakeTxClient{
+		accountNumber: 17,
+		sequence:      42,
+		broadcastResp: &sdk.TxResponse{Code: 0, TxHash: "h", Height: 0},
+		// Return inclusion on first poll so the test doesn't wait
+		// the full inclusionPollTimeout.
+		queryDefault: &sdk.TxResponse{Code: 0, Height: 7},
+	}
+
+	_, err := signAndBroadcast(context.Background(), cfg, tc, SignAndBroadcastInput{
+		ChainID: "pacific-1",
+		KeyName: "node_admin",
+		Msg:     makeMsgVote(t, addr),
+		Fees:    "4000usei",
+		Gas:     200_000,
+		TaskID:  "00000000-0000-0000-0000-0000000000fe",
+	}, addr)
+	if err != nil {
+		t.Fatalf("signAndBroadcast: %v", err)
+	}
+	if len(tc.lastTxBytes) == 0 {
+		t.Fatal("no tx bytes captured")
+	}
+
+	// Decode the proto Tx directly and assert the raw AuthInfo.Fee
+	// fields. sdk.FeeTx.FeePayer() falls back to GetSigners()[0] when
+	// Fee.Payer is empty, so checking the interface method alone would
+	// silently accept a future `WithFeePayer(signer)` plumbing — the
+	// invariant we want is no fee-grant lookup, i.e. proto fields blank.
+	var pbTx txtypes.Tx
+	if err := pbTx.Unmarshal(tc.lastTxBytes); err != nil {
+		t.Fatalf("proto unmarshal tx: %v", err)
+	}
+	if pbTx.AuthInfo == nil || pbTx.AuthInfo.Fee == nil {
+		t.Fatalf("decoded tx missing AuthInfo.Fee")
+	}
+	if pbTx.AuthInfo.Fee.Payer != "" {
+		t.Errorf("AuthInfo.Fee.Payer = %q, want empty", pbTx.AuthInfo.Fee.Payer)
+	}
+	if pbTx.AuthInfo.Fee.Granter != "" {
+		t.Errorf("AuthInfo.Fee.Granter = %q, want empty", pbTx.AuthInfo.Fee.Granter)
 	}
 }
 

--- a/sidecar/tasks/sign_and_broadcast_test.go
+++ b/sidecar/tasks/sign_and_broadcast_test.go
@@ -28,10 +28,10 @@ type fakeTxClient struct {
 	sequence      uint64
 	accountErr    error
 
-	broadcastResp  *sdk.TxResponse
-	broadcastErr   error
-	broadcasts     int
-	lastTxBytes    []byte
+	broadcastResp *sdk.TxResponse
+	broadcastErr  error
+	broadcasts    int
+	lastTxBytes   []byte
 
 	// queryDefault returns canned data for any hash (mirroring production
 	// QueryTx). Nil returns not-found.

--- a/sidecar/tasks/sign_and_broadcast_test.go
+++ b/sidecar/tasks/sign_and_broadcast_test.go
@@ -275,12 +275,10 @@ func TestAccountRetrieverFailure_Propagates(t *testing.T) {
 	}
 }
 
-// TestSignedTxHasNoFeePayerOrGranter asserts the signed tx's AuthInfo
-// leaves fee_payer and fee_granter empty (closes seictl#172 item 3).
-// The signer-pays-its-own-fees invariant is implicit today — tx.Factory
-// never plumbs WithFeePayer — but if a future contributor wires those
-// fields, the denom whitelist tells us nothing about who's paying.
-// This test locks the invariant at the signed-bytes level.
+// TestSignedTxHasNoFeePayerOrGranter locks the signer-pays-its-own-fees
+// invariant at the signed-bytes level. Without it a future contributor
+// wiring WithFeePayer slips past the denom whitelist — the whitelist
+// proves what denom is used, not who's paying.
 func TestSignedTxHasNoFeePayerOrGranter(t *testing.T) {
 	cfg, addr := newGuardCfg(t, "pacific-1")
 	tc := &fakeTxClient{
@@ -307,11 +305,9 @@ func TestSignedTxHasNoFeePayerOrGranter(t *testing.T) {
 		t.Fatal("no tx bytes captured")
 	}
 
-	// Decode the proto Tx directly and assert the raw AuthInfo.Fee
-	// fields. sdk.FeeTx.FeePayer() falls back to GetSigners()[0] when
-	// Fee.Payer is empty, so checking the interface method alone would
-	// silently accept a future `WithFeePayer(signer)` plumbing — the
-	// invariant we want is no fee-grant lookup, i.e. proto fields blank.
+	// Assert raw proto fields, not sdk.FeeTx.FeePayer() — the interface
+	// method falls back to GetSigners()[0] when Fee.Payer is empty, so
+	// a future WithFeePayer(signer) plumbing would silently pass.
 	var pbTx txtypes.Tx
 	if err := pbTx.Unmarshal(tc.lastTxBytes); err != nil {
 		t.Fatalf("proto unmarshal tx: %v", err)


### PR DESCRIPTION
First user-facing gov sign-tx handler. Composes on the sign-tx foundation (#170) and hardening (#173).

## Summary
- New \`TaskGovVote\` task type + \`sidecar/tasks/gov_vote.go\` handler that builds Cosmos gov v1beta1 \`MsgVote\` and delegates to \`SignAndBroadcast\`.
- \`GovVoteTask\` Go client SDK helper.
- No chain-query idempotency — chain handles last-write-wins on \`(proposalID, voter)\`; caller's request is authoritative.
- Also closes #172 item 3 (deferred from #173): \`TestSignedTxHasNoFeePayerOrGranter\` decodes the signed proto Tx and asserts \`AuthInfo.Fee.Payer\` / \`Granter\` are empty strings.
- Exported \`ParseVoteOption\` so client and server share one canonical option set (no drift).
- Two follow-ups tracked in #174: per-handler idempotency review template (load-bearing once a non-idempotent sign-tx handler ships), \`TaskResult.Output\` engine extension.

## Test plan
- [x] \`TestParseVoteOption\` table — case-insensitivity, kebab alias, empty/unknown rejection
- [x] \`TestBuildVoteMsg\` subtests — happy path (incl. \`ValidateBasic\` assertion), zero proposalID, invalid option, nil keyring, empty keyName, missing key — all Terminal
- [x] \`TestSignedTxHasNoFeePayerOrGranter\` — proto-level fee-payer/granter empty assertion
- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1\` clean (all packages)
- [x] \`go test -race ./sidecar/tasks/\` clean
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` reports 0 issues
- [x] Coral trio cross-review (platform / kubernetes / security) — synthesized findings applied; remaining deferred to #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new sign-and-broadcast task that can submit on-chain governance votes using the validator’s keyring, which is security-sensitive (especially given the sidecar API exposure). Also introduces new invariants around tx fee payer/granter enforced by tests, but mistakes could still result in unintended transactions/fees.
> 
> **Overview**
> Adds a new `gov-vote` task end-to-end: registers `engine.TaskGovVote` in `serve.go`, defines the task type in `engine/types.go`, and implements `sidecar/tasks/gov_vote.go` to build a gov v1beta1 `MsgVote` and delegate signing/broadcasting to `SignAndBroadcast`.
> 
> Extends the Go client SDK (`sidecar/client/tasks.go`) with a typed `GovVoteTask` (validation + wire params) and shares vote-option parsing via exported `tasks.ParseVoteOption`.
> 
> Hardens tx signing tests by capturing broadcast tx bytes and asserting, at the protobuf level, that `AuthInfo.Fee.Payer` and `AuthInfo.Fee.Granter` are empty, preventing accidental fee delegation regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1061c36bd09a8ebc0a2a6b70aba38abdc074cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->