### PR TITLE
chore(sidecar): remove dead code (PLT-453 Phase 1)

### DIFF
--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -90,19 +90,6 @@ func (t SnapshotRestoreTask) ToTaskRequest() TaskRequest {
 	return req
 }
 
-// SnapshotRestoreTaskFromParams reconstructs a SnapshotRestoreTask from
-// a generic params map. Useful for round-trip testing.
-func SnapshotRestoreTaskFromParams(params map[string]interface{}) SnapshotRestoreTask {
-	var t SnapshotRestoreTask
-	switch h := params["targetHeight"].(type) {
-	case float64:
-		t.TargetHeight = int64(h)
-	case int64:
-		t.TargetHeight = h
-	}
-	return t
-}
-
 // SnapshotUploadTask archives and streams a local snapshot to S3.
 // S3 coordinates are derived by the sidecar from its environment.
 type SnapshotUploadTask struct {
@@ -115,12 +102,6 @@ func (t SnapshotUploadTask) Validate() error { return nil }
 func (t SnapshotUploadTask) ToTaskRequest() TaskRequest {
 	req := TaskRequest{Type: t.TaskType()}
 	return req
-}
-
-// SnapshotUploadTaskFromParams reconstructs a SnapshotUploadTask from
-// a generic params map.
-func SnapshotUploadTaskFromParams(_ map[string]interface{}) SnapshotUploadTask {
-	return SnapshotUploadTask{}
 }
 
 // ConfigureGenesisTask instructs the sidecar to resolve and write genesis.json.
@@ -137,12 +118,6 @@ func (t ConfigureGenesisTask) Validate() error { return nil }
 func (t ConfigureGenesisTask) ToTaskRequest() TaskRequest {
 	req := TaskRequest{Type: t.TaskType()}
 	return req
-}
-
-// ConfigureGenesisTaskFromParams reconstructs a ConfigureGenesisTask from
-// a generic params map.
-func ConfigureGenesisTaskFromParams(_ map[string]interface{}) ConfigureGenesisTask {
-	return ConfigureGenesisTask{}
 }
 
 // PeerSourceType identifies the peer discovery mechanism.
@@ -228,62 +203,6 @@ func (t DiscoverPeersTask) ToTaskRequest() TaskRequest {
 	p := map[string]interface{}{"sources": sources}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	return req
-}
-
-// DiscoverPeersTaskFromParams reconstructs a DiscoverPeersTask from
-// a generic params map.
-func DiscoverPeersTaskFromParams(params map[string]interface{}) (DiscoverPeersTask, error) {
-	rawSources, ok := params["sources"]
-	if !ok {
-		return DiscoverPeersTask{}, fmt.Errorf("missing 'sources' key")
-	}
-	items, ok := rawSources.([]interface{})
-	if !ok {
-		return DiscoverPeersTask{}, fmt.Errorf("sources is not a list")
-	}
-
-	var sources []PeerSource
-	for i, item := range items {
-		m, ok := item.(map[string]interface{})
-		if !ok {
-			return DiscoverPeersTask{}, fmt.Errorf("source[%d] is not an object", i)
-		}
-		typ, _ := m["type"].(string)
-		src := PeerSource{Type: PeerSourceType(typ)}
-
-		switch PeerSourceType(typ) {
-		case PeerSourceEC2Tags:
-			src.Region, _ = m["region"].(string)
-			if rawTags, ok := m["tags"].(map[string]interface{}); ok {
-				src.Tags = make(map[string]string, len(rawTags))
-				for k, v := range rawTags {
-					src.Tags[k], _ = v.(string)
-				}
-			}
-		case PeerSourceStatic:
-			if rawAddrs, ok := m["addresses"].([]interface{}); ok {
-				src.Addresses = make([]string, 0, len(rawAddrs))
-				for _, a := range rawAddrs {
-					if s, ok := a.(string); ok {
-						src.Addresses = append(src.Addresses, s)
-					}
-				}
-			}
-		case PeerSourceDNSEndpoints:
-			if rawEps, ok := m["endpoints"].([]interface{}); ok {
-				src.Endpoints = make([]string, 0, len(rawEps))
-				for _, e := range rawEps {
-					if s, ok := e.(string); ok {
-						src.Endpoints = append(src.Endpoints, s)
-					}
-				}
-			}
-		default:
-			return DiscoverPeersTask{}, fmt.Errorf("source[%d] unknown type %q", i, typ)
-		}
-		sources = append(sources, src)
-	}
-	return DiscoverPeersTask{Sources: sources}, nil
 }
 
 // ConfigPatchTask applies generic TOML merge-patches to seid config files.
@@ -419,32 +338,6 @@ func (t ConfigApplyTask) ToTaskRequest() TaskRequest {
 	return req
 }
 
-// ConfigApplyTaskFromParams reconstructs a ConfigApplyTask from a generic
-// params map.
-func ConfigApplyTaskFromParams(params map[string]interface{}) ConfigApplyTask {
-	s := func(k string) string { v, _ := params[k].(string); return v }
-	inc, _ := params["incremental"].(bool)
-	tv := 0
-	if raw, ok := params["targetVersion"].(float64); ok {
-		tv = int(raw)
-	}
-	var overrides map[string]string
-	if raw, ok := params["overrides"].(map[string]interface{}); ok {
-		overrides = make(map[string]string, len(raw))
-		for k, v := range raw {
-			overrides[k], _ = v.(string)
-		}
-	}
-	return ConfigApplyTask{
-		Intent: seiconfig.ConfigIntent{
-			Mode:          seiconfig.NodeMode(s("mode")),
-			Overrides:     overrides,
-			Incremental:   inc,
-			TargetVersion: tv,
-		},
-	}
-}
-
 // ConfigValidateTask reads on-disk config and returns validation diagnostics.
 type ConfigValidateTask struct{}
 
@@ -479,19 +372,6 @@ func (t ConfigReloadTask) ToTaskRequest() TaskRequest {
 	p := map[string]interface{}{"fields": fields}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	return req
-}
-
-// ConfigReloadTaskFromParams reconstructs a ConfigReloadTask from a generic
-// params map.
-func ConfigReloadTaskFromParams(params map[string]interface{}) ConfigReloadTask {
-	var fields map[string]string
-	if raw, ok := params["fields"].(map[string]interface{}); ok {
-		fields = make(map[string]string, len(raw))
-		for k, v := range raw {
-			fields[k], _ = v.(string)
-		}
-	}
-	return ConfigReloadTask{Fields: fields}
 }
 
 // ResultExportTask queries the local seid RPC for block results and uploads
@@ -530,18 +410,6 @@ func (t ResultExportTask) ToTaskRequest() TaskRequest {
 	}
 	req := TaskRequest{Type: t.TaskType(), Params: &p}
 	return req
-}
-
-// ResultExportTaskFromParams reconstructs a ResultExportTask from
-// a generic params map.
-func ResultExportTaskFromParams(params map[string]interface{}) ResultExportTask {
-	s := func(k string) string { v, _ := params[k].(string); return v }
-	return ResultExportTask{
-		Bucket:       s("bucket"),
-		Prefix:       s("prefix"),
-		Region:       s("region"),
-		CanonicalRPC: s("canonicalRpc"),
-	}
 }
 
 // GenerateIdentityTask creates validator identity (keys, node ID).

