### PR TITLE
fix(statesync): explicit RPC witnesses + reachability probe

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1855,10 +1855,6 @@ github.com/sei-protocol/goutils v0.0.2 h1:Bfa7Sv+4CVLNM20QcpvGb81B8C5HkQC/kW1CQp
 github.com/sei-protocol/goutils v0.0.2/go.mod h1:iYE2DuJfEnM+APPehr2gOUXfuLuPsVxorcDO+Tzq9q8=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:kW+yxMoSm4RvpP5VT5lFfSa+dqnOE9ZpapE2qNIJwvc=
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
-github.com/sei-protocol/sei-config v0.0.17 h1:DCIxsx6WWv+DbBtTkusptwq9tpvRkyFQ1HlNjucNvjg=
-github.com/sei-protocol/sei-config v0.0.17/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
-github.com/sei-protocol/sei-config v0.0.18 h1:oUyKNxh7hNpCvYG+8cChAbUA8Q1igE9an+EGs4I+tC8=
-github.com/sei-protocol/sei-config v0.0.18/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-config v0.0.19 h1:87jB4u/TmZ8+xMLWqIDNODGslOdMGhw6ydOpOEb2dK8=
 github.com/sei-protocol/sei-config v0.0.19/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -318,11 +318,9 @@ type ConfigureStateSyncTask struct {
 	UseLocalSnapshot bool
 	TrustPeriod      string
 	BackfillBlocks   int64
-	// RpcServers, when set, are the state-sync light-client witness endpoints
-	// ("host:port") used verbatim — the caller (controller) resolves these to
-	// reachable RPC endpoints (internal cluster RPC services), so the sidecar
-	// does not derive them from persistent-peers. Left empty, the sidecar falls
-	// back to deriving witnesses from the node's peers.
+	// RpcServers, when set, are state-sync witness endpoints ("host:port") used
+	// verbatim; the controller resolves these to internal cluster RPC services.
+	// Left empty, the sidecar derives witnesses from the node's peers.
 	RpcServers []string
 }
 

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -318,6 +318,12 @@ type ConfigureStateSyncTask struct {
 	UseLocalSnapshot bool
 	TrustPeriod      string
 	BackfillBlocks   int64
+	// RpcServers, when set, are the state-sync light-client witness endpoints
+	// ("host:port") used verbatim — the caller (controller) resolves these to
+	// reachable RPC endpoints (internal cluster RPC services), so the sidecar
+	// does not derive them from persistent-peers. Left empty, the sidecar falls
+	// back to deriving witnesses from the node's peers.
+	RpcServers []string
 }
 
 func (t ConfigureStateSyncTask) TaskType() string { return TaskTypeConfigureStateSync }
@@ -333,6 +339,9 @@ func (t ConfigureStateSyncTask) ToTaskRequest() TaskRequest {
 	}
 	if t.BackfillBlocks > 0 {
 		p["backfillBlocks"] = t.BackfillBlocks
+	}
+	if len(t.RpcServers) > 0 {
+		p["rpcServers"] = t.RpcServers
 	}
 	var req TaskRequest
 	if len(p) == 0 {

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -318,10 +318,7 @@ type ConfigureStateSyncTask struct {
 	UseLocalSnapshot bool
 	TrustPeriod      string
 	BackfillBlocks   int64
-	// RpcServers, when set, are state-sync witness endpoints ("host:port") used
-	// verbatim; the controller resolves these to internal cluster RPC services.
-	// Left empty, the sidecar derives witnesses from the node's peers.
-	RpcServers []string
+	RpcServers       []string
 }
 
 func (t ConfigureStateSyncTask) TaskType() string { return TaskTypeConfigureStateSync }

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -229,6 +229,31 @@ func TestConfigureStateSyncRoundTrip(t *testing.T) {
 	}
 }
 
