### PR TITLE
fix(presets/genesis-chain): opt validators into sidecar signing via operatorKeyring

### DIFF
--- a/nodedeployment/presets/genesis-chain.yaml
+++ b/nodedeployment/presets/genesis-chain.yaml
@@ -4,7 +4,14 @@ spec:
   replicas: 4
   template:
     spec:
-      validator: {}
+      validator:
+        # Opt the bench validator into sidecar signing. With no .secret set,
+        # the controller wires the sidecar to read the keyring written by
+        # the gentx task at $SEI_HOME/keyring-test/ on the shared data PVC
+        # (Cosmos SDK test backend, unencrypted). This unlocks gov-vote and
+        # gov-software-upgrade tasks during nightly major-upgrade workflows
+        # without requiring a per-deployment operator Secret.
+        operatorKeyring: {}
   genesis: {}
   updateStrategy:
     type: InPlace


### PR DESCRIPTION
## Summary
- Add \`operatorKeyring: {}\` to the bench validator template in the \`genesis-chain\` preset. Without it, sei-k8s-controller emits no \`SEI_KEYRING_BACKEND\` on the sidecar, the Cosmos SDK can't open any keyring, and gov-vote / gov-software-upgrade tasks fail their preconditions.
- With the empty block, the controller wires the sidecar with \`SEI_KEYRING_BACKEND=test\` + \`SEI_KEYRING_DIR=\$SEI_HOME/keyring-test\` — exactly where the gentx task writes the validator key during the genesis ceremony. The sidecar reads it back and gov-vote / gov-software-upgrade unlock for nightly major-upgrade workflows.

## Depends on
- sei-protocol/sei-k8s-controller#296 (must merge first)

## Test plan
- [x] \`go test ./nodedeployment/...\` passes (preset is YAML; tests load it as-is).
- [ ] End-to-end: nightly major-upgrade workflow on harbor cluster signs gov-vote + gov-software-upgrade tasks successfully after both this PR and the controller PR land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)