--- a/sidecar/client/tasks_test.go
+++ b/sidecar/client/tasks_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -94,7 +95,7 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 			if task.TargetHeight == 0 {
 				return req.Params == nil
 			}
-			rebuilt := SnapshotRestoreTaskFromParams(*req.Params)
+			rebuilt := snapshotRestoreTaskFromParams(*req.Params)
 			return rebuilt.TargetHeight == task.TargetHeight
 		},
 		genSnapshotRestoreTask(),
@@ -143,7 +144,7 @@ func TestDiscoverPeersRoundTrip(t *testing.T) {
 			if req.Type != TaskTypeDiscoverPeers {
 				return false
 			}
-			rebuilt, err := DiscoverPeersTaskFromParams(*req.Params)
+			rebuilt, err := discoverPeersTaskFromParams(*req.Params)
 			if err != nil {
 				return false
 			}
@@ -469,7 +470,7 @@ func TestResultExportRoundTrip(t *testing.T) {
 			if req.Type != TaskTypeResultExport {
 				return false
 			}
-			rebuilt := ResultExportTaskFromParams(*req.Params)
+			rebuilt := resultExportTaskFromParams(*req.Params)
 			return rebuilt.Bucket == task.Bucket &&
 				rebuilt.Region == task.Region
 		},
@@ -516,7 +517,7 @@ func TestResultExportTask_WithCanonicalRPC(t *testing.T) {
 		t.Errorf("canonicalRpc = %v, want %q", p["canonicalRpc"], "http://canonical-rpc:26657")
 	}
 
-	rebuilt := ResultExportTaskFromParams(p)
+	rebuilt := resultExportTaskFromParams(p)
 	if rebuilt.CanonicalRPC != task.CanonicalRPC {
 		t.Errorf("round-trip CanonicalRPC = %q, want %q", rebuilt.CanonicalRPC, task.CanonicalRPC)
 	}
@@ -624,5 +625,86 @@ func TestAwaitConditionJSONRoundTrip(t *testing.T) {
 	// JSON numbers decode as float64.
 	if p["targetHeight"] != float64(8000) {
 		t.Errorf("targetHeight = %v (type %T), want 8000", p["targetHeight"], p["targetHeight"])
+	}
+}
+
+// snapshotRestoreTaskFromParams reconstructs a SnapshotRestoreTask from
+// a generic params map. Useful for round-trip testing.
+func snapshotRestoreTaskFromParams(params map[string]interface{}) SnapshotRestoreTask {
+	var t SnapshotRestoreTask
+	switch h := params["targetHeight"].(type) {
+	case float64:
+		t.TargetHeight = int64(h)
+	case int64:
+		t.TargetHeight = h
+	}
+	return t
+}
+
+// discoverPeersTaskFromParams reconstructs a DiscoverPeersTask from
+// a generic params map.
+func discoverPeersTaskFromParams(params map[string]interface{}) (DiscoverPeersTask, error) {
+	rawSources, ok := params["sources"]
+	if !ok {
+		return DiscoverPeersTask{}, fmt.Errorf("missing 'sources' key")
+	}
+	items, ok := rawSources.([]interface{})
+	if !ok {
+		return DiscoverPeersTask{}, fmt.Errorf("sources is not a list")
+	}
+
+	var sources []PeerSource
+	for i, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			return DiscoverPeersTask{}, fmt.Errorf("source[%d] is not an object", i)
+		}
+		typ, _ := m["type"].(string)
+		src := PeerSource{Type: PeerSourceType(typ)}
+
+		switch PeerSourceType(typ) {
+		case PeerSourceEC2Tags:
+			src.Region, _ = m["region"].(string)
+			if rawTags, ok := m["tags"].(map[string]interface{}); ok {
+				src.Tags = make(map[string]string, len(rawTags))
+				for k, v := range rawTags {
+					src.Tags[k], _ = v.(string)
+				}
+			}
+		case PeerSourceStatic:
+			if rawAddrs, ok := m["addresses"].([]interface{}); ok {
+				src.Addresses = make([]string, 0, len(rawAddrs))
+				for _, a := range rawAddrs {
+					if s, ok := a.(string); ok {
+						src.Addresses = append(src.Addresses, s)
+					}
+				}
+			}
+		case PeerSourceDNSEndpoints:
+			if rawEps, ok := m["endpoints"].([]interface{}); ok {
+				src.Endpoints = make([]string, 0, len(rawEps))
+				for _, e := range rawEps {
+					if s, ok := e.(string); ok {
+						src.Endpoints = append(src.Endpoints, s)
+					}
+				}
+			}
+		default:
+			return DiscoverPeersTask{}, fmt.Errorf("source[%d] unknown type %q", i, typ)
+		}
+		sources = append(sources, src)
+	}
+	return DiscoverPeersTask{Sources: sources}, nil
+}
+
+// resultExportTaskFromParams reconstructs a ResultExportTask from
+// a generic params map.
+func resultExportTaskFromParams(params map[string]interface{}) ResultExportTask {
+	s := func(k string) string { v, _ := params[k].(string); return v }
+	return ResultExportTask{
+		Bucket:       s("bucket"),
+		Prefix:       s("prefix"),
+		Region:       s("region"),
+		CanonicalRPC: s("canonicalRpc"),
 	}
 }

