### PR TITLE
chore: bump sei-config v0.0.14 → v0.0.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7
-	github.com/sei-protocol/sei-config v0.0.14
+	github.com/sei-protocol/sei-config v0.0.15
 	github.com/sei-protocol/seilog v0.0.3
 	github.com/urfave/cli/v3 v3.6.1
 	k8s.io/api v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1855,8 +1855,8 @@ github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQp
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:kW+yxMoSm4RvpP5VT5lFfSa+dqnOE9ZpapE2qNIJwvc=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
-github.com/sei-protocol/sei-config v0.0.14 h1:1KS0EteCBEsjglNEPS/8VAOA7/NDLxEuPHPZg0MvSaM=
-github.com/sei-protocol/sei-config v0.0.14/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.15 h1:kd9ZbDYq4eAJxpELI8oISVXFiPr3Jf1kTHL/V3gf5TU=
+github.com/sei-protocol/sei-config v0.0.15/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082/go.mod h1:V0fNURAjS6A8+sA1VllegjNeSobay3oRUW5VFZd04bA=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=


### PR DESCRIPTION
## Summary

Picks up sei-protocol/sei-config#19, which removed the `API.GRPC.Enable = false` override on `applyValidatorOverrides` to align with canonical sei-infra EC2 validators.

## Behavioral effect for seictl

Validator-mode `app.toml` files generated by the sidecar's config-apply path will now include `[grpc] enable = true` (was `false`). `gRPCWeb` stays disabled (no current consumer). REST / EVM / StateStore overrides unchanged.

## Downstream

After this merges (and the matching `chore: bump version to v0.0.52` fast-follow lands), bumping seictl's image SHA in sei-k8s-controller's platform overlays will, on next validator pod cycle, propagate the new app.toml. That unblocks the cosmos-exporter sidecar, which dials `localhost:9090` at startup and currently Fatal-loops on K8s validators because gRPC isn't listening.

Note: config-apply only re-runs on Init/NodeUpdate plans, not on env-var change. Existing validator pods will retain their old app.toml until cycled.

## Cross-review

Substantive review happened on the underlying sei-config#19 PR (security-specialist + platform-engineer + kubernetes-specialist all returned proceed-with-conditions; conditions are tracked as sei-k8s-controller#311 + #312). This PR is the mechanical dep bump only.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] Fast-follow `chore: bump version to v0.0.52` PR after merge
- [x] Downstream: sei-k8s-controller `SEI_SIDECAR_IMAGE` overlay bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)