### PR TITLE
feat(presets): default pprof on dev presets (genesis-chain, rpc)

### DIFF
--- a/nodedeployment/presets/genesis-chain.yaml
+++ b/nodedeployment/presets/genesis-chain.yaml
@@ -5,6 +5,8 @@ spec:
   template:
     spec:
       validator: {}
+      overrides:
+        network.rpc.pprof_listen_address: "0.0.0.0:6060"
   genesis: {}
   updateStrategy:
     type: InPlace

--- a/nodedeployment/presets/rpc.yaml
+++ b/nodedeployment/presets/rpc.yaml
@@ -5,5 +5,7 @@ spec:
   template:
     spec:
       fullNode: {}
+      overrides:
+        network.rpc.pprof_listen_address: "0.0.0.0:6060"
   updateStrategy:
     type: InPlace


### PR DESCRIPTION
## Summary
Sets `network.rpc.pprof_listen_address = "0.0.0.0:6060"` in both dev presets so engineers can profile dev SNDs via `kubectl port-forward`. Rationale + risk: #194. Companion harbor-dev recipe: sei-protocol/Tide#99.

## Test plan
- [ ] `seictl nd apply <id> --preset rpc --chain-id <id> --image <ref> -n eng-<alias>` then `grep pprof_listen_address /.sei/config/config.toml` inside the pod returns the override
- [ ] `kubectl port-forward <pod> 6060:6060` + `curl localhost:6060/debug/pprof/` returns the index page

Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)