--- a/sidecar/s3/client.go
+++ b/sidecar/s3/client.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
@@ -80,32 +79,4 @@ func DefaultDownloaderFactory(ctx context.Context, region string) (Downloader, e
 		return nil, fmt.Errorf("loading AWS config: %w", err)
 	}
 	return s3.NewFromConfig(cfg), nil
-}
-
-// WriteAtBuffer is a goroutine-safe in-memory io.WriterAt, used for
-// downloading small S3 objects (e.g. latest.txt) via DownloadObject.
-type WriteAtBuffer struct {
-	mu  sync.Mutex
-	buf []byte
-}
-
-func (w *WriteAtBuffer) WriteAt(p []byte, off int64) (int, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	end := int(off) + len(p)
-	if end > len(w.buf) {
-		grown := make([]byte, end)
-		copy(grown, w.buf)
-		w.buf = grown
-	}
-	copy(w.buf[off:], p)
-	return len(p), nil
-}
-
-func (w *WriteAtBuffer) Bytes() []byte {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	out := make([]byte, len(w.buf))
-	copy(out, w.buf)
-	return out
 }

--- a/sidecar/s3/client_test.go
+++ b/sidecar/s3/client_test.go
@@ -5,6 +5,34 @@ import (
 	"testing"
 )
 