+// Wire contract the controller depends on: RpcServers must surface verbatim
+// under the "rpcServers" params key the sidecar handler reads.
+func TestConfigureStateSyncRpcServersWire(t *testing.T) {
+	witnesses := []string{
+		"syncer-0-0-0.syncer-0-0.arctic-1.svc.cluster.local:26657",
+		"syncer-0-1-0.syncer-0-1.arctic-1.svc.cluster.local:26657",
+	}
+	req := ConfigureStateSyncTask{RpcServers: witnesses}.ToTaskRequest()
+	if req.Params == nil {
+		t.Fatal("Params = nil, want rpcServers populated")
+	}
+	got, ok := (*req.Params)["rpcServers"].([]string)
+	if !ok {
+		t.Fatalf("params[rpcServers] = %T, want []string", (*req.Params)["rpcServers"])
+	}
+	if len(got) != len(witnesses) {
+		t.Fatalf("rpcServers = %v, want %v", got, witnesses)
+	}
+	for i := range witnesses {
+		if got[i] != witnesses[i] {
+			t.Errorf("rpcServers[%d] = %q, want %q", i, got[i], witnesses[i])
+		}
+	}
+}
+
 func TestMarkReadyRoundTrip(t *testing.T) {
 	task := MarkReadyTask{}
 	if err := task.Validate(); err != nil {

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sei-protocol/seictl/internal/patch"
 	"github.com/sei-protocol/seictl/sidecar/engine"
@@ -21,6 +22,8 @@ var ssLog = seilog.NewLogger("seictl", "task", "state-sync")
 const (
 	stateSyncMarkerFile = ".sei-sidecar-statesync-done"
 	trustHeightOffset   = 2000
+	rpcPort             = "26657"
+	witnessProbeTimeout = 10 * time.Second
 )
 
 // StateSyncConfig holds the trust point and RPC servers for Tendermint state sync.
@@ -59,30 +62,38 @@ type StateSyncRequest struct {
 	UseLocalSnapshot bool   `json:"useLocalSnapshot"`
 	TrustPeriod      string `json:"trustPeriod"`
 	BackfillBlocks   int64  `json:"backfillBlocks"`
+	// RpcServers are explicit light-client witness endpoints ("host:port").
+	// When set they are used verbatim and witnesses are NOT derived from
+	// persistent-peers. The controller supplies reachable internal RPC
+	// endpoints here so the witness plane stays internal even for nodes whose
+	// persistent-peers are external P2P NLB hostnames (which serve only P2P).
+	RpcServers []string `json:"rpcServers"`
 }
 
-// Configure reads persistent-peers from config.toml, queries a peer for a
+// Configure determines the state-sync light-client witnesses, queries one for a
 // trust point, and writes the state sync settings back to config.toml.
-// When UseLocalSnapshot is true, the trust height is derived from the
-// locally-restored snapshot and use-local-snapshot is set in config.toml.
+//
+// Witnesses come from p.RpcServers when the caller provides them (the
+// controller resolves these to reachable internal RPC endpoints); otherwise
+// they are derived from persistent-peers. Either way only witnesses that
+// actually answer /status are written — a witness that does not serve RPC
+// (e.g. an external P2P NLB hostname) otherwise makes seid exit with
+// "no witnesses connected" and crashloop. When UseLocalSnapshot is true the
+// trust height is taken from the locally-restored snapshot rather than queried.
 func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncRequest) error {
 	if markerExists(s.homeDir, stateSyncMarkerFile) {
 		ssLog.Debug("already completed, skipping")
 		return nil
 	}
 
-	peers, err := readPeersFromConfig(s.homeDir)
+	candidates, err := s.witnessCandidates(p)
 	if err != nil {
 		return fmt.Errorf("configure-state-sync: %w", err)
 	}
-	if len(peers) == 0 {
-		return fmt.Errorf("configure-state-sync: no peers in config.toml")
-	}
-	ssLog.Debug("found peers", "count", len(peers))
 
-	rpcHosts := extractRPCHosts(peers, 2)
-	if len(rpcHosts) == 0 {
-		return fmt.Errorf("configure-state-sync: could not extract RPC hosts from peers")
+	reachable := s.reachableWitnesses(ctx, candidates)
+	if len(reachable) == 0 {
+		return fmt.Errorf("configure-state-sync: no reachable RPC witness among %v", candidates)
 	}
 
 	var trustHeight int64
@@ -94,8 +105,8 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncRequest)
 		trustHeight = h
 		ssLog.Info("using local snapshot height as trust height", "height", trustHeight)
 	} else {
-		ssLog.Info("querying latest height", "host", rpcHosts[0])
-		latestHeight, err := s.queryLatestHeight(ctx, rpcHosts[0])
+		ssLog.Info("querying latest height", "endpoint", reachable[0])
+		latestHeight, err := s.queryLatestHeight(ctx, reachable[0])
 		if err != nil {
 			return fmt.Errorf("configure-state-sync: querying latest height: %w", err)
 		}
@@ -105,25 +116,23 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncRequest)
 		}
 	}
 
-	ssLog.Info("querying trust hash", "trust-height", trustHeight, "host", rpcHosts[0])
-	trustHash, err := s.queryBlockHash(ctx, rpcHosts[0], trustHeight)
+	ssLog.Info("querying trust hash", "trust-height", trustHeight, "endpoint", reachable[0])
+	trustHash, err := s.queryBlockHash(ctx, reachable[0], trustHeight)
 	if err != nil {
 		return fmt.Errorf("configure-state-sync: querying block hash at height %d: %w", trustHeight, err)
 	}
 
-	for len(rpcHosts) < 2 {
-		rpcHosts = append(rpcHosts, rpcHosts[0])
-	}
-	rpcServers := make([]string, len(rpcHosts))
-	for i, h := range rpcHosts {
-		rpcServers[i] = h + ":26657"
+	// CometBFT's light client requires at least two witnesses; pad by
+	// duplicating the primary when only one reachable witness exists.
+	for len(reachable) < 2 {
+		reachable = append(reachable, reachable[0])
 	}
 
 	cfg := StateSyncConfig{
 		TrustHeight:      trustHeight,
 		TrustHash:        trustHash,
 		TrustPeriod:      p.TrustPeriod,
-		RpcServers:       strings.Join(rpcServers, ","),
+		RpcServers:       strings.Join(reachable, ","),
 		UseLocalSnapshot: p.UseLocalSnapshot,
 		BackfillBlocks:   p.BackfillBlocks,
 	}
@@ -136,6 +145,62 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncRequest)
 	}
 
 	return writeMarker(s.homeDir, stateSyncMarkerFile)
+}
+
+// witnessCandidates returns the candidate state-sync witness endpoints
+// ("host:port"). Caller-provided RpcServers are used verbatim; otherwise the
+// witnesses are derived from persistent-peers by attaching the RPC port to each
+// peer's host. The peer-derived form is correct for peers that serve RPC on the
+// same host as P2P (EC2 peers, internal cluster DNS) and is filtered by
+// reachableWitnesses for peers that do not (external P2P NLB hostnames).
+func (s *StateSyncConfigurer) witnessCandidates(p StateSyncRequest) ([]string, error) {
+	if len(p.RpcServers) > 0 {
+		ssLog.Info("using caller-provided rpc witnesses", "count", len(p.RpcServers))
+		return p.RpcServers, nil
+	}
+
+	peers, err := readPeersFromConfig(s.homeDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(peers) == 0 {
+		return nil, fmt.Errorf("no peers in config.toml")
+	}
+	ssLog.Debug("found peers", "count", len(peers))
+
+	hosts := extractRPCHosts(peers, 2)
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("could not extract RPC hosts from peers")
+	}
+	endpoints := make([]string, len(hosts))
+	for i, h := range hosts {
+		endpoints[i] = h + ":" + rpcPort
+	}
+	return endpoints, nil
+}
+
+// reachableWitnesses returns the candidate endpoints whose /status responds.
+// Dropping unreachable witnesses turns an otherwise-crashlooping config (seid
+// exits on "no witnesses connected") into a working config or a clear
+// configure-time error.
+func (s *StateSyncConfigurer) reachableWitnesses(ctx context.Context, candidates []string) []string {
+	reachable := make([]string, 0, len(candidates))
+	for _, ep := range candidates {
+		if err := s.probeWitness(ctx, ep); err != nil {
+			ssLog.Warn("state-sync witness unreachable, skipping", "endpoint", ep, "err", err)
+			continue
+		}
+		reachable = append(reachable, ep)
+	}
+	return reachable
+}
+
+// probeWitness reports whether endpoint answers /status within the probe timeout.
+func (s *StateSyncConfigurer) probeWitness(ctx context.Context, endpoint string) error {
+	pctx, cancel := context.WithTimeout(ctx, witnessProbeTimeout)
+	defer cancel()
+	_, err := s.rpcClientForEndpoint(endpoint).Get(pctx, "/status")
+	return err
 }
 
 // discoverLocalSnapshotHeight scans the Tendermint snapshots directory for the
@@ -192,13 +257,13 @@ func extractRPCHosts(peers []string, maxHosts int) []string {
 	return hosts
 }
 
-// rpcClientForHost builds an rpc.Client targeting a peer's RPC endpoint.
-func (s *StateSyncConfigurer) rpcClientForHost(host string) *rpc.Client {
-	return rpc.NewClient(fmt.Sprintf("http://%s:26657", host), s.httpClient)
+// rpcClientForEndpoint builds an rpc.Client targeting a full "host:port" RPC endpoint.
+func (s *StateSyncConfigurer) rpcClientForEndpoint(endpoint string) *rpc.Client {
+	return rpc.NewClient("http://"+endpoint, s.httpClient)
 }
 
-func (s *StateSyncConfigurer) queryLatestHeight(ctx context.Context, host string) (int64, error) {
-	raw, err := s.rpcClientForHost(host).Get(ctx, "/status")
+func (s *StateSyncConfigurer) queryLatestHeight(ctx context.Context, endpoint string) (int64, error) {
+	raw, err := s.rpcClientForEndpoint(endpoint).Get(ctx, "/status")
 	if err != nil {
 		return 0, err
 	}
@@ -215,9 +280,9 @@ func (s *StateSyncConfigurer) queryLatestHeight(ctx context.Context, host string
 	return height, nil
 }
 
-func (s *StateSyncConfigurer) queryBlockHash(ctx context.Context, host string, height int64) (string, error) {
+func (s *StateSyncConfigurer) queryBlockHash(ctx context.Context, endpoint string, height int64) (string, error) {
 	path := fmt.Sprintf("/block?height=%d", height)
-	raw, err := s.rpcClientForHost(host).Get(ctx, path)
+	raw, err := s.rpcClientForEndpoint(endpoint).Get(ctx, path)
 	if err != nil {
 		return "", err
 	}

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -195,7 +195,12 @@ func (s *StateSyncConfigurer) reachableWitnesses(ctx context.Context, candidates
 	return reachable
 }
 
-// probeWitness reports whether endpoint answers /status within the probe timeout.
+// probeWitness reports whether endpoint answers /status. The context deadline
+// is the load-bearing bound here: the sidecar's http.Client has no Timeout, so
+// a black-holed endpoint (TCP accepted but no response) is bounded only by this
+// ctx cancellation. A listener-down endpoint returns connection-refused
+// immediately. (The rpc client applies an equal default internally, so the
+// effective bound is witnessProbeTimeout either way.)
 func (s *StateSyncConfigurer) probeWitness(ctx context.Context, endpoint string) error {
 	pctx, cancel := context.WithTimeout(ctx, witnessProbeTimeout)
 	defer cancel()

--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -63,23 +63,19 @@ type StateSyncRequest struct {
 	TrustPeriod      string `json:"trustPeriod"`
 	BackfillBlocks   int64  `json:"backfillBlocks"`
 	// RpcServers are explicit light-client witness endpoints ("host:port").
-	// When set they are used verbatim and witnesses are NOT derived from
-	// persistent-peers. The controller supplies reachable internal RPC
-	// endpoints here so the witness plane stays internal even for nodes whose
-	// persistent-peers are external P2P NLB hostnames (which serve only P2P).
+	// When non-empty they are used verbatim; otherwise witnesses are derived
+	// from persistent-peers.
 	RpcServers []string `json:"rpcServers"`
 }
 
 // Configure determines the state-sync light-client witnesses, queries one for a
-// trust point, and writes the state sync settings back to config.toml.
+// trust point, and writes the settings to config.toml.
 //
-// Witnesses come from p.RpcServers when the caller provides them (the
-// controller resolves these to reachable internal RPC endpoints); otherwise
-// they are derived from persistent-peers. Either way only witnesses that
-// actually answer /status are written — a witness that does not serve RPC
-// (e.g. an external P2P NLB hostname) otherwise makes seid exit with
-// "no witnesses connected" and crashloop. When UseLocalSnapshot is true the
-// trust height is taken from the locally-restored snapshot rather than queried.
+// Witnesses come from p.RpcServers when provided, otherwise are derived from
+// persistent-peers. Only witnesses that answer /status are written: a peer that
+// serves P2P but not RPC (e.g. an external P2P NLB hostname) would otherwise make
+// seid exit on "no witnesses connected" and crashloop. With UseLocalSnapshot the
+// trust height comes from the restored snapshot instead of a query.
 func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncRequest) error {
 	if markerExists(s.homeDir, stateSyncMarkerFile) {
 		ssLog.Debug("already completed, skipping")
@@ -147,12 +143,11 @@ func (s *StateSyncConfigurer) Configure(ctx context.Context, p StateSyncRequest)
 	return writeMarker(s.homeDir, stateSyncMarkerFile)
 }
 
-// witnessCandidates returns the candidate state-sync witness endpoints
-// ("host:port"). Caller-provided RpcServers are used verbatim; otherwise the
-// witnesses are derived from persistent-peers by attaching the RPC port to each
-// peer's host. The peer-derived form is correct for peers that serve RPC on the
-// same host as P2P (EC2 peers, internal cluster DNS) and is filtered by
-// reachableWitnesses for peers that do not (external P2P NLB hostnames).
+// witnessCandidates returns the candidate witness endpoints ("host:port"):
+// caller-provided RpcServers verbatim, otherwise each persistent-peer host with
+// the RPC port attached. The peer-derived form holds for peers that serve RPC on
+// the P2P host (EC2 peers, internal cluster DNS); reachableWitnesses drops those
+// that don't.
 func (s *StateSyncConfigurer) witnessCandidates(p StateSyncRequest) ([]string, error) {
 	if len(p.RpcServers) > 0 {
 		ssLog.Info("using caller-provided rpc witnesses", "count", len(p.RpcServers))
@@ -180,9 +175,6 @@ func (s *StateSyncConfigurer) witnessCandidates(p StateSyncRequest) ([]string, e
 }
 
 // reachableWitnesses returns the candidate endpoints whose /status responds.
-// Dropping unreachable witnesses turns an otherwise-crashlooping config (seid
-// exits on "no witnesses connected") into a working config or a clear
-// configure-time error.
 func (s *StateSyncConfigurer) reachableWitnesses(ctx context.Context, candidates []string) []string {
 	reachable := make([]string, 0, len(candidates))
 	for _, ep := range candidates {
@@ -195,12 +187,9 @@ func (s *StateSyncConfigurer) reachableWitnesses(ctx context.Context, candidates
 	return reachable
 }
 
-// probeWitness reports whether endpoint answers /status. The context deadline
-// is the load-bearing bound here: the sidecar's http.Client has no Timeout, so
-// a black-holed endpoint (TCP accepted but no response) is bounded only by this
-// ctx cancellation. A listener-down endpoint returns connection-refused
-// immediately. (The rpc client applies an equal default internally, so the
-// effective bound is witnessProbeTimeout either way.)
+// probeWitness reports whether endpoint answers /status. The context deadline is
+// load-bearing: the sidecar's http.Client has no Timeout, so a black-holed
+// endpoint (TCP accepted, no response) is bounded only by this cancellation.
 func (s *StateSyncConfigurer) probeWitness(ctx context.Context, endpoint string) error {
 	pctx, cancel := context.WithTimeout(ctx, witnessProbeTimeout)
 	defer cancel()

--- a/sidecar/tasks/statesync_test.go
+++ b/sidecar/tasks/statesync_test.go
@@ -551,6 +551,46 @@ func TestStateSyncConfigurer_DropsUnreachableWitness(t *testing.T) {
 	}
 }
 
+// The exact production-regression ordering: the FIRST candidate is unreachable
+// (an external P2P NLB host) and the trust query must fall through to the
+// reachable second one. reachable[0] is the post-probe slice, so the dead
+// primary is filtered out before it's used for the trust point.
+func TestStateSyncConfigurer_PrimaryUnreachableFallsThrough(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, []string{
+		"nodeId1@syncer-0-0-p2p.arctic-1.prod.platform.sei.io:26656", // P2P-only, no RPC
+		"nodeId2@1.2.3.4:26656", // serves RPC
+	})
+
+	hash := generateBlockHash()
+	mock := &mockHTTPDoer{
+		responses: map[string]*http.Response{
+			"http://1.2.3.4:26657/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "10000"}
+			}`)),
+			"http://1.2.3.4:26657/block?height=8000": jsonResponse(wrapResult(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash))),
+		},
+	}
+
+	configurer := NewStateSyncConfigurer(homeDir, mock)
+	if err := configurer.Configure(context.Background(), StateSyncRequest{}); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	ss := readTOML(t, filepath.Join(homeDir, "config", "config.toml"))["statesync"].(map[string]any)
+	if ss["trust-height"] != int64(8000) {
+		t.Errorf("expected trust query to fall through to the reachable witness, trust-height = %v", ss["trust-height"])
+	}
+	if ss["trust-hash"] != hash {
+		t.Errorf("expected trust-hash %s, got %v", hash, ss["trust-hash"])
+	}
+	if ss["rpc-servers"] != "1.2.3.4:26657,1.2.3.4:26657" {
+		t.Errorf("expected only the reachable witness, got %v", ss["rpc-servers"])
+	}
+}
+
 // When no candidate witness is reachable, fail at configure time with a clear
 // error rather than writing a config that makes seid exit on "no witnesses".
 func TestStateSyncConfigurer_NoReachableWitness(t *testing.T) {

--- a/sidecar/tasks/statesync_test.go
+++ b/sidecar/tasks/statesync_test.go
@@ -483,7 +483,7 @@ func TestReadPeersFromConfig_NoConfigFile(t *testing.T) {
 }
 
 // Caller-provided RpcServers are used verbatim, independent of persistent-peers
-// (here there are none) — the controller resolves these to internal RPC DNS.
+// (here there are none).
 func TestStateSyncConfigurer_ExplicitRpcServers(t *testing.T) {
 	homeDir := t.TempDir()
 	setupPeersInConfig(t, homeDir, nil)
@@ -551,10 +551,9 @@ func TestStateSyncConfigurer_DropsUnreachableWitness(t *testing.T) {
 	}
 }
 
-// The exact production-regression ordering: the FIRST candidate is unreachable
-// (an external P2P NLB host) and the trust query must fall through to the
-// reachable second one. reachable[0] is the post-probe slice, so the dead
-// primary is filtered out before it's used for the trust point.
+// The production-regression ordering: the first candidate is unreachable (a
+// P2P-only NLB host), so the trust query must fall through to the reachable
+// second one — reachable[0] is the post-probe slice, not the raw peer list.
 func TestStateSyncConfigurer_PrimaryUnreachableFallsThrough(t *testing.T) {
 	homeDir := t.TempDir()
 	setupPeersInConfig(t, homeDir, []string{

--- a/sidecar/tasks/statesync_test.go
+++ b/sidecar/tasks/statesync_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"fmt"
@@ -21,7 +22,11 @@ func (m *mockHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 	if !ok {
 		return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
 	}
-	return resp, nil
+	// Read and restore the body so repeated requests to the same URL (the
+	// witness reachability probe, then the trust-point query) both succeed.
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return &http.Response{StatusCode: resp.StatusCode, Body: io.NopCloser(bytes.NewReader(body))}, nil
 }
 
 func generateBlockHash() string {
@@ -62,6 +67,9 @@ func TestStateSyncConfigurer_Success(t *testing.T) {
 	mock := &mockHTTPDoer{
 		responses: map[string]*http.Response{
 			"http://1.2.3.4:26657/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "10000"}
+			}`)),
+			"http://5.6.7.8:26657/status": jsonResponse(wrapResult(`{
 				"sync_info": {"latest_block_height": "10000"}
 			}`)),
 			"http://1.2.3.4:26657/block?height=8000": jsonResponse(wrapResult(fmt.Sprintf(`{
@@ -296,6 +304,9 @@ func TestStateSyncConfigurer_NetworkWithBackfill(t *testing.T) {
 			"http://1.2.3.4:26657/status": jsonResponse(wrapResult(`{
 				"sync_info": {"latest_block_height": "10000"}
 			}`)),
+			"http://5.6.7.8:26657/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "10000"}
+			}`)),
 			"http://1.2.3.4:26657/block?height=8000": jsonResponse(wrapResult(fmt.Sprintf(`{
 				"block_id": {"hash": %q}
 			}`, hash))),
@@ -337,6 +348,12 @@ func TestStateSyncConfigurer_LocalSnapshot(t *testing.T) {
 	hash := generateBlockHash()
 	mock := &mockHTTPDoer{
 		responses: map[string]*http.Response{
+			"http://1.2.3.4:26657/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "198030000"}
+			}`)),
+			"http://5.6.7.8:26657/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "198030000"}
+			}`)),
 			"http://1.2.3.4:26657/block?height=198030000": jsonResponse(wrapResult(fmt.Sprintf(`{
 				"block_id": {"hash": %q}
 			}`, hash))),
@@ -377,7 +394,14 @@ func TestStateSyncConfigurer_LocalSnapshotNoDir(t *testing.T) {
 	homeDir := t.TempDir()
 	setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656"})
 
-	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
+	mock := &mockHTTPDoer{
+		responses: map[string]*http.Response{
+			"http://1.2.3.4:26657/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "100"}
+			}`)),
+		},
+	}
+	configurer := NewStateSyncConfigurer(homeDir, mock)
 	err := configurer.Configure(context.Background(), StateSyncRequest{UseLocalSnapshot: true})
 	if err == nil {
 		t.Fatal("expected error when no snapshot directory exists")
@@ -455,5 +479,90 @@ func TestReadPeersFromConfig_NoConfigFile(t *testing.T) {
 	}
 	if len(peers) != 0 {
 		t.Fatalf("expected 0 peers for missing config, got %d", len(peers))
+	}
+}
+
+// Caller-provided RpcServers are used verbatim, independent of persistent-peers
+// (here there are none) — the controller resolves these to internal RPC DNS.
+func TestStateSyncConfigurer_ExplicitRpcServers(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, nil)
+
+	const witness = "syncer-0-0-0.syncer-0-0.arctic-1.svc.cluster.local:26657"
+	hash := generateBlockHash()
+	mock := &mockHTTPDoer{
+		responses: map[string]*http.Response{
+			"http://" + witness + "/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "10000"}
+			}`)),
+			"http://" + witness + "/block?height=8000": jsonResponse(wrapResult(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash))),
+		},
+	}
+
+	configurer := NewStateSyncConfigurer(homeDir, mock)
+	if err := configurer.Configure(context.Background(), StateSyncRequest{
+		RpcServers: []string{witness},
+	}); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	ss := readTOML(t, filepath.Join(homeDir, "config", "config.toml"))["statesync"].(map[string]any)
+	if ss["rpc-servers"] != witness+","+witness {
+		t.Errorf("expected explicit witness padded to two, got %v", ss["rpc-servers"])
+	}
+	if ss["trust-height"] != int64(8000) {
+		t.Errorf("expected trust-height 8000, got %v", ss["trust-height"])
+	}
+}
+
+// The regression case: a peer-derived witness whose host serves P2P but not RPC
+// (an external NLB hostname). The reachable witness is kept; the dead one is
+// dropped instead of being written and crashlooping seid.
+func TestStateSyncConfigurer_DropsUnreachableWitness(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, []string{
+		"nodeId1@1.2.3.4:26656",
+		"nodeId2@syncer-0-0-p2p.arctic-1.prod.platform.sei.io:26656",
+	})
+
+	hash := generateBlockHash()
+	mock := &mockHTTPDoer{
+		responses: map[string]*http.Response{
+			// Only 1.2.3.4 serves RPC; the p2p NLB host has no /status entry.
+			"http://1.2.3.4:26657/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "10000"}
+			}`)),
+			"http://1.2.3.4:26657/block?height=8000": jsonResponse(wrapResult(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash))),
+		},
+	}
+
+	configurer := NewStateSyncConfigurer(homeDir, mock)
+	if err := configurer.Configure(context.Background(), StateSyncRequest{}); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	ss := readTOML(t, filepath.Join(homeDir, "config", "config.toml"))["statesync"].(map[string]any)
+	if ss["rpc-servers"] != "1.2.3.4:26657,1.2.3.4:26657" {
+		t.Errorf("expected unreachable witness dropped, got %v", ss["rpc-servers"])
+	}
+}
+
+// When no candidate witness is reachable, fail at configure time with a clear
+// error rather than writing a config that makes seid exit on "no witnesses".
+func TestStateSyncConfigurer_NoReachableWitness(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, []string{"nodeId1@1.2.3.4:26656"})
+
+	configurer := NewStateSyncConfigurer(homeDir, &mockHTTPDoer{})
+	err := configurer.Configure(context.Background(), StateSyncRequest{})
+	if err == nil {
+		t.Fatal("expected error when no witness is reachable")
+	}
+	if !strings.Contains(err.Error(), "no reachable RPC witness") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem
`ConfigureStateSync` derives light-client witnesses from `persistent-peers` by stripping each peer's port and re-appending `:26657`. For a node whose peers are **external P2P NLB hostnames** (a `networking.tcp` validator), that yields witnesses pointing at the P2P-only NLB on `:26657` — which has no RPC listener. seid then exits with `no witnesses connected` and crashloops. (Observed live on arctic-1 node-19; root cause traced with the platform/kubernetes specialists.)

The witness derivation assumes a peer's P2P host also serves RPC on 26657 — true for EC2 peers and internal cluster DNS, false for the external P2P NLB.

## Changes
1. **Explicit witnesses.** `StateSyncRequest.RpcServers` / `ConfigureStateSyncTask.RpcServers`. When the caller (the sei-k8s-controller) supplies witnesses, they're used verbatim and the peer-derived heuristic is skipped — the controller resolves these to the peers' **internal RPC service DNS**, keeping the witness plane internal even for external-addressed nodes. Empty → existing peer-derived behavior (correct for EC2/internal peers and older controllers; back-compatible).
2. **Reachability probe.** Each candidate witness's `/status` is probed; only reachable ones are written, and an empty result fails with a clear `no reachable RPC witness` error instead of a config that crashloops seid. This also self-heals the peer-derived path by dropping P2P-only hostnames.

Query helpers now take full `host:port` endpoints. The `>=2` witness padding is preserved.

## Tests
New: explicit `RpcServers` used (no peers needed), unreachable peer-derived witness dropped (the regression scenario), and the no-reachable error. Existing tests updated for the probe-then-query call pattern (mock made repeat-safe). `go test ./sidecar/...` green.

## Rollout note
This is the **first** of two coordinated changes — deploy this sidecar image **before** the sei-k8s-controller change that sets `RpcServers`, since the controller's field is ignored by older sidecars (additive, back-compatible).