### PR TITLE
chore: bump sei-config v0.0.17 → v0.0.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7
-	github.com/sei-protocol/sei-config v0.0.17
+	github.com/sei-protocol/sei-config v0.0.18
 	github.com/sei-protocol/seilog v0.0.3
 	github.com/urfave/cli/v3 v3.6.1
 	k8s.io/api v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1857,6 +1857,8 @@ github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:k
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
 github.com/sei-protocol/sei-config v0.0.17 h1:DCIxsx6WWv+DbBtTkusptwq9tpvRkyFQ1HlNjucNvjg=
 github.com/sei-protocol/sei-config v0.0.17/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.18 h1:oUyKNxh7hNpCvYG+8cChAbUA8Q1igE9an+EGs4I+tC8=
+github.com/sei-protocol/sei-config v0.0.18/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082/go.mod h1:V0fNURAjS6A8+sA1VllegjNeSobay3oRUW5VFZd04bA=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=


### PR DESCRIPTION
Picks up [sei-config#25](https://github.com/sei-protocol/sei-config/pull/25) — v1→v2 write mode migration for seid v6.5.

**What changes:**
- Default `WriteMode` is now `memiavl_only` (was `cosmos_only`)
- Nodes with v1 configs (`cosmos_only`, `dual_write`, `split_write`) are automatically migrated on startup via `DefaultMigrations()`

**Why:** The nightly seid image rejects `cosmos_only` with `invalid state-commit.sc-write-mode "cosmos_only"`, crash-looping all 13 chaos scenario validators. This fix makes the sidecar emit `memiavl_only` for all new and migrated nodes.

All tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)