+// WriteAtBuffer is a goroutine-safe in-memory io.WriterAt, used for
+// downloading small S3 objects (e.g. latest.txt) via DownloadObject.
+type WriteAtBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (w *WriteAtBuffer) WriteAt(p []byte, off int64) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	end := int(off) + len(p)
+	if end > len(w.buf) {
+		grown := make([]byte, end)
+		copy(grown, w.buf)
+		w.buf = grown
+	}
+	copy(w.buf[off:], p)
+	return len(p), nil
+}
+
+func (w *WriteAtBuffer) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]byte, len(w.buf))
+	copy(out, w.buf)
+	return out
+}
+
 func TestWriteAtBuffer_BasicWriteAndRead(t *testing.T) {
 	var buf WriteAtBuffer
 	data := []byte("hello world")

--- a/sidecar/tasks/generate_gentx_test.go
+++ b/sidecar/tasks/generate_gentx_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -42,13 +41,4 @@ func TestGentxGenerator_NoMarkerOnFailure(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(homeDir, gentxMarkerFile)); err == nil {
 		t.Fatal("marker file should not exist after failure")
 	}
-}
-
-func contains(s []string, substr string) bool {
-	for _, v := range s {
-		if strings.Contains(v, substr) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
**PLT-453 Phase 1** — behavior-preserving sidecar code-health pass (test-gated). Net −61 LOC.

## Changes
- **Delete 4 fully-dead exported helpers** from `sidecar/client/tasks.go` — `SnapshotUploadTaskFromParams`, `ConfigureGenesisTaskFromParams`, `ConfigApplyTaskFromParams`, `ConfigReloadTaskFromParams`. Zero references anywhere (verified repo-wide; `sei-k8s-controller` imports none).
- **Relocate + unexport** the 3 round-trip helpers actually used by tests into `tasks_test.go` (`snapshotRestore`/`discoverPeers`/`resultExport` `taskFromParams`) — matches the package's unexported-test-helper convention; removes them from the shipped `client` API.
- **Relocate** the test-only `WriteAtBuffer` (`s3/client.go` → `s3/client_test.go`).
- **Delete** the unused `contains` test helper (`generate_gentx_test.go`).

## How it was reviewed (iterative coral cross-review)
- `systems-engineer` built it and caught that **4 of the 7** `*FromParams` were *fully* dead (no callers even in tests) — so they're **deleted outright** rather than relocated-and-hidden in `_test.go` (staticcheck exempts exported `_test.go` symbols, which would have masked them).
- `idiomatic-reviewer` cleared it (verdict: ship) and flagged the surviving 3 as exported-in-test-file against the package convention → **unexported** them.

## Verification
`gofmt -s` clean · `go build`/`go vet`/`go test ./sidecar/...` green · `staticcheck ./sidecar/...` 0 findings.

Note: the 3 surviving helpers are unexported test-only round-trip reconstructors tied to specific round-trip tests; if a future pass removes one of those tests, the helper becomes orphaned — the guard is grep, not staticcheck (exported/test exemption).

Linear: PLT-453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)