### PR TITLE
feat(nodedeployment): add --genesis-override flag

### DIFF
--- a/nodedeployment/apply.go
+++ b/nodedeployment/apply.go
@@ -143,7 +143,7 @@ var applyCmd = cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:  "genesis-override",
-			Usage: "Set a key in spec.genesis.overrides: --genesis-override <module.field[.field...]>=<value> (e.g. --genesis-override staking.params.unbonding_time=600s). Keys must be dotted cosmos-module paths — the first segment is a module in app_state (staking, bank, gov, ...). Values parse as JSON when possible (numbers, bools, objects); otherwise as strings. Repeatable. Requires --preset genesis-chain. --set cannot reach this map because its parser splits on every dot.",
+			Usage: `Set a key in spec.genesis.overrides: --genesis-override <module.field[.field...]>=<value> (e.g. --genesis-override staking.params.unbonding_time=600s). Keys must be dotted cosmos-module paths — the first segment is a module in app_state (staking, bank, gov, ...). Values parse as JSON when possible (numbers, bools, objects); otherwise as strings. To force a numeric-looking value to render as string, wrap in JSON quotes (e.g. --genesis-override foo.bar='"42"'). Repeatable. Requires --preset genesis-chain. --set cannot reach this map because its parser splits on every dot.`,
 		},
 		&cli.BoolFlag{
 			Name:  "dry-run",

--- a/nodedeployment/apply.go
+++ b/nodedeployment/apply.go
@@ -19,14 +19,15 @@ func applyAction(ctx context.Context, c *cli.Command) error {
 	}
 
 	args := renderArgs{
-		preset:          c.String("preset"),
-		name:            name,
-		namespace:       c.String("namespace"),
-		chainID:         c.String("chain-id"),
-		image:           c.String("image"),
-		sets:            c.StringSlice("set"),
-		genesisAccounts: c.StringSlice("genesis-account"),
-		overrides:       c.StringSlice("override"),
+		preset:           c.String("preset"),
+		name:             name,
+		namespace:        c.String("namespace"),
+		chainID:          c.String("chain-id"),
+		image:            c.String("image"),
+		sets:             c.StringSlice("set"),
+		genesisAccounts:  c.StringSlice("genesis-account"),
+		overrides:        c.StringSlice("override"),
+		genesisOverrides: c.StringSlice("genesis-override"),
 	}
 	if c.IsSet("replicas") {
 		args.replicas = int(c.Int("replicas"))
@@ -139,6 +140,10 @@ var applyCmd = cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "override",
 			Usage: "Set a key in spec.template.spec.overrides: --override <toml-path>=<value> (e.g. --override evm.enabled_legacy_sei_apis=sei_getLogs,sei_getBlockByNumber). Keys are dotted TOML paths consumed by the controller's config-apply pipeline; --set cannot reach this map because its parser splits on every dot. Repeatable.",
+		},
+		&cli.StringSliceFlag{
+			Name:  "genesis-override",
+			Usage: "Set a key in spec.genesis.overrides: --genesis-override <module.field[.field...]>=<value> (e.g. --genesis-override staking.params.unbonding_time=600s). Keys must be dotted cosmos-module paths — the first segment is a module in app_state (staking, bank, gov, ...). Values parse as JSON when possible (numbers, bools, objects); otherwise as strings. Repeatable. Requires --preset genesis-chain. --set cannot reach this map because its parser splits on every dot.",
 		},
 		&cli.BoolFlag{
 			Name:  "dry-run",

--- a/nodedeployment/preset.go
+++ b/nodedeployment/preset.go
@@ -1,6 +1,7 @@
 package nodedeployment
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -12,16 +13,17 @@ import (
 )
 
 type renderArgs struct {
-	preset          string
-	name            string
-	namespace       string
-	chainID         string
-	image           string
-	replicas        int
-	hasReps         bool
-	sets            []string
-	genesisAccounts []string
-	overrides       []string
+	preset           string
+	name             string
+	namespace        string
+	chainID          string
+	image            string
+	replicas         int
+	hasReps          bool
+	sets             []string
+	genesisAccounts  []string
+	overrides        []string
+	genesisOverrides []string
 }
 
 // presetRequiredFields surfaces missing required fields as a friendly
@@ -145,6 +147,17 @@ func render(args renderArgs) (*unstructured.Unstructured, error) {
 		}
 	}
 
+	if len(args.genesisOverrides) > 0 {
+		if args.preset != "genesis-chain" {
+			return nil, usageError("--genesis-override is only valid with --preset genesis-chain")
+		}
+		for _, expr := range args.genesisOverrides {
+			if err := applyGenesisOverride(u.Object, expr); err != nil {
+				return nil, usageError("apply --genesis-override %q: %s", expr, err.Error())
+			}
+		}
+	}
+
 	// Reassert identity after --set so --set metadata.namespace=kube-system
 	// can't silently retarget.
 	u.SetName(args.name)
@@ -171,6 +184,55 @@ func render(args renderArgs) (*unstructured.Unstructured, error) {
 	}
 
 	return u, nil
+}
+
+// applyGenesisOverride writes a single key=value pair into
+// spec.genesis.overrides. The key is a dotted cosmos-module path
+// (module.field[.field...]) — the first segment must be a key in
+// app_state of the genesis JSON. Value parses as JSON if it parses
+// (number, bool, object, array, or JSON-quoted string); otherwise
+// it's stored as a raw string.
+//
+// Distinct from applyOverride (spec.template.spec.overrides) because
+// the genesis-overrides map's value type is map[string]<JSON> rather
+// than map[string]string, and the key shape is validated upstream by
+// the sidecar's applyGenesisOverrides. Single-segment keys are
+// rejected here so the user sees the issue at apply time rather than
+// after the SND has stalled retrying the assemble-genesis task.
+func applyGenesisOverride(root map[string]interface{}, expr string) error {
+	eq := strings.Index(expr, "=")
+	if eq < 0 {
+		return fmt.Errorf("missing '=' in --genesis-override expression")
+	}
+	key := expr[:eq]
+	val := expr[eq+1:]
+	if key == "" {
+		return fmt.Errorf("empty key before '='")
+	}
+	parts := strings.Split(key, ".")
+	if len(parts) < 2 {
+		return fmt.Errorf("key %q must be of the form module.field[.field...]", key)
+	}
+	for i, p := range parts {
+		if p == "" {
+			return fmt.Errorf("key %q has empty segment at index %d", key, i)
+		}
+	}
+
+	var parsed interface{}
+	if jsonErr := json.Unmarshal([]byte(val), &parsed); jsonErr != nil {
+		parsed = val
+	}
+
+	existing, _, err := unstructured.NestedMap(root, "spec", "genesis", "overrides")
+	if err != nil {
+		return fmt.Errorf("read existing overrides: %w", err)
+	}
+	if existing == nil {
+		existing = map[string]interface{}{}
+	}
+	existing[key] = parsed
+	return unstructured.SetNestedMap(root, existing, "spec", "genesis", "overrides")
 }
 
 // applyOverride writes a single key=value pair into

--- a/nodedeployment/preset.go
+++ b/nodedeployment/preset.go
@@ -209,6 +209,9 @@ func applyGenesisOverride(root map[string]interface{}, expr string) error {
 	if key == "" {
 		return fmt.Errorf("empty key before '='")
 	}
+	if val == "" {
+		return fmt.Errorf("empty value after '=' (the sidecar rejects empty json.RawMessage at assemble-genesis)")
+	}
 	parts := strings.Split(key, ".")
 	if len(parts) < 2 {
 		return fmt.Errorf("key %q must be of the form module.field[.field...]", key)

--- a/nodedeployment/preset_test.go
+++ b/nodedeployment/preset_test.go
@@ -640,6 +640,97 @@ func TestApplyOverride_Errors(t *testing.T) {
 	}
 }
 
+func TestRender_GenesisOverrideFlag(t *testing.T) {
+	got, err := render(renderArgs{
+		preset:  "genesis-chain",
+		name:    "x",
+		chainID: "c",
+		image:   "img:1",
+		genesisOverrides: []string{
+			`staking.params.unbonding_time=600s`,
+			`bank.params.default_send_enabled=true`,
+			`gov.params.voting_period_seconds=120`,
+			`mint.params.inflation={"min":0.05,"max":0.2}`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	overrides, found, _ := unstructured.NestedMap(got.Object, "spec", "genesis", "overrides")
+	if !found {
+		t.Fatalf("spec.genesis.overrides not found")
+	}
+	if v := overrides["staking.params.unbonding_time"]; v != "600s" {
+		t.Errorf("staking.params.unbonding_time = %v (%T); want \"600s\" (string)", v, v)
+	}
+	if v := overrides["bank.params.default_send_enabled"]; v != true {
+		t.Errorf("bank.params.default_send_enabled = %v (%T); want true (bool)", v, v)
+	}
+	if v := overrides["gov.params.voting_period_seconds"]; v != float64(120) {
+		t.Errorf("gov.params.voting_period_seconds = %v (%T); want 120 (float64 from JSON)", v, v)
+	}
+	inflation, ok := overrides["mint.params.inflation"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mint.params.inflation not a map: %T", overrides["mint.params.inflation"])
+	}
+	if inflation["min"] != float64(0.05) || inflation["max"] != float64(0.2) {
+		t.Errorf("mint.params.inflation = %v; want {min:0.05, max:0.2}", inflation)
+	}
+}
+
+func TestRender_GenesisOverrideRejectsNonGenesisPreset(t *testing.T) {
+	_, err := render(renderArgs{
+		preset:           "rpc",
+		name:             "rpc-fleet",
+		chainID:          "pacific-1",
+		image:            "img:1",
+		genesisOverrides: []string{"staking.params.unbonding_time=600s"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "only valid with --preset genesis-chain") {
+		t.Errorf("expected 'only valid with --preset genesis-chain' error, got %v", err)
+	}
+}
+
+func TestApplyGenesisOverride_Errors(t *testing.T) {
+	cases := []struct {
+		expr string
+		want string
+	}{
+		{"no-equals", "missing '='"},
+		{"=value", "empty key"},
+		{"single=value", "must be of the form module.field"},
+		{"staking..params=value", "empty segment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			err := applyGenesisOverride(map[string]interface{}{}, tc.expr)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want containing %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyGenesisOverride_PreservesExistingKeys(t *testing.T) {
+	root := map[string]interface{}{}
+	if err := applyGenesisOverride(root, "staking.params.unbonding_time=600s"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := applyGenesisOverride(root, "bank.params.default_send_enabled=true"); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	overrides, found, _ := unstructured.NestedMap(root, "spec", "genesis", "overrides")
+	if !found {
+		t.Fatalf("overrides not found")
+	}
+	if len(overrides) != 2 {
+		t.Errorf("expected 2 keys, got %v", overrides)
+	}
+}
+
 func TestParseValue(t *testing.T) {
 	cases := map[string]interface{}{
 		"":       "",

--- a/nodedeployment/preset_test.go
+++ b/nodedeployment/preset_test.go
@@ -698,6 +698,7 @@ func TestApplyGenesisOverride_Errors(t *testing.T) {
 	}{
 		{"no-equals", "missing '='"},
 		{"=value", "empty key"},
+		{"staking.params.unbonding_time=", "empty value"},
 		{"single=value", "must be of the form module.field"},
 		{"staking..params=value", "empty segment"},
 	}
@@ -711,6 +712,17 @@ func TestApplyGenesisOverride_Errors(t *testing.T) {
 				t.Errorf("err = %q; want containing %q", err.Error(), tc.want)
 			}
 		})
+	}
+}
+
+func TestApplyGenesisOverride_JSONStringEscape(t *testing.T) {
+	root := map[string]interface{}{}
+	if err := applyGenesisOverride(root, `staking.params.unbonding_time="42"`); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	overrides, _, _ := unstructured.NestedMap(root, "spec", "genesis", "overrides")
+	if v := overrides["staking.params.unbonding_time"]; v != "42" {
+		t.Errorf("want string \"42\", got %v (%T)", v, v)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #183. Adds a dedicated `seictl nd apply --genesis-override <key>=<value>` flag that writes flat dotted-key entries into `spec.genesis.overrides` on the rendered SeiNodeDeployment. Mirrors the existing `--override` flag (which targets `spec.template.spec.overrides`).

## Why

`spec.genesis.overrides` (shipped this morning via #181 + sei-k8s-controller#270) requires a flat `map[string]<JSON>` with dotted cosmos-module keys (`"staking.params.unbonding_time": "600s"`). The sidecar's `applyGenesisOverrides` enforces this: keys must be `module.field[.field...]`, first segment must be a cosmos module in `app_state`.

`seictl --set spec.genesis.overrides.<path>=<value>` cannot emit that shape — `--set`'s path parser splits unconditionally on `.` and builds a nested map. Today's first attempt at the field (sei-protocol/harbor-engineering-workspace#14) shipped the nested-map shape and the sidecar rejected it on every retry with `key "app_state" must be of the form module.field[.field...]`. Required a manual `yq`-patching workaround (sei-protocol/harbor-engineering-workspace#16).

## What this PR does

```sh
seictl nd apply <name> --preset genesis-chain \
  --chain-id <id> --image <ref> \
  --genesis-override staking.params.unbonding_time=600s \
  --genesis-override bank.params.default_send_enabled=true \
  --genesis-override gov.params.voting_period_seconds=120 \
  --genesis-override mint.params.inflation='{"min":0.05,"max":0.2}' \
  -n eng-<alias>
```

Renders:

```yaml
spec:
  genesis:
    overrides:
      "staking.params.unbonding_time": "600s"
      "bank.params.default_send_enabled": true
      "gov.params.voting_period_seconds": 120
      "mint.params.inflation":
        min: 0.05
        max: 0.2
```

- Keys are stored as literal map-key strings — no path splitting
- Values parse as JSON when they parse (numbers, bools, objects, arrays); otherwise as raw strings
- Local key-shape validation (`module.field[.field...]`) fails fast at apply time rather than after the SND has stalled
- Rejected when `--preset != genesis-chain` (rpc preset has no `spec.genesis`)
- Repeatable, distinct from `--override`

## Tests

- `TestRender_GenesisOverrideFlag` — string / bool / number / object values all round-trip correctly through the renderer
- `TestRender_GenesisOverrideRejectsNonGenesisPreset`
- `TestApplyGenesisOverride_Errors` — missing `=`, empty key, single-segment key, empty path segment
- `TestApplyGenesisOverride_PreservesExistingKeys` — multiple flag uses accumulate into one map

`make test` passes.

## Follow-ups

After this releases (v0.0.51?), the harbor-dev skill docs in sei-protocol/Tide get a follow-up PR that replaces the manual-`yq` workaround with the canonical `--genesis-override` invocation. Will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)