### PR TITLE
feat(sidecar/assemble-genesis): apply spec.genesis.overrides to assembled genesis.json

### DIFF
--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -559,7 +560,6 @@ type GenerateGentxTask struct {
 	ChainID        string
 	StakingAmount  string
 	AccountBalance string
-	GenesisParams  string
 }
 
 func (t GenerateGentxTask) TaskType() string { return TaskTypeGenerateGentx }
@@ -582,9 +582,6 @@ func (t GenerateGentxTask) ToTaskRequest() TaskRequest {
 		"chainId":        t.ChainID,
 		"stakingAmount":  t.StakingAmount,
 		"accountBalance": t.AccountBalance,
-	}
-	if t.GenesisParams != "" {
-		p["genesisParams"] = t.GenesisParams
 	}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	return req
@@ -654,11 +651,17 @@ func validateGenesisAccounts(prefix string, accounts []GenesisAccountEntry) erro
 
 // AssembleAndUploadGenesisTask collects per-node artifacts and produces final genesis.json.
 // S3 coordinates are derived by the sidecar from its environment.
+//
+// Overrides is a flat map of dotted-path keys into genesis.app_state to raw
+// JSON values, applied to the assembled genesis after collect-gentxs runs.
+// The controller validates keys (immutability post-bootstrap) via CEL; the
+// sidecar applies them verbatim and fails loudly on bad paths.
 type AssembleAndUploadGenesisTask struct {
 	AccountBalance string
 	Namespace      string
 	Nodes          []GenesisNodeParam
 	Accounts       []GenesisAccountEntry
+	Overrides      map[string]json.RawMessage
 }
 
 func (t AssembleAndUploadGenesisTask) TaskType() string { return TaskTypeAssembleGenesis }
@@ -688,6 +691,13 @@ func (t AssembleAndUploadGenesisTask) ToTaskRequest() TaskRequest {
 	}
 	if accounts := genesisAccountsToWire(t.Accounts); accounts != nil {
 		p["accounts"] = accounts
+	}
+	if len(t.Overrides) > 0 {
+		overrides := make(map[string]interface{}, len(t.Overrides))
+		for k, v := range t.Overrides {
+			overrides[k] = v
+		}
+		p["overrides"] = overrides
 	}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	return req

--- a/sidecar/tasks/assemble_genesis.go
+++ b/sidecar/tasks/assemble_genesis.go
@@ -58,11 +58,19 @@ type GenesisAccountEntry struct {
 
 // AssembleGenesisRequest holds the typed parameters for the assemble-and-upload-genesis task.
 // S3 bucket, region, and prefix are derived from the sidecar's environment.
+//
+// Overrides is a flat map of dotted-path keys into genesis.app_state to
+// raw JSON values. The first dotted token is the cosmos module name (a key
+// in app_state); subsequent tokens walk into that module's JSON tree. The
+// leaf value is replaced verbatim with the supplied json.RawMessage. The
+// controller enforces immutability of these keys post-bootstrap via CEL;
+// the sidecar applies them once during the genesis ceremony.
 type AssembleGenesisRequest struct {
-	AccountBalance string                `json:"accountBalance"`
-	Namespace      string                `json:"namespace"`
-	Nodes          []AssembleNodeEntry   `json:"nodes"`
-	Accounts       []GenesisAccountEntry `json:"accounts,omitempty"`
+	AccountBalance string                     `json:"accountBalance"`
+	Namespace      string                     `json:"namespace"`
+	Nodes          []AssembleNodeEntry        `json:"nodes"`
+	Accounts       []GenesisAccountEntry      `json:"accounts,omitempty"`
+	Overrides      map[string]json.RawMessage `json:"overrides,omitempty"`
 }
 
 // nodeNames returns the list of node name strings from the Nodes entries.
@@ -131,6 +139,10 @@ func (a *GenesisAssembler) Handler() engine.TaskHandler {
 		}
 
 		if err := a.collectGentxs(); err != nil {
+			return err
+		}
+
+		if err := a.applyOverrides(cfg.Overrides); err != nil {
 			return err
 		}
 
@@ -377,6 +389,45 @@ func (a *GenesisAssembler) collectGentxs() error {
 		return fmt.Errorf("assemble-genesis: collect-gentxs: %w", err)
 	}
 
+	return nil
+}
+
+// applyOverrides re-reads the assembled genesis.json, applies the
+// caller-supplied app_state overrides, and writes the file back. This runs
+// after collectGentxs so the dispatched MsgCreateValidator data and
+// derived persistent peers are already baked into app_state — overrides
+// are an in-place patch on the final assembled doc.
+func (a *GenesisAssembler) applyOverrides(overrides map[string]json.RawMessage) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	genFile := filepath.Join(a.homeDir, "config", "genesis.json")
+	genDoc, err := tmtypes.GenesisDocFromFile(genFile)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: reading genesis for overrides: %w", err)
+	}
+
+	var appState map[string]json.RawMessage
+	if err := json.Unmarshal(genDoc.AppState, &appState); err != nil {
+		return fmt.Errorf("assemble-genesis: parsing app_state for overrides: %w", err)
+	}
+
+	if err := applyGenesisOverrides(appState, overrides); err != nil {
+		return fmt.Errorf("assemble-genesis: %w", err)
+	}
+
+	appStateJSON, err := json.Marshal(appState)
+	if err != nil {
+		return fmt.Errorf("assemble-genesis: marshaling overridden app_state: %w", err)
+	}
+	genDoc.AppState = appStateJSON
+
+	if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+		return fmt.Errorf("assemble-genesis: writing genesis after overrides: %w", err)
+	}
+
+	assembleLog.Info("applied genesis overrides", "count", len(overrides))
 	return nil
 }
 

--- a/sidecar/tasks/assemble_genesis_test.go
+++ b/sidecar/tasks/assemble_genesis_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -122,5 +123,154 @@ func TestParseAssembleNodes_MissingName(t *testing.T) {
 	// The node should unmarshal but with empty Name — the handler validates this.
 	if nodes[0].Name != "" {
 		t.Fatalf("expected empty name, got %q", nodes[0].Name)
+	}
+}
+
+// genesisWithAppState writes a Tendermint genesis.json containing the given
+// JSON-encoded app_state body. Used by override tests that need real
+// module-shaped data to walk into.
+func genesisWithAppState(t *testing.T, homeDir, appStateJSON string) string {
+	t.Helper()
+	configDir := filepath.Join(homeDir, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	genFile := filepath.Join(configDir, "genesis.json")
+	body := `{
+		"chain_id": "test-chain-1",
+		"genesis_time": "2026-01-01T00:00:00Z",
+		"initial_height": "1",
+		"consensus_params": {
+			"block": {"max_bytes": "22020096", "max_gas": "-1"},
+			"evidence": {"max_age_num_blocks": "100000", "max_age_duration": "172800000000000", "max_bytes": "1048576"},
+			"validator": {"pub_key_types": ["ed25519"]},
+			"version": {}
+		},
+		"validators": [],
+		"app_hash": "",
+		"app_state": ` + appStateJSON + `
+	}`
+	if err := os.WriteFile(genFile, []byte(body), 0o644); err != nil {
+		t.Fatalf("write genesis: %v", err)
+	}
+	return genFile
+}
+
+func TestAssembler_ApplyOverrides_NoOpOnEmpty(t *testing.T) {
+	homeDir := t.TempDir()
+	genFile := genesisWithAppState(t, homeDir, `{"staking":{"params":{"unbonding_time":"1814400s"}}}`)
+	mtimeBefore := mustModTime(t, genFile)
+
+	a := NewGenesisAssembler(homeDir, "b", "r", "test-chain-1", nil, nil)
+	if err := a.applyOverrides(nil); err != nil {
+		t.Fatalf("nil overrides: %v", err)
+	}
+	if err := a.applyOverrides(map[string]json.RawMessage{}); err != nil {
+		t.Fatalf("empty overrides: %v", err)
+	}
+
+	if mustModTime(t, genFile) != mtimeBefore {
+		t.Errorf("genesis.json was rewritten on no-op overrides")
+	}
+}
+
+func TestAssembler_ApplyOverrides_PatchesGenesisFile(t *testing.T) {
+	homeDir := t.TempDir()
+	genFile := genesisWithAppState(t, homeDir, `{
+		"staking": {"params": {"unbonding_time": "1814400s", "max_validators": 100}},
+		"gov":     {"params": {"max_deposit_period": "172800s"}}
+	}`)
+
+	a := NewGenesisAssembler(homeDir, "b", "r", "test-chain-1", nil, nil)
+	err := a.applyOverrides(map[string]json.RawMessage{
+		"staking.params.unbonding_time": json.RawMessage(`"600s"`),
+		"gov.params.max_deposit_period": json.RawMessage(`"60s"`),
+	})
+	if err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+
+	// Read the file back and confirm the leaves changed.
+	body, err := os.ReadFile(genFile)
+	if err != nil {
+		t.Fatalf("reading genesis back: %v", err)
+	}
+	var doc struct {
+		AppState map[string]json.RawMessage `json:"app_state"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("parsing genesis: %v", err)
+	}
+	var staking struct {
+		Params struct {
+			UnbondingTime string `json:"unbonding_time"`
+			MaxValidators int    `json:"max_validators"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(doc.AppState["staking"], &staking); err != nil {
+		t.Fatalf("parsing staking: %v", err)
+	}
+	if staking.Params.UnbondingTime != "600s" {
+		t.Errorf("unbonding_time = %q, want 600s", staking.Params.UnbondingTime)
+	}
+	if staking.Params.MaxValidators != 100 {
+		t.Errorf("max_validators = %d, want preserved 100", staking.Params.MaxValidators)
+	}
+
+	var gov struct {
+		Params struct {
+			MaxDepositPeriod string `json:"max_deposit_period"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(doc.AppState["gov"], &gov); err != nil {
+		t.Fatalf("parsing gov: %v", err)
+	}
+	if gov.Params.MaxDepositPeriod != "60s" {
+		t.Errorf("max_deposit_period = %q, want 60s", gov.Params.MaxDepositPeriod)
+	}
+}
+
+func TestAssembler_ApplyOverrides_BubblesBadKeyError(t *testing.T) {
+	homeDir := t.TempDir()
+	_ = genesisWithAppState(t, homeDir, `{"staking":{"params":{"unbonding_time":"1814400s"}}}`)
+
+	a := NewGenesisAssembler(homeDir, "b", "r", "test-chain-1", nil, nil)
+	err := a.applyOverrides(map[string]json.RawMessage{
+		"nope.params.x": json.RawMessage(`"y"`),
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown module override")
+	}
+	if !strings.Contains(err.Error(), "unknown module") {
+		t.Errorf("error = %q, want substring 'unknown module'", err.Error())
+	}
+}
+
+// TestAssembleGenesisRequest_OverridesRoundTrip verifies the new Overrides
+// field deserializes from the wire shape the controller emits.
+func TestAssembleGenesisRequest_OverridesRoundTrip(t *testing.T) {
+	wire := `{
+		"accountBalance": "10000000usei",
+		"namespace": "default",
+		"nodes": [{"name": "val-0"}],
+		"overrides": {
+			"staking.params.unbonding_time": "600s",
+			"staking.params.max_validators": 50
+		}
+	}`
+	var got AssembleGenesisRequest
+	if err := json.Unmarshal([]byte(wire), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Overrides) != 2 {
+		t.Fatalf("overrides len = %d, want 2", len(got.Overrides))
+	}
+	if string(got.Overrides["staking.params.unbonding_time"]) != `"600s"` {
+		t.Errorf("unbonding_time raw = %q, want %q",
+			string(got.Overrides["staking.params.unbonding_time"]), `"600s"`)
+	}
+	if string(got.Overrides["staking.params.max_validators"]) != "50" {
+		t.Errorf("max_validators raw = %q, want %q",
+			string(got.Overrides["staking.params.max_validators"]), "50")
 	}
 }

--- a/sidecar/tasks/generate_gentx.go
+++ b/sidecar/tasks/generate_gentx.go
@@ -51,7 +51,6 @@ type GenerateGentxRequest struct {
 	ChainID        string `json:"chainId"`
 	StakingAmount  string `json:"stakingAmount"`
 	AccountBalance string `json:"accountBalance"`
-	GenesisParams  string `json:"genesisParams"`
 }
 
 // GentxGenerator produces a genesis transaction by calling the same SDK
@@ -72,8 +71,7 @@ func NewGentxGenerator(homeDir string) *GentxGenerator {
 //	{
 //	  "chainId":        "my-chain",
 //	  "stakingAmount":  "1000000usei",
-//	  "accountBalance": "10000000usei",
-//	  "genesisParams":  "" (optional, reserved for future genesis customization)
+//	  "accountBalance": "10000000usei"
 //	}
 func (g *GentxGenerator) Handler() engine.TaskHandler {
 	return engine.TypedHandler(func(ctx context.Context, params GenerateGentxRequest) error {

--- a/sidecar/tasks/genesis_overrides.go
+++ b/sidecar/tasks/genesis_overrides.go
@@ -1,0 +1,106 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// applyGenesisOverrides applies a flat map of dotted-path overrides to a
+// cosmos-sdk genesis app_state map. Keys take the shape
+// "<module>.<field>[.<field>...]" — the first segment must be a key in
+// appState (the cosmos module name), and remaining segments walk into the
+// module's JSON tree. The leaf JSON value is replaced verbatim.
+//
+// Intermediate path segments must resolve to JSON objects. A missing
+// intermediate key is created as an empty object so callers can add new
+// nested paths. A non-object intermediate is a hard error — we never
+// silently overwrite scalars or arrays.
+//
+// The function fails loudly on malformed input (empty keys, single-token
+// keys, unknown modules, non-object intermediates) so misconfiguration
+// surfaces at ceremony time via the task's failure path rather than as
+// silently-ignored fields in the final genesis.
+func applyGenesisOverrides(appState map[string]json.RawMessage, overrides map[string]json.RawMessage) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	for key, value := range overrides {
+		if key == "" {
+			return fmt.Errorf("genesis-overrides: empty key")
+		}
+		parts := strings.Split(key, ".")
+		if len(parts) < 2 {
+			return fmt.Errorf("genesis-overrides: key %q must be of the form module.field[.field...]", key)
+		}
+		for i, p := range parts {
+			if p == "" {
+				return fmt.Errorf("genesis-overrides: key %q has empty segment at index %d", key, i)
+			}
+		}
+		if len(value) == 0 {
+			return fmt.Errorf("genesis-overrides: key %q has empty value", key)
+		}
+
+		module := parts[0]
+		moduleRaw, ok := appState[module]
+		if !ok {
+			return fmt.Errorf("genesis-overrides: unknown module %q (key %q); app_state has no such top-level key", module, key)
+		}
+
+		var moduleState map[string]json.RawMessage
+		if err := json.Unmarshal(moduleRaw, &moduleState); err != nil {
+			return fmt.Errorf("genesis-overrides: module %q is not a JSON object: %w", module, err)
+		}
+		if moduleState == nil {
+			moduleState = map[string]json.RawMessage{}
+		}
+
+		if err := setNestedRaw(moduleState, parts[1:], value, key); err != nil {
+			return err
+		}
+
+		moduleBz, err := json.Marshal(moduleState)
+		if err != nil {
+			return fmt.Errorf("genesis-overrides: re-marshaling module %q: %w", module, err)
+		}
+		appState[module] = moduleBz
+	}
+	return nil
+}
+
+// setNestedRaw walks path into state, creating empty objects for missing
+// intermediates, and writes value at the leaf. The originalKey is carried
+// only for error messages.
+func setNestedRaw(state map[string]json.RawMessage, path []string, value json.RawMessage, originalKey string) error {
+	if len(path) == 0 {
+		return fmt.Errorf("genesis-overrides: key %q has no field path under module", originalKey)
+	}
+	if len(path) == 1 {
+		state[path[0]] = value
+		return nil
+	}
+
+	head, rest := path[0], path[1:]
+	var child map[string]json.RawMessage
+	if raw, ok := state[head]; ok && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &child); err != nil {
+			return fmt.Errorf("genesis-overrides: key %q traverses non-object at segment %q: %w", originalKey, head, err)
+		}
+	}
+	if child == nil {
+		child = map[string]json.RawMessage{}
+	}
+
+	if err := setNestedRaw(child, rest, value, originalKey); err != nil {
+		return err
+	}
+
+	childBz, err := json.Marshal(child)
+	if err != nil {
+		return fmt.Errorf("genesis-overrides: re-marshaling intermediate %q for key %q: %w", head, originalKey, err)
+	}
+	state[head] = childBz
+	return nil
+}

--- a/sidecar/tasks/genesis_overrides_test.go
+++ b/sidecar/tasks/genesis_overrides_test.go
@@ -1,0 +1,329 @@
+package tasks
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// mustAppState builds an app_state seed map from a JSON literal so tests
+// read like the on-the-wire structure they're verifying.
+func mustAppState(t *testing.T, body string) map[string]json.RawMessage {
+	t.Helper()
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("seed app_state: %v", err)
+	}
+	return out
+}
+
+func TestApplyGenesisOverrides_NilAndEmpty(t *testing.T) {
+	state := mustAppState(t, `{"staking":{"params":{"unbonding_time":"21 days"}}}`)
+	before, _ := json.Marshal(state)
+
+	if err := applyGenesisOverrides(state, nil); err != nil {
+		t.Fatalf("nil overrides: %v", err)
+	}
+	if err := applyGenesisOverrides(state, map[string]json.RawMessage{}); err != nil {
+		t.Fatalf("empty overrides: %v", err)
+	}
+	after, _ := json.Marshal(state)
+	if string(before) != string(after) {
+		t.Errorf("app_state mutated on no-op input:\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestApplyGenesisOverrides_StringLeaf(t *testing.T) {
+	state := mustAppState(t, `{"staking":{"params":{"unbonding_time":"21 days"}}}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"staking.params.unbonding_time": json.RawMessage(`"600s"`),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got := unbondingTime(t, state)
+	if got != "600s" {
+		t.Errorf("unbonding_time = %q, want %q", got, "600s")
+	}
+}
+
+func TestApplyGenesisOverrides_NumberLeaf(t *testing.T) {
+	state := mustAppState(t, `{"staking":{"params":{"max_validators":100}}}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"staking.params.max_validators": json.RawMessage(`50`),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	stakingState := unmarshalObj(t, state["staking"])
+	params := unmarshalObj(t, stakingState["params"])
+	if got := string(params["max_validators"]); got != "50" {
+		t.Errorf("max_validators raw = %q, want %q", got, "50")
+	}
+}
+
+func TestApplyGenesisOverrides_ObjectLeaf(t *testing.T) {
+	state := mustAppState(t, `{"gov":{"params":{"voting_params":{"voting_period":"172800s"}}}}`)
+	newParams := json.RawMessage(`{"voting_period":"60s","quorum":"0.4"}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"gov.params.voting_params": newParams,
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	govState := unmarshalObj(t, state["gov"])
+	params := unmarshalObj(t, govState["params"])
+	vp := unmarshalObj(t, params["voting_params"])
+	if got := string(vp["voting_period"]); got != `"60s"` {
+		t.Errorf("voting_period = %q, want %q", got, `"60s"`)
+	}
+	if got := string(vp["quorum"]); got != `"0.4"` {
+		t.Errorf("quorum = %q, want %q", got, `"0.4"`)
+	}
+}
+
+func TestApplyGenesisOverrides_MultipleKeysAcrossModules(t *testing.T) {
+	state := mustAppState(t, `{
+		"staking": {"params": {"unbonding_time": "21 days", "max_validators": 100}},
+		"gov":     {"params": {"max_deposit_period": "172800s"}}
+	}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"staking.params.unbonding_time": json.RawMessage(`"600s"`),
+		"staking.params.max_validators": json.RawMessage(`50`),
+		"gov.params.max_deposit_period": json.RawMessage(`"60s"`),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if got := unbondingTime(t, state); got != "600s" {
+		t.Errorf("unbonding_time = %q, want 600s", got)
+	}
+
+	stakingState := unmarshalObj(t, state["staking"])
+	params := unmarshalObj(t, stakingState["params"])
+	if got := string(params["max_validators"]); got != "50" {
+		t.Errorf("max_validators = %q, want 50", got)
+	}
+
+	govState := unmarshalObj(t, state["gov"])
+	govParams := unmarshalObj(t, govState["params"])
+	if got := string(govParams["max_deposit_period"]); got != `"60s"` {
+		t.Errorf("max_deposit_period = %q, want \"60s\"", got)
+	}
+}
+
+func TestApplyGenesisOverrides_DeepNestedPath(t *testing.T) {
+	state := mustAppState(t, `{"mod":{"a":{"b":{"c":{"d":"old"}}}}}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"mod.a.b.c.d": json.RawMessage(`"new"`),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	mod := unmarshalObj(t, state["mod"])
+	a := unmarshalObj(t, mod["a"])
+	b := unmarshalObj(t, a["b"])
+	c := unmarshalObj(t, b["c"])
+	if got := string(c["d"]); got != `"new"` {
+		t.Errorf("deep leaf = %q, want \"new\"", got)
+	}
+}
+
+func TestApplyGenesisOverrides_CreatesMissingIntermediate(t *testing.T) {
+	// Override under an existing module that doesn't yet have the
+	// intermediate path. The helper auto-creates empty objects so
+	// new sub-fields can be added without seeding the path first.
+	state := mustAppState(t, `{"staking":{"params":{"unbonding_time":"21 days"}}}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"staking.future.new_field": json.RawMessage(`true`),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	stakingState := unmarshalObj(t, state["staking"])
+	future := unmarshalObj(t, stakingState["future"])
+	if got := string(future["new_field"]); got != "true" {
+		t.Errorf("future.new_field = %q, want true", got)
+	}
+}
+
+func TestApplyGenesisOverrides_Idempotent(t *testing.T) {
+	overrides := map[string]json.RawMessage{
+		"staking.params.unbonding_time": json.RawMessage(`"600s"`),
+		"staking.params.max_validators": json.RawMessage(`50`),
+	}
+
+	stateA := mustAppState(t, `{"staking":{"params":{"unbonding_time":"21 days","max_validators":100}}}`)
+	if err := applyGenesisOverrides(stateA, overrides); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	afterFirst, _ := json.Marshal(stateA)
+
+	if err := applyGenesisOverrides(stateA, overrides); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	afterSecond, _ := json.Marshal(stateA)
+
+	if string(afterFirst) != string(afterSecond) {
+		t.Errorf("not idempotent:\nfirst=%s\nsecond=%s", afterFirst, afterSecond)
+	}
+}
+
+func TestApplyGenesisOverrides_RejectsBadKey(t *testing.T) {
+	state := mustAppState(t, `{"staking":{"params":{"unbonding_time":"21 days"}}}`)
+
+	cases := []struct {
+		name      string
+		overrides map[string]json.RawMessage
+		want      string
+	}{
+		{
+			name:      "empty key",
+			overrides: map[string]json.RawMessage{"": json.RawMessage(`"x"`)},
+			want:      "empty key",
+		},
+		{
+			name:      "single token",
+			overrides: map[string]json.RawMessage{"staking": json.RawMessage(`"x"`)},
+			want:      "module.field",
+		},
+		{
+			name:      "trailing dot",
+			overrides: map[string]json.RawMessage{"staking.params.": json.RawMessage(`"x"`)},
+			want:      "empty segment",
+		},
+		{
+			name:      "double dot",
+			overrides: map[string]json.RawMessage{"staking..unbonding_time": json.RawMessage(`"x"`)},
+			want:      "empty segment",
+		},
+		{
+			name:      "empty value",
+			overrides: map[string]json.RawMessage{"staking.params.unbonding_time": json.RawMessage(``)},
+			want:      "empty value",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := applyGenesisOverrides(copyAppState(t, state), c.overrides)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.want)
+			}
+		})
+	}
+}
+
+func TestApplyGenesisOverrides_UnknownModule(t *testing.T) {
+	state := mustAppState(t, `{"staking":{"params":{"unbonding_time":"21 days"}}}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"nope.params.x": json.RawMessage(`"y"`),
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown module")
+	}
+	if !strings.Contains(err.Error(), "unknown module") {
+		t.Errorf("error = %q, want substring 'unknown module'", err.Error())
+	}
+}
+
+func TestApplyGenesisOverrides_TraverseScalar(t *testing.T) {
+	state := mustAppState(t, `{"staking":{"params":"this-is-a-string"}}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"staking.params.unbonding_time": json.RawMessage(`"600s"`),
+	})
+	if err == nil {
+		t.Fatal("expected error traversing scalar intermediate")
+	}
+	if !strings.Contains(err.Error(), "non-object") {
+		t.Errorf("error = %q, want substring 'non-object'", err.Error())
+	}
+}
+
+func TestApplyGenesisOverrides_TraverseArray(t *testing.T) {
+	state := mustAppState(t, `{"staking":{"params":["a","b"]}}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"staking.params.unbonding_time": json.RawMessage(`"600s"`),
+	})
+	if err == nil {
+		t.Fatal("expected error traversing array intermediate")
+	}
+	if !strings.Contains(err.Error(), "non-object") {
+		t.Errorf("error = %q, want substring 'non-object'", err.Error())
+	}
+}
+
+func TestApplyGenesisOverrides_LeavesUnrelatedKeysIntact(t *testing.T) {
+	state := mustAppState(t, `{
+		"staking": {"params": {"unbonding_time": "21 days", "max_validators": 100}},
+		"gov":     {"params": {"max_deposit_period": "172800s"}}
+	}`)
+	err := applyGenesisOverrides(state, map[string]json.RawMessage{
+		"staking.params.unbonding_time": json.RawMessage(`"600s"`),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// staking.params.max_validators preserved
+	stakingState := unmarshalObj(t, state["staking"])
+	params := unmarshalObj(t, stakingState["params"])
+	if got := string(params["max_validators"]); got != "100" {
+		t.Errorf("max_validators = %q, want preserved 100", got)
+	}
+
+	// entire gov module preserved
+	gov := unmarshalObj(t, state["gov"])
+	govParams := unmarshalObj(t, gov["params"])
+	if got := string(govParams["max_deposit_period"]); got != `"172800s"` {
+		t.Errorf("gov.params.max_deposit_period = %q, want preserved", got)
+	}
+}
+
+// unbondingTime is a convenience helper used by multiple tests to drill
+// into staking.params.unbonding_time and return the unquoted string.
+func unbondingTime(t *testing.T, state map[string]json.RawMessage) string {
+	t.Helper()
+	staking := unmarshalObj(t, state["staking"])
+	params := unmarshalObj(t, staking["params"])
+	var s string
+	if err := json.Unmarshal(params["unbonding_time"], &s); err != nil {
+		t.Fatalf("decoding unbonding_time: %v", err)
+	}
+	return s
+}
+
+func unmarshalObj(t *testing.T, raw json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decoding object: %v", err)
+	}
+	return out
+}
+
+func copyAppState(t *testing.T, in map[string]json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	bz, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(bz, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if reflect.DeepEqual(in, out) == false {
+		// Sanity guard — not a test assertion, just paranoia about the helper.
+		t.Logf("note: marshal/unmarshal round-trip diverged for state; tests should still be valid")
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

SIP-3 testing needs a fresh test cluster whose `staking.params.unbonding_time` is `600s`, not the cosmos default of 21 days. The controller already accepts `SeiNodeDeployment.spec.genesis.overrides` and propagates them through, but the sidecar was dropping them on the floor at the assemble-genesis step. This PR closes that gap.

## Wire contract

`AssembleGenesisRequest` gains:

```go
Overrides map[string]json.RawMessage `json:"overrides,omitempty"`
```

Keys are dotted snake_case paths into `genesis.app_state`. The first segment is the cosmos module name (a top-level key in `app_state`); subsequent segments walk into that module's JSON tree and replace the leaf verbatim. Values are raw JSON, so callers can override scalars, numbers, or whole objects:

| key | value |
| --- | --- |
| `staking.params.unbonding_time` | `"600s"` |
| `gov.params.max_deposit_period` | `"60s"` |
| `staking.params.max_validators` | `50` |
| `gov.params.voting_params`      | `{"voting_period":"60s","quorum":"0.4"}` |

## Validator-side flow change

`GenesisAssembler.Handler()` order is now:

```
downloadGentxFiles
  -> addMissingGenesisAccounts
  -> addExternalGenesisAccounts
  -> collectGentxs
  -> applyOverrides   <-- new
  -> uploadGenesis
  -> uploadPeers
```

Overrides are applied **after** collect-gentxs so any validator-derived state and persistent peers baked in by `genutil.GenAppStateFromConfig` are already in place — the override step is an in-place JSON patch on the final assembled `genesis.json`.

## Design anchors (from the coral round)

- Single SND-level dispatch; no per-node fan-out for overrides.
- Bootstrap-only — the sidecar doesn't enforce immutability; the controller does that via CEL.
- Fails loudly on bad keys (empty, single-token, trailing/double dot, empty value, unknown module, non-object intermediates) so misconfiguration surfaces as a `FailedTaskDetail` on the owning `SeiNodeDeployment` rather than as a silently-ignored field.
- No cosmos-sdk module allowlist — the chain will fail loud on garbage at `InitGenesis`.

## Other changes

- Drops the dead `GenesisParams` field from `GenerateGentxRequest` and its client-side mirror. The "reserved for future genesis customization" comment is now the dedicated `Overrides` path on the SND-level assemble task.
- New helper `applyGenesisOverrides` lives in `sidecar/tasks/genesis_overrides.go`; `GenesisAssembler.applyOverrides` is the disk-I/O glue that re-reads `config/genesis.json`, calls the helper, and writes back via `genutil.ExportGenesisFile`.

## Companion change

The controller-side wiring (populating `assembleParams.Overrides` from `SeiNodeDeployment.spec.genesis.overrides` in `internal/planner/group.go`) is being implemented in parallel in `sei-protocol/sei-k8s-controller`. See sei-protocol/sei-k8s-controller#270.

## Test plan

- [x] `go test ./sidecar/tasks/... -count=1` passes
- [x] `make test` passes
- [x] `make lint` clean
- [x] Unit coverage in `genesis_overrides_test.go`: string/number/object leaves, deep nesting, cross-module, missing intermediate, idempotency, all error surfaces
- [x] Disk-level coverage in `assemble_genesis_test.go`: `applyOverrides` mutates `genesis.json` and bubbles bad-key errors
- [x] Wire round-trip test for `AssembleGenesisRequest.Overrides`
- [ ] Integration: SIP-3 test cluster boots with `unbonding_time=600s` and observes the resulting validator un-bonding behavior end-to-end