### PR TITLE
feat(sidecar): trusted-header authn mode (#165, seictl side)

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -132,7 +132,13 @@ var serveCmd = cli.Command{
 		// the full dep set via the goroutine-spawn happens-before edge.
 		eng.RehydrateStaleTasks()
 
-		srv := server.NewServer(":"+port, eng, homeDir)
+		authnMode, err := server.AuthnMode()
+		if err != nil {
+			return err
+		}
+		bindAddr := server.BindAddress(port, authnMode)
+		serveLog.Info("sidecar HTTP", "authnMode", authnMode, "bind", bindAddr)
+		srv := server.NewServer(bindAddr, eng, homeDir, authnMode)
 		srvErr := srv.ListenAndServe(ctx)
 
 		if closeErr := store.Close(); closeErr != nil {

--- a/serve.go
+++ b/serve.go
@@ -137,7 +137,11 @@ var serveCmd = cli.Command{
 			return err
 		}
 		bindAddr := server.BindAddress(port, authnMode)
-		serveLog.Info("sidecar HTTP", "authnMode", authnMode, "bind", bindAddr)
+		logArgs := []any{"authnMode", authnMode, "bind", bindAddr}
+		if authnMode == server.AuthnModeTrustedHeader {
+			logArgs = append(logArgs, "bypassPaths", server.BypassPaths())
+		}
+		serveLog.Info("sidecar HTTP", logArgs...)
 		srv := server.NewServer(bindAddr, eng, homeDir, authnMode)
 		srvErr := srv.ListenAndServe(ctx)
 

--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -6,11 +6,25 @@ info:
 
     ## Authentication
 
-    Sign-tx tasks ship UNAUTHENTICATED in Phase 1-3 of the
-    governance-flow workstream — see sei-protocol/seictl#163 and #165.
-    From Phase 4 a `kube-rbac-proxy` sidecar fronts this API on `:8443`
-    (TokenReview + a single coarse `create seinodetasks.sei.io` SAR)
-    and the sidecar rebinds to 127.0.0.1:7777, trusting `X-Remote-User`.
+    Controlled by the `SEI_SIDECAR_AUTHN_MODE` environment variable:
+
+    - **Unset (default):** API is unauthenticated. The sidecar binds
+      all interfaces. Any actor with network reach to the listen port
+      can submit txs as the validator's operator account. Acceptable
+      only on validator-only pod networks.
+    - **`trusted-header`:** A `kube-rbac-proxy` container fronts this
+      API on TLS `:8443` and performs TokenReview + a single coarse
+      `create seinodetasks.sei.io` SAR against the K8s API. The
+      sidecar binds loopback only and requires `X-Remote-User` on
+      every request, except for three paths that bypass auth so
+      probes and scrapes — none of which carry auth headers — keep
+      working:
+
+      - `/v0/healthz` — kubelet readiness probe
+      - `/v0/livez` — kubelet liveness probe
+      - `/v0/metrics` — Prometheus scrape
+
+      `kube-rbac-proxy` must include all three in its `--allow-paths`.
   version: 0.8.0
   license:
     name: Apache-2.0
@@ -54,7 +68,7 @@ paths:
         task type — per-task narrowing is additive via `resourceNames`
         on the ClusterRole.
       security:
-        - bearerAuth: []
+        - remoteUserHeader: []
       requestBody:
         required: true
         content:
@@ -85,7 +99,7 @@ paths:
       summary: List recent task results
       description: Returns the most recent task results.
       security:
-        - bearerAuth: []
+        - remoteUserHeader: []
       responses:
         "200":
           description: Task results.
@@ -101,7 +115,7 @@ paths:
       operationId: getTask
       summary: Get a task result
       security:
-        - bearerAuth: []
+        - remoteUserHeader: []
       parameters:
         - name: id
           in: path
@@ -127,7 +141,7 @@ paths:
       summary: Remove a task
       description: Removes a task result or cancels an active task.
       security:
-        - bearerAuth: []
+        - remoteUserHeader: []
       parameters:
         - name: id
           in: path
@@ -147,14 +161,21 @@ paths:
 
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+    remoteUserHeader:
+      type: apiKey
+      in: header
+      name: X-Remote-User
       description: |
-        Enforced by the upstream `kube-rbac-proxy` in Phase 4+ (#165).
-        In Phase 1-3 the sidecar is unauthenticated; tooling MUST NOT
-        rely on this scheme for its own access control.
+        Trusted-header model: the sidecar trusts the value of
+        `X-Remote-User` because it binds loopback and a co-located
+        `kube-rbac-proxy` is the sole reachable client. The proxy
+        performs TokenReview + SAR against the K8s API and forwards
+        the authenticated identity in this header. Tooling MUST NOT
+        send this header directly — it is set by the proxy.
+
+        Only applies when `SEI_SIDECAR_AUTHN_MODE=trusted-header`. With
+        the env var unset the API is unauthenticated and this scheme
+        is not enforced.
 
   schemas:
     TaskRequest:

--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -16,15 +16,16 @@ info:
       API on TLS `:8443` and performs TokenReview + a single coarse
       `create seinodetasks.sei.io` SAR against the K8s API. The
       sidecar binds loopback only and requires `X-Remote-User` on
-      every request, except for three paths that bypass auth so
+      every request, except for four paths that bypass auth so
       probes and scrapes — none of which carry auth headers — keep
       working:
 
       - `/v0/healthz` — kubelet readiness probe
+      - `/v0/startupz` — kubelet startup probe
       - `/v0/livez` — kubelet liveness probe
       - `/v0/metrics` — Prometheus scrape
 
-      `kube-rbac-proxy` must include all three in its `--allow-paths`.
+      `kube-rbac-proxy` must include all four in its `--allow-paths`.
   version: 0.8.0
   license:
     name: Apache-2.0
@@ -36,7 +37,7 @@ paths:
   /v0/healthz:
     get:
       operationId: healthz
-      summary: Liveness probe
+      summary: Readiness probe
       description: Returns 200 after mark-ready has completed; 503 otherwise.
       responses:
         "200":

--- a/sidecar/client/sidecar.gen.go
+++ b/sidecar/client/sidecar.gen.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	BearerAuthScopes = "bearerAuth.Scopes"
+	RemoteUserHeaderScopes = "remoteUserHeader.Scopes"
 )
 
 // Defines values for StatusResponseStatus.

--- a/sidecar/docs/authn.md
+++ b/sidecar/docs/authn.md
@@ -1,0 +1,77 @@
+# Sidecar HTTP API authentication
+
+The sidecar exposes its task API over plain HTTP. Authentication is
+controlled by a single environment variable; the runtime trust
+boundary is the pod, not the loopback interface.
+
+## Environment contract
+
+| Env | Values | Default | Behavior |
+|---|---|---|---|
+| `SEI_SIDECAR_AUTHN_MODE` | unset \| `unauthenticated` \| `trusted-header` | unset | unset/`unauthenticated`: bind all interfaces, no auth. `trusted-header`: bind loopback, require `X-Remote-User` on non-probe paths. |
+
+Parsing is strict: any non-empty value other than `unauthenticated`
+or `trusted-header` is a startup error so a typo cannot silently
+degrade a hardened deployment.
+
+## `trusted-header` mode
+
+The sidecar is paired with an in-pod `kube-rbac-proxy` container on
+TLS `:8443`. The proxy performs TokenReview + a single coarse
+`create seinodetasks.sei.io` SubjectAccessReview against the K8s API,
+then forwards passed requests to `127.0.0.1:7777` with `X-Remote-User`
+naming the authenticated identity.
+
+The sidecar requires exactly one non-empty `X-Remote-User` value per
+request. Two values fail closed — that would mean the proxy is
+appending rather than overwriting, which would let an attacker-
+supplied header arrive first.
+
+### Bypass paths
+
+Three paths skip the `X-Remote-User` check because their callers do
+not carry auth headers:
+
+| Path | Caller |
+|---|---|
+| `/v0/healthz` | kubelet readiness probe |
+| `/v0/livez` | kubelet liveness probe |
+| `/v0/metrics` | Prometheus scrape |
+
+The `kube-rbac-proxy` `--allow-paths` flag must include all three so
+probes and scrapes traverse the proxy without TokenReview.
+
+### Pod-level isolation requirements
+
+The trust boundary is the pod. Pods running in `trusted-header` mode
+MUST NOT enable any of:
+
+- `hostNetwork: true` — collapses loopback into the host's network
+  namespace, exposing `127.0.0.1:7777` to every other `hostNetwork`
+  pod on the node.
+- `hostPID: true` — lets off-pod processes attach.
+- `hostIPC: true` — exposes SysV IPC across the pod boundary.
+
+A colocated container in the pod can still reach `127.0.0.1:7777`
+directly and forge `X-Remote-User`. With `shareProcessNamespace:
+true` (the current `SeiNode` default) it can also read
+`/proc/<sidecar>/mem` and exfiltrate the unlocked keyring — memory
+read is the load-bearing threat, not header forgery. The middleware
+does not defend against either; the controller-side configuration of
+the pod is what establishes the boundary.
+
+## Controller-side contract
+
+The contract this sidecar exposes to `sei-k8s-controller`:
+
+- Env var: `SEI_SIDECAR_AUTHN_MODE=trusted-header`
+- Internal port: `7777`, bound to `127.0.0.1`
+- Probe path: `/v0/healthz` (readiness), `/v0/livez` (liveness)
+- Prometheus path: `/v0/metrics`
+- `kube-rbac-proxy --allow-paths`: `/v0/healthz,/v0/livez,/v0/metrics`
+- Forwarded header: `X-Remote-User` — proxy MUST overwrite, not
+  append
+- Pod isolation: `hostNetwork`/`hostPID`/`hostIPC` all false
+
+Kubelet probes hit the pod IP, not loopback. With the sidecar bound
+loopback-only, probes must be routed through the proxy port.

--- a/sidecar/docs/authn.md
+++ b/sidecar/docs/authn.md
@@ -29,17 +29,25 @@ supplied header arrive first.
 
 ### Bypass paths
 
-Three paths skip the `X-Remote-User` check because their callers do
+Four paths skip the `X-Remote-User` check because their callers do
 not carry auth headers:
 
 | Path | Caller |
 |---|---|
 | `/v0/healthz` | kubelet readiness probe |
+| `/v0/startupz` | kubelet startup probe |
 | `/v0/livez` | kubelet liveness probe |
 | `/v0/metrics` | Prometheus scrape |
 
-The `kube-rbac-proxy` `--allow-paths` flag must include all three so
-probes and scrapes traverse the proxy without TokenReview.
+The `kube-rbac-proxy` `--allow-paths` flag must include all four so
+probes and scrapes traverse the proxy without TokenReview. The
+authoritative list is logged at sidecar startup in trusted-header
+mode and is exposed programmatically via `server.BypassPaths()`.
+
+Rejected requests are counted in the
+`seictl_sidecar_authn_rejections_total{reason}` metric — labels
+`missing_header`, `duplicate_header`, `empty_header` distinguish the
+common misconfigurations.
 
 ### Pod-level isolation requirements
 
@@ -66,9 +74,9 @@ The contract this sidecar exposes to `sei-k8s-controller`:
 
 - Env var: `SEI_SIDECAR_AUTHN_MODE=trusted-header`
 - Internal port: `7777`, bound to `127.0.0.1`
-- Probe path: `/v0/healthz` (readiness), `/v0/livez` (liveness)
+- Probe paths: `/v0/healthz` (readiness), `/v0/startupz` (startup), `/v0/livez` (liveness)
 - Prometheus path: `/v0/metrics`
-- `kube-rbac-proxy --allow-paths`: `/v0/healthz,/v0/livez,/v0/metrics`
+- `kube-rbac-proxy --allow-paths`: `/v0/healthz,/v0/startupz,/v0/livez,/v0/metrics`
 - Forwarded header: `X-Remote-User` — proxy MUST overwrite, not
   append
 - Pod isolation: `hostNetwork`/`hostPID`/`hostIPC` all false

--- a/sidecar/docs/keyring.md
+++ b/sidecar/docs/keyring.md
@@ -19,7 +19,7 @@ in the pod — lives in `docs/design/in-pod-governance-signing.md`.
 
 For the `file` backend, a trailing `/keyring-file` path segment is stripped before handoff to the SDK — the Cosmos SDK keyring re-appends `keyring-file/` internally, so callers passing `/sei/keyring-file` and `/sei` both end up at `/sei/keyring-file/*`. This matches both operator mental models.
 
-Unset `SEI_KEYRING_BACKEND` is the Phase-1 default: the sidecar starts normally
+Unset `SEI_KEYRING_BACKEND` is the default: the sidecar starts normally
 and rejects sign-tx submissions with `keyring not configured`. The node's
 genesis-ceremony tasks (e.g. `generate-gentx`) continue to function — those
 use a separate, in-process test backend that is intentionally isolated from

--- a/sidecar/server/auth.go
+++ b/sidecar/server/auth.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // SECURITY POSTURE — trusted-header mode
@@ -39,17 +42,42 @@ const (
 	remoteUserHeader = "X-Remote-User"
 )
 
-// bypassPaths skip the X-Remote-User check in trusted-header mode:
-//   - /v0/healthz: kubelet readiness probe (no auth headers).
-//   - /v0/livez:   kubelet liveness probe (no auth headers).
-//   - /v0/metrics: Prometheus scrape (no SA token in the scrape job).
-//
-// kube-rbac-proxy must include all three in its --allow-paths so
-// probes and scrapes traverse the proxy without TokenReview.
+// bypassPaths skip the X-Remote-User check in trusted-header mode.
+// Each path's caller does not carry K8s auth headers, so requiring
+// X-Remote-User would break the corresponding probe / scrape.
+// kube-rbac-proxy must include every path here in its --allow-paths.
 var bypassPaths = map[string]struct{}{
-	"/v0/healthz": {},
-	"/v0/livez":   {},
-	"/v0/metrics": {},
+	"/v0/healthz":  {}, // kubelet readiness probe
+	"/v0/startupz": {}, // kubelet startup probe
+	"/v0/livez":    {}, // kubelet liveness probe
+	"/v0/metrics":  {}, // Prometheus scrape
+}
+
+// BypassPaths returns the set of paths exempt from the X-Remote-User
+// check, sorted, so serve.go can log them at startup and the
+// controller-side PR can keep --allow-paths in sync.
+func BypassPaths() []string {
+	out := make([]string, 0, len(bypassPaths))
+	for p := range bypassPaths {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// authnRejections counts 401s from the trust-header check. Tagged by
+// reason so a misconfigured proxy (duplicate-header) is grep-able
+// apart from genuine missing-header attempts.
+var authnRejections = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "seictl_sidecar_authn_rejections_total",
+		Help: "Count of 401 responses from the trusted-header middleware, by reason.",
+	},
+	[]string{"reason"},
+)
+
+func init() {
+	prometheus.MustRegister(authnRejections)
 }
 
 // AuthnMode reads SEI_SIDECAR_AUTHN_MODE and returns the canonical
@@ -90,11 +118,18 @@ func trustedHeaderMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		vals := r.Header.Values(remoteUserHeader)
-		if len(vals) != 1 || vals[0] == "" {
-			writeError(w, http.StatusUnauthorized, "expected exactly one non-empty "+remoteUserHeader+" header")
-			return
+		switch vals := r.Header.Values(remoteUserHeader); {
+		case len(vals) == 0:
+			authnRejections.WithLabelValues("missing_header").Inc()
+			writeError(w, http.StatusUnauthorized, "missing "+remoteUserHeader+" header")
+		case len(vals) > 1:
+			authnRejections.WithLabelValues("duplicate_header").Inc()
+			writeError(w, http.StatusUnauthorized, "expected exactly one "+remoteUserHeader+" header — proxy must overwrite, not append")
+		case vals[0] == "":
+			authnRejections.WithLabelValues("empty_header").Inc()
+			writeError(w, http.StatusUnauthorized, "empty "+remoteUserHeader+" header")
+		default:
+			next.ServeHTTP(w, r)
 		}
-		next.ServeHTTP(w, r)
 	})
 }

--- a/sidecar/server/auth.go
+++ b/sidecar/server/auth.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// SECURITY POSTURE — trusted-header mode
+//
+// The trust boundary is the POD, not the loopback interface. Loopback
+// bind keeps the sidecar off the pod network, but every container in
+// the pod shares the network namespace and can reach 127.0.0.1:7777
+// directly with a forged X-Remote-User. With shareProcessNamespace:
+// true (the current SeiNode default), a colocated container can also
+// read /proc/<sidecar>/mem and exfiltrate the unlocked keyring —
+// memory-read is the load-bearing threat, not header forgery; this
+// middleware does not defend against it.
+//
+// Pod-level isolation requirements (enforced by the controller-side
+// PR): hostNetwork, hostPID, and hostIPC MUST all be false.
+// hostNetwork would expose 127.0.0.1 to every other hostNetwork pod
+// on the node. hostPID/hostIPC would let off-pod processes attach.
+
+const (
+	// AuthnModeUnauthenticated: sidecar binds all interfaces; every
+	// caller is trusted. Acceptable only on validator-only pod
+	// networks.
+	AuthnModeUnauthenticated = ""
+
+	// AuthnModeTrustedHeader pairs the sidecar with an in-pod
+	// kube-rbac-proxy on TLS :8443. The proxy performs TokenReview +
+	// SAR against the K8s API and forwards passed requests to
+	// 127.0.0.1:7777 with X-Remote-User naming the authenticated
+	// identity.
+	AuthnModeTrustedHeader = "trusted-header"
+
+	remoteUserHeader = "X-Remote-User"
+)
+
+// bypassPaths skip the X-Remote-User check in trusted-header mode:
+//   - /v0/healthz: kubelet readiness probe (no auth headers).
+//   - /v0/livez:   kubelet liveness probe (no auth headers).
+//   - /v0/metrics: Prometheus scrape (no SA token in the scrape job).
+//
+// kube-rbac-proxy must include all three in its --allow-paths so
+// probes and scrapes traverse the proxy without TokenReview.
+var bypassPaths = map[string]struct{}{
+	"/v0/healthz": {},
+	"/v0/livez":   {},
+	"/v0/metrics": {},
+}
+
+// AuthnMode reads SEI_SIDECAR_AUTHN_MODE and returns the canonical
+// value. Strict: an unrecognized non-empty value is an error, so a
+// typo (e.g. "trusted_header" with underscore) cannot silently
+// degrade a hardened deployment to wide-open :7777.
+func AuthnMode() (string, error) {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("SEI_SIDECAR_AUTHN_MODE")))
+	switch raw {
+	case "", "unauthenticated":
+		return AuthnModeUnauthenticated, nil
+	case AuthnModeTrustedHeader:
+		return AuthnModeTrustedHeader, nil
+	default:
+		return "", fmt.Errorf("SEI_SIDECAR_AUTHN_MODE=%q is not recognized (allowed: \"\", \"unauthenticated\", %q)", raw, AuthnModeTrustedHeader)
+	}
+}
+
+// BindAddress returns the listen address for the given mode. The
+// loopback bind in trusted-header mode is load-bearing — it confines
+// the listen socket to the pod's network namespace so the only path
+// to :7777 is through the in-pod proxy.
+func BindAddress(port, mode string) string {
+	if mode == AuthnModeTrustedHeader {
+		return "127.0.0.1:" + port
+	}
+	return ":" + port
+}
+
+// trustedHeaderMiddleware enforces X-Remote-User on every path
+// outside bypassPaths. The header check requires EXACTLY one
+// non-empty value: a misconfigured proxy that appends instead of
+// overwriting would let an attacker-supplied value arrive first, so
+// len != 1 fails closed rather than silently trusting the first.
+func trustedHeaderMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := bypassPaths[r.URL.Path]; ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		vals := r.Header.Values(remoteUserHeader)
+		if len(vals) != 1 || vals[0] == "" {
+			writeError(w, http.StatusUnauthorized, "expected exactly one non-empty "+remoteUserHeader+" header")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/sidecar/server/auth_test.go
+++ b/sidecar/server/auth_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAuthnMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     string
+		want    string
+		wantErr string
+	}{
+		{"unset", "", AuthnModeUnauthenticated, ""},
+		{"explicit unauthenticated", "unauthenticated", AuthnModeUnauthenticated, ""},
+		{"trusted-header", "trusted-header", AuthnModeTrustedHeader, ""},
+		{"case-insensitive", "TRUSTED-HEADER", AuthnModeTrustedHeader, ""},
+		{"whitespace tolerated", "  trusted-header  ", AuthnModeTrustedHeader, ""},
+		{"typo with underscore", "trusted_header", "", "not recognized"},
+		{"missing hyphen", "trustedheader", "", "not recognized"},
+		{"future mode not yet supported", "mtls", "", "not recognized"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("SEI_SIDECAR_AUTHN_MODE", c.env)
+			got, err := AuthnMode()
+			if c.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want err containing %q, got nil (mode=%q)", c.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), c.wantErr) {
+					t.Fatalf("err = %q, want substring %q", err.Error(), c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("AuthnMode() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestBindAddress(t *testing.T) {
+	if got := BindAddress("7777", AuthnModeUnauthenticated); got != ":7777" {
+		t.Errorf("unauthenticated: %q, want :7777", got)
+	}
+	if got := BindAddress("7777", AuthnModeTrustedHeader); got != "127.0.0.1:7777" {
+		t.Errorf("trusted-header: %q, want 127.0.0.1:7777", got)
+	}
+}
+
+func TestTrustedHeaderMiddleware(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := trustedHeaderMiddleware(inner)
+
+	cases := []struct {
+		name    string
+		path    string
+		headers map[string][]string
+		want    int
+		called  bool
+	}{
+		{"healthz bypasses (readiness probe)", "/v0/healthz", nil, http.StatusOK, true},
+		{"livez bypasses (liveness probe)", "/v0/livez", nil, http.StatusOK, true},
+		{"metrics bypasses (Prometheus scrape)", "/v0/metrics", nil, http.StatusOK, true},
+		{"node-id requires auth", "/v0/node-id", nil, http.StatusUnauthorized, false},
+		{"missing header on tasks", "/v0/tasks", nil, http.StatusUnauthorized, false},
+		{"empty header on tasks", "/v0/tasks", map[string][]string{"X-Remote-User": {""}}, http.StatusUnauthorized, false},
+		// Defense against an APPEND-misconfigured proxy: an
+		// attacker-supplied value would arrive first.
+		{"duplicate header rejected", "/v0/tasks", map[string][]string{"X-Remote-User": {"attacker", "system:serviceaccount:platform:bot"}}, http.StatusUnauthorized, false},
+		{"single header passes", "/v0/tasks", map[string][]string{"X-Remote-User": {"system:serviceaccount:platform:bot"}}, http.StatusOK, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			called = false
+			req := httptest.NewRequest(http.MethodGet, c.path, nil)
+			req.Header = http.Header(c.headers)
+			rr := httptest.NewRecorder()
+			wrapped.ServeHTTP(rr, req)
+			if rr.Code != c.want {
+				body, _ := io.ReadAll(rr.Body)
+				t.Fatalf("status = %d (body: %s), want %d", rr.Code, body, c.want)
+			}
+			if called != c.called {
+				t.Fatalf("inner called = %v, want %v", called, c.called)
+			}
+		})
+	}
+}
+
+func TestNewServerAppliesMiddlewareInTrustedHeaderMode(t *testing.T) {
+	s := NewServer(":0", nil, t.TempDir(), AuthnModeTrustedHeader)
+
+	t.Run("healthz bypasses", func(t *testing.T) {
+		defer func() { _ = recover() }() // handleHealthz panics on nil engine; the auth gate is what we're testing.
+		req := httptest.NewRequest(http.MethodGet, "/v0/healthz", nil)
+		rr := httptest.NewRecorder()
+		s.handler.ServeHTTP(rr, req)
+		if rr.Code == http.StatusUnauthorized {
+			t.Fatalf("healthz hit 401 unexpectedly: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("status without header 401s", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v0/status", nil)
+		rr := httptest.NewRecorder()
+		s.handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rr.Code)
+		}
+	})
+}
+
+func TestNewServerSkipsMiddlewareInUnauthenticatedMode(t *testing.T) {
+	s := NewServer(":0", nil, t.TempDir(), AuthnModeUnauthenticated)
+	if s.handler != s.mux {
+		t.Fatal("unauthenticated mode wrapped the mux in middleware")
+	}
+}

--- a/sidecar/server/auth_test.go
+++ b/sidecar/server/auth_test.go
@@ -72,6 +72,7 @@ func TestTrustedHeaderMiddleware(t *testing.T) {
 		called  bool
 	}{
 		{"healthz bypasses (readiness probe)", "/v0/healthz", nil, http.StatusOK, true},
+		{"startupz bypasses (startup probe)", "/v0/startupz", nil, http.StatusOK, true},
 		{"livez bypasses (liveness probe)", "/v0/livez", nil, http.StatusOK, true},
 		{"metrics bypasses (Prometheus scrape)", "/v0/metrics", nil, http.StatusOK, true},
 		{"node-id requires auth", "/v0/node-id", nil, http.StatusUnauthorized, false},
@@ -127,5 +128,18 @@ func TestNewServerSkipsMiddlewareInUnauthenticatedMode(t *testing.T) {
 	s := NewServer(":0", nil, t.TempDir(), AuthnModeUnauthenticated)
 	if s.handler != s.mux {
 		t.Fatal("unauthenticated mode wrapped the mux in middleware")
+	}
+}
+
+func TestBypassPaths(t *testing.T) {
+	got := BypassPaths()
+	want := []string{"/v0/healthz", "/v0/livez", "/v0/metrics", "/v0/startupz"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d paths, want %d: %v", len(got), len(want), got)
+	}
+	for i, p := range want {
+		if got[i] != p {
+			t.Errorf("path %d: %q, want %q", i, got[i], p)
+		}
 	}
 }

--- a/sidecar/server/server.go
+++ b/sidecar/server/server.go
@@ -15,7 +15,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
 )
+
+var serverLog = seilog.NewLogger("seictl", "sidecar", "server")
 
 const (
 	ed25519PrivKeyLen   = 64 // seed (32) + public key (32)
@@ -56,6 +59,7 @@ func NewServer(addr string, eng *engine.Engine, homeDir, authnMode string) *Serv
 		mux:     http.NewServeMux(),
 	}
 	s.mux.HandleFunc("GET /v0/healthz", s.handleHealthz)
+	s.mux.HandleFunc("GET /v0/startupz", s.handleHealthz)
 	s.mux.HandleFunc("GET /v0/livez", s.handleLivez)
 	s.mux.HandleFunc("GET /v0/status", s.handleStatus)
 	s.mux.Handle("GET /v0/metrics", promhttp.Handler())
@@ -90,12 +94,20 @@ func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Server) handleLivez(w http.ResponseWriter, _ *http.Request) {
-	if err := s.engine.Livez(); err != nil {
+// handleLivez follows the kube-apiserver convention: bare 200/503
+// status for kubelet probes. ?verbose=1 includes the underlying
+// store error for human triage.
+func (s *Server) handleLivez(w http.ResponseWriter, r *http.Request) {
+	err := s.engine.Livez()
+	if err == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if r.URL.Query().Get("verbose") == "1" {
 		writeError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusServiceUnavailable)
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
@@ -202,13 +214,21 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
+		// Cap impersonation-header amplification in trusted-header
+		// mode (proxy injects X-Remote-User / Group / Extra-*).
+		// Go's default is 1MB.
+		MaxHeaderBytes: 32 * 1024,
 	}
 
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		// 25s leaves a 5s buffer under K8s's default 30s
+		// terminationGracePeriodSeconds.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 		defer cancel()
-		_ = srv.Shutdown(shutdownCtx)
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			serverLog.Warn("graceful shutdown failed", "err", err)
+		}
 	}()
 
 	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {

--- a/sidecar/server/server.go
+++ b/sidecar/server/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	homeDir string
 	engine  *engine.Engine
 	mux     *http.ServeMux
+	handler http.Handler // mux, possibly wrapped by trustedHeaderMiddleware
 }
 
 // TaskRequest is the JSON body for POST /v0/tasks. When ID is provided,
@@ -45,9 +46,9 @@ type ErrorResponse struct {
 	Error string `json:"error"`
 }
 
-// NewServer creates a Server wired to the given engine.
-// homeDir is the seid home directory (e.g. /sei) used by the node-id endpoint.
-func NewServer(addr string, eng *engine.Engine, homeDir string) *Server {
+// NewServer wires a Server to the engine. authnMode must come from
+// AuthnMode() so the env read and validation happen once at startup.
+func NewServer(addr string, eng *engine.Engine, homeDir, authnMode string) *Server {
 	s := &Server{
 		addr:    addr,
 		homeDir: homeDir,
@@ -63,6 +64,11 @@ func NewServer(addr string, eng *engine.Engine, homeDir string) *Server {
 	s.mux.HandleFunc("GET /v0/tasks", s.handleListTasks)
 	s.mux.HandleFunc("GET /v0/tasks/{id}", s.handleGetTask)
 	s.mux.HandleFunc("DELETE /v0/tasks/{id}", s.handleDeleteTask)
+
+	s.handler = s.mux
+	if authnMode == AuthnModeTrustedHeader {
+		s.handler = trustedHeaderMiddleware(s.mux)
+	}
 	return s
 }
 
@@ -191,7 +197,7 @@ func (s *Server) handleNodeID(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) ListenAndServe(ctx context.Context) error {
 	srv := &http.Server{
 		Addr:              s.addr,
-		Handler:           s.mux,
+		Handler:           s.handler,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      30 * time.Second,

--- a/sidecar/server/server_test.go
+++ b/sidecar/server/server_test.go
@@ -65,7 +65,7 @@ func waitForTaskResult(eng *engine.Engine, id string) *engine.TaskResult {
 
 func TestLivezReturns200WhenStoreHealthy(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 	rec := serveHTTP(srv, http.MethodGet, "/v0/livez", "")
 
 	if rec.Code != http.StatusOK {
@@ -76,7 +76,7 @@ func TestLivezReturns200WhenStoreHealthy(t *testing.T) {
 func TestLivezReturns200BeforeReady(t *testing.T) {
 	// Livez should pass even before mark-ready (healthz would return 503).
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	if eng.Healthz() {
 		t.Fatal("expected healthz=false before mark-ready")
@@ -95,7 +95,7 @@ func TestLivezReturns503WhenStoreDown(t *testing.T) {
 		t.Fatal(err)
 	}
 	eng := engine.NewEngine(ctx, nil, store)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	// Close the backing store to simulate SQLite failure.
 	store.Close()
@@ -108,7 +108,7 @@ func TestLivezReturns503WhenStoreDown(t *testing.T) {
 
 func TestHealthzReturns503BeforeReady(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 	rec := serveHTTP(srv, http.MethodGet, "/v0/healthz", "")
 
 	if rec.Code != http.StatusServiceUnavailable {
@@ -120,7 +120,7 @@ func TestHealthzReturns200AfterMarkReady(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskMarkReady: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	_, _ = eng.Submit(engine.Task{Type: engine.TaskMarkReady})
 	waitForReady(eng)
@@ -135,7 +135,7 @@ func TestStatusResponse(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskMarkReady: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	rec := serveHTTP(srv, http.MethodGet, "/v0/status", "")
 	if rec.Code != http.StatusOK {
@@ -166,7 +166,7 @@ func TestPostTaskReturnsID(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	body := `{"type":"config-patch","params":{"peers":["a@1.2.3.4:26656"]}}`
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", body)
@@ -187,7 +187,7 @@ func TestPostTaskWithCallerID(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	body := `{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","type":"config-patch"}`
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", body)
@@ -218,7 +218,7 @@ func TestPostTaskDedupReturnsExistingID(t *testing.T) {
 			return nil
 		},
 	}, store)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	body := `{"id":"ffffffff-1111-2222-3333-444444444444","type":"config-patch"}`
 	rec1 := serveHTTP(srv, http.MethodPost, "/v0/tasks", body)
@@ -251,7 +251,7 @@ func TestPostTaskInvalidIDReturns400(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	body := `{"id":"not-a-valid-uuid","type":"config-patch"}`
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", body)
@@ -270,7 +270,7 @@ func TestPostTaskInvalidIDReturns400(t *testing.T) {
 
 func TestPostTaskInvalidJSON(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{not json}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -279,7 +279,7 @@ func TestPostTaskInvalidJSON(t *testing.T) {
 
 func TestPostTaskMissingType(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"params":{}}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -288,7 +288,7 @@ func TestPostTaskMissingType(t *testing.T) {
 
 func TestPostTaskUnknownType(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"nonexistent"}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -297,7 +297,7 @@ func TestPostTaskUnknownType(t *testing.T) {
 
 func TestListTasksEmpty(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 	rec := serveHTTP(srv, http.MethodGet, "/v0/tasks", "")
 
 	var results []engine.TaskResult
@@ -313,7 +313,7 @@ func TestListTasksAfterSubmit(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
@@ -334,7 +334,7 @@ func TestGetTask(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
@@ -368,7 +368,7 @@ func TestGetTaskInProgress(t *testing.T) {
 			return nil
 		},
 	}, store)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	if rec.Code != http.StatusCreated {
@@ -413,7 +413,7 @@ func TestGetTaskInProgress(t *testing.T) {
 
 func TestGetTaskNotFound(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 	rec := serveHTTP(srv, http.MethodGet, "/v0/tasks/nonexistent", "")
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
@@ -424,7 +424,7 @@ func TestDeleteTask(t *testing.T) {
 	eng := newTestEngine(t, map[engine.TaskType]engine.TaskHandler{
 		engine.TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
 	})
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	rec := serveHTTP(srv, http.MethodPost, "/v0/tasks", `{"type":"config-patch"}`)
 	var resp map[string]string
@@ -490,7 +490,7 @@ func TestNodeID_ReturnsCorrectID(t *testing.T) {
 	want := writeTestNodeKey(t, homeDir)
 
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, homeDir)
+	srv := NewServer(":0", eng, homeDir, AuthnModeUnauthenticated)
 
 	rec := serveHTTP(srv, http.MethodGet, "/v0/node-id", "")
 	if rec.Code != http.StatusOK {
@@ -510,7 +510,7 @@ func TestNodeID_ReturnsCorrectID(t *testing.T) {
 
 func TestNodeID_MissingKeyFile(t *testing.T) {
 	eng := newTestEngine(t, nil)
-	srv := NewServer(":0", eng, t.TempDir())
+	srv := NewServer(":0", eng, t.TempDir(), AuthnModeUnauthenticated)
 
 	rec := serveHTTP(srv, http.MethodGet, "/v0/node-id", "")
 	if rec.Code != http.StatusInternalServerError {

--- a/sidecar/tasks/gov_software_upgrade.go
+++ b/sidecar/tasks/gov_software_upgrade.go
@@ -1,11 +1,9 @@
 // Package tasks — gov-software-upgrade handler.
 //
-// SECURITY POSTURE NOTE — sei-protocol/seictl#163 / #165
-//
-// Reached via the sidecar's HTTP API. In Phase 1-3 the API is
-// unauthenticated; anyone with network reach can submit proposals as
-// the validator's operator account. Phase 4 (#165) fronts the sidecar
-// with kube-rbac-proxy. REMOVE THIS NOTICE when #165 lands.
+// This handler signs software-upgrade proposals as the validator's
+// operator account. API authentication is controlled by
+// SEI_SIDECAR_AUTHN_MODE; see sidecar/server/auth.go for the
+// deployment guidance.
 //
 // REHYDRATION WARNING — sei-protocol/seictl#174
 //

--- a/sidecar/tasks/gov_vote.go
+++ b/sidecar/tasks/gov_vote.go
@@ -1,11 +1,8 @@
 // Package tasks — gov-vote handler.
 //
-// SECURITY POSTURE NOTE — sei-protocol/seictl#163 / #165
-//
-// Reached via the sidecar's HTTP API. In Phase 1-3 the API is
-// unauthenticated; anyone with network reach can submit votes as the
-// validator's operator account. Phase 4 (#165) fronts the sidecar
-// with kube-rbac-proxy. REMOVE THIS NOTICE when #165 lands.
+// This handler signs votes as the validator's operator account.
+// API authentication is controlled by SEI_SIDECAR_AUTHN_MODE; see
+// sidecar/server/auth.go for the deployment guidance.
 
 package tasks
 

--- a/sidecar/tasks/sign_and_broadcast.go
+++ b/sidecar/tasks/sign_and_broadcast.go
@@ -1,14 +1,11 @@
 // Package tasks — sign-tx family helper.
 //
-// SECURITY POSTURE NOTE — sei-protocol/seictl#163 / #165
-//
-// SignAndBroadcast is reached via the sidecar's HTTP API. In Phase 1-3
-// the API is unauthenticated and bound on 0.0.0.0:7777: any caller with
-// network reach can submit txs as the validator's operator account.
-// Phase 4 (#165) fronts the sidecar with kube-rbac-proxy on :8443
-// (TokenReview + a single coarse `create seinodetasks.sei.io` SAR) and
-// rebinds the sidecar to 127.0.0.1:7777. REMOVE THIS NOTICE when #165
-// lands.
+// SignAndBroadcast signs txs as the validator's operator account.
+// API-level authentication is controlled by SEI_SIDECAR_AUTHN_MODE:
+// trusted-header mode pairs the sidecar with a kube-rbac-proxy
+// container that gates every request via TokenReview + SAR. When the
+// env var is unset, the API is unauthenticated and any actor with
+// network reach to the listen port can reach this code path.
 
 package tasks
 


### PR DESCRIPTION
Closes #165 on the seictl side. Controller-side wiring (kube-rbac-proxy container, RBAC, cert-manager Certificate) lands in a separate sei-k8s-controller PR.

## Summary
- New \`SEI_SIDECAR_AUTHN_MODE\` env var with strict parsing
  - Unset / \`unauthenticated\`: backward-compat — bind all interfaces, no auth
  - \`trusted-header\`: bind \`127.0.0.1:7777\`, require exactly one non-empty \`X-Remote-User\` header per request
- Bypass paths in trusted-header mode: \`/v0/healthz\` (readiness probe), \`/v0/livez\` (liveness probe), \`/v0/metrics\` (Prometheus scrape) — all callers that can't carry auth headers
- Defense-in-depth: \`Header.Values()\` + \`len == 1\` + non-empty rejects a misconfigured proxy that appends rather than overwrites \`X-Remote-User\`
- Strict env parsing: a typo like \`trusted_header\` fails startup instead of silently degrading to unauthenticated
- New operator-facing doc \`sidecar/docs/authn.md\` (peer to \`keyring.md\`) — single referent for the cross-repo contract with sei-k8s-controller
- OpenAPI rewritten: dropped misleading \`bearerAuth\` scheme, added \`remoteUserHeader\` apiKey scheme with operator guidance
- Verbose SECURITY POSTURE NOTE banners on sign-tx files replaced with short pointers to the env var

## Security model

The trust boundary is the **pod**, not the loopback interface. Loopback bind confines the listen socket to the pod's network namespace, but any colocated container can still reach \`127.0.0.1:7777\` directly. With \`shareProcessNamespace: true\` (current SeiNode default), a sibling container can also read \`/proc/<sidecar>/mem\` and exfiltrate the unlocked keyring — memory read is the load-bearing threat, not header forgery; the middleware does not defend against it.

Pods running \`trusted-header\` mode MUST NOT enable \`hostNetwork\`, \`hostPID\`, or \`hostIPC\`. Enforcement is the controller-side PR's responsibility.

## Test plan
- [x] \`TestAuthnMode\` — strict parsing including typo cases (\`trusted_header\` underscore, \`trustedheader\` no hyphen, future-mode \`mtls\`)
- [x] \`TestBindAddress\` — loopback in trusted-header mode, all-interfaces in unauthenticated
- [x] \`TestTrustedHeaderMiddleware\` table — 8 cases including all three bypasses, gated \`/v0/node-id\`, missing/empty/duplicate/valid header
- [x] \`TestNewServerAppliesMiddlewareInTrustedHeaderMode\` / \`TestNewServerSkipsMiddlewareInUnauthenticatedMode\` — wiring
- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1\` clean (all packages)
- [x] \`go test -race ./sidecar/server/ ./sidecar/tasks/\` clean
- [x] \`gofmt -s -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` reports 0 issues
- [x] Coral trio extensive cross-review (platform / kubernetes / security) — synthesized findings applied; full-PR comment hygiene pass; deferred items tracked in #178

## Follow-ups in #178
- Plumb \`X-Remote-User\` identity through ctx for audit logging
- Startup WARN on unauthenticated mode
- Optional \`hostNetwork\` detection refuse-to-start
- mTLS / shared secret between proxy and sidecar (multi-tenant future)

## Out of scope for this PR
- Controller-side wiring (kube-rbac-proxy container, NetworkPolicy, cert-manager Certificate) — separate sei-k8s-controller PR
- End-to-end test against a real kube-rbac-proxy — waits for the controller-side PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authentication mode and changes server binding behavior, which is security-sensitive and could break deployments if misconfigured (env parsing, proxy header behavior, probe paths). Default behavior remains unchanged when the env var is unset.
> 
> **Overview**
> Introduces `SEI_SIDECAR_AUTHN_MODE` to optionally run the sidecar API in **trusted-header** mode: bind to `127.0.0.1` and require exactly one non-empty `X-Remote-User` header on all non-probe paths, with metrics for auth rejections and a shared bypass list for probes/scrapes.
> 
> Wires mode selection into `serve.go` (startup logging + bind address), updates `server.NewServer` to conditionally wrap handlers and adds `/v0/startupz`, tightens HTTP server limits/timeouts, and adjusts `/v0/livez` to return 503 on failure (optionally verbose).
> 
> Updates the OpenAPI spec and generated client to replace `bearerAuth` with a `remoteUserHeader` scheme, adds operator documentation in `sidecar/docs/authn.md`, and refreshes sign-tx task security notes to point at the new authn model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29ef59fa73480c08f7aa02912436923e95199114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->