### PR TITLE
feat(sidecar): gov-param-change task (PLT-487)

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -124,6 +124,7 @@ var serveCmd = cli.Command{
 			engine.TaskSetGenesisPeers:          tasks.NewGenesisPeersSetter(homeDir, genesisBucket, genesisRegion, chainID, nil).Handler(),
 			engine.TaskGovVote:                  tasks.NewGovVoter(execCfg).Handler(),
 			engine.TaskGovSoftwareUpgrade:       tasks.NewGovSoftwareUpgrader(execCfg).Handler(),
+			engine.TaskGovParamChange:           tasks.NewGovParamChanger(execCfg).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers, store)

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -59,6 +59,7 @@ const (
 
 	TaskTypeGovVote            = string(engine.TaskGovVote)
 	TaskTypeGovSoftwareUpgrade = string(engine.TaskGovSoftwareUpgrade)
+	TaskTypeGovParamChange     = string(engine.TaskGovParamChange)
 )
 
 // Known condition and action values for AwaitConditionTask.
@@ -662,6 +663,103 @@ func (t GovSoftwareUpgradeTask) ToTaskRequest() TaskRequest {
 	}
 	if t.UpgradeInfo != "" {
 		p["upgradeInfo"] = t.UpgradeInfo
+	}
+	if t.Memo != "" {
+		p["memo"] = t.Memo
+	}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
+}
+
+// ParamChangeInput is one (subspace, key, value) entry of a
+// ParameterChangeProposal. Value is raw JSON of whatever shape the
+// param's registered type expects — a scalar (100), a string
+// ("86400000000000"), a bool, or an object. It is carried as
+// json.RawMessage and stringified exactly ONCE in the handler
+// (gov_param_change.go); a pre-escaped string would double-encode and
+// fail at apply time.
+type ParamChangeInput struct {
+	Subspace string          `json:"subspace"`
+	Key      string          `json:"key"`
+	Value    json.RawMessage `json:"value"`
+}
+
+// GovParamChangeTask submits a gov v1beta1 ParameterChangeProposal. The
+// chain auto-assigns proposalID; it is not returned via the task result
+// (operators correlate via the memo's taskID= tag).
+//
+// REHYDRATION WARNING: MsgSubmitProposal is NOT chain-idempotent, and —
+// unlike a software upgrade, which the upgrade module applies once at a
+// named height — a param-change has no "applies once" safety net: a
+// rehydration double-submit produces two real proposals and two
+// deposits. See the handler doc in sidecar/tasks/gov_param_change.go
+// and #174.
+type GovParamChangeTask struct {
+	ChainID string
+	KeyName string
+
+	Title       string
+	Description string
+
+	Changes []ParamChangeInput
+
+	InitialDeposit string
+
+	Memo string
+	Fees string
+	Gas  uint64
+}
+
+func (t GovParamChangeTask) TaskType() string { return TaskTypeGovParamChange }
+
+func (t GovParamChangeTask) Validate() error {
+	if t.ChainID == "" {
+		return errors.New("gov-param-change: chainId required")
+	}
+	if t.KeyName == "" {
+		return errors.New("gov-param-change: keyName required")
+	}
+	if t.Title == "" {
+		return errors.New("gov-param-change: title required")
+	}
+	if t.Description == "" {
+		return errors.New("gov-param-change: description required")
+	}
+	if len(t.Changes) == 0 {
+		return errors.New("gov-param-change: at least one change required")
+	}
+	for i, c := range t.Changes {
+		if c.Subspace == "" {
+			return fmt.Errorf("gov-param-change: changes[%d].subspace required", i)
+		}
+		if c.Key == "" {
+			return fmt.Errorf("gov-param-change: changes[%d].key required", i)
+		}
+		if len(c.Value) == 0 {
+			return fmt.Errorf("gov-param-change: changes[%d].value required", i)
+		}
+	}
+	if t.InitialDeposit == "" {
+		return errors.New("gov-param-change: initialDeposit required")
+	}
+	if t.Fees == "" {
+		return errors.New("gov-param-change: fees required")
+	}
+	if t.Gas == 0 {
+		return errors.New("gov-param-change: gas required (must be > 0)")
+	}
+	return nil
+}
+
+func (t GovParamChangeTask) ToTaskRequest() TaskRequest {
+	p := map[string]interface{}{
+		"chainId":        t.ChainID,
+		"keyName":        t.KeyName,
+		"title":          t.Title,
+		"description":    t.Description,
+		"changes":        t.Changes,
+		"initialDeposit": t.InitialDeposit,
+		"fees":           t.Fees,
+		"gas":            t.Gas,
 	}
 	if t.Memo != "" {
 		p["memo"] = t.Memo

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -676,7 +676,10 @@ func (t GovSoftwareUpgradeTask) ToTaskRequest() TaskRequest {
 // ("86400000000000"), a bool, or an object. It is carried as
 // json.RawMessage and stringified exactly ONCE in the handler
 // (gov_param_change.go); a pre-escaped string would double-encode and
-// fail at apply time.
+// fail at apply time. Integer-valued params must be JSON strings (e.g.
+// "100"), not bare numbers — the sidecar decode is float64-based and
+// loses precision above 2^53 (Sei large-integer params are string-encoded
+// by convention).
 type ParamChangeInput struct {
 	Subspace string          `json:"subspace"`
 	Key      string          `json:"key"`

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -33,6 +33,7 @@ const (
 	TaskSetGenesisPeers          TaskType = "set-genesis-peers"
 	TaskGovVote                  TaskType = "gov-vote"
 	TaskGovSoftwareUpgrade       TaskType = "gov-software-upgrade"
+	TaskGovParamChange           TaskType = "gov-param-change"
 )
 
 // Task is a unit of work submitted by the controller. When ID is set, the

--- a/sidecar/tasks/gov_param_change.go
+++ b/sidecar/tasks/gov_param_change.go
@@ -1,0 +1,185 @@
+// Package tasks — gov-param-change handler.
+//
+// This handler signs ParameterChangeProposals as the validator's
+// operator account. API authentication is controlled by
+// SEI_SIDECAR_AUTHN_MODE; see sidecar/server/auth.go.
+//
+// REHYDRATION WARNING — sei-protocol/seictl#174
+//
+// MsgSubmitProposal is NOT chain-idempotent: a crash between
+// BroadcastSync and task-result persist re-runs this handler on pod
+// restart, re-signs at sequence+1, and broadcasts a SECOND proposal
+// with identical content. Unlike gov-software-upgrade — where the
+// upgrade module applies exactly once at the named height, bounding the
+// blast radius — a param-change has NO "applies once" safety net: two
+// duplicate proposals both enter governance, the operator pays
+// InitialDeposit twice, and voter attention splits. #174 tracks the
+// pre-broadcast txHash marker that closes this window for all sign-tx
+// handlers; until it lands, callers must submit-once.
+
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	govtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/gov/types"
+	proposal "github.com/sei-protocol/sei-chain/sei-cosmos/x/params/types/proposal"
+
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seilog"
+)
+
+var govParamChangeLog = seilog.NewLogger("seictl", "task", "gov-param-change")
+
+// paramChange is one (subspace, key, value) entry. Value is raw JSON of
+// whatever shape the param's registered type expects (scalar, string,
+// bool, or object). It is stringified exactly ONCE — see buildParamChangeMsg.
+type paramChange struct {
+	Subspace string          `json:"subspace"`
+	Key      string          `json:"key"`
+	Value    json.RawMessage `json:"value"`
+}
+
+// GovParamChangeRequest holds gov-param-change params. Idempotency is
+// NOT handled — see the REHYDRATION WARNING at the top of this file.
+type GovParamChangeRequest struct {
+	ChainID string `json:"chainId"`
+	KeyName string `json:"keyName"`
+
+	Title       string `json:"title"`
+	Description string `json:"description"`
+
+	Changes []paramChange `json:"changes"`
+
+	InitialDeposit string `json:"initialDeposit"`
+
+	Memo string `json:"memo,omitempty"`
+	Fees string `json:"fees"`
+	Gas  uint64 `json:"gas"`
+}
+
+// GovParamChanger captures cfg by value at construction; engine.Config
+// is documented read-only after startup, so the copy is safe.
+type GovParamChanger struct {
+	cfg engine.ExecutionConfig
+}
+
+func NewGovParamChanger(cfg engine.ExecutionConfig) *GovParamChanger {
+	return &GovParamChanger{cfg: cfg}
+}
+
+// Handler delegates to SignAndBroadcast after MsgSubmitProposal
+// construction. See the REHYDRATION WARNING at the top of this file: a
+// crash between broadcast and result-persist re-submits a second
+// proposal with identical content, and param-change has no apply-once
+// safety net — do not reuse this pattern for retry loops until #174's
+// pre-broadcast txHash marker lands.
+func (g *GovParamChanger) Handler() engine.TaskHandler {
+	return engine.TypedHandler(func(ctx context.Context, params GovParamChangeRequest) error {
+		msg, err := buildParamChangeMsg(g.cfg, params)
+		if err != nil {
+			return err
+		}
+		result, err := SignAndBroadcast(ctx, g.cfg, SignAndBroadcastInput{
+			ChainID: params.ChainID,
+			KeyName: params.KeyName,
+			Msg:     msg,
+			Fees:    params.Fees,
+			Gas:     params.Gas,
+			Memo:    params.Memo,
+			TaskID:  engine.TaskIDFromContext(ctx),
+		})
+		if err != nil {
+			return err
+		}
+		inclusionStatus := "undetermined"
+		if result.IncludedAt != nil {
+			inclusionStatus = "included"
+		}
+		keys := make([]string, 0, len(params.Changes))
+		for _, c := range params.Changes {
+			keys = append(keys, c.Subspace+"/"+c.Key)
+		}
+		govParamChangeLog.Info("proposal broadcast",
+			"taskId", engine.TaskIDFromContext(ctx),
+			"chainId", params.ChainID,
+			"keyName", params.KeyName,
+			"changes", keys,
+			"deposit", params.InitialDeposit,
+			"txHash", result.TxHash,
+			"height", result.Height,
+			"sequence", result.Sequence,
+			"inclusionStatus", inclusionStatus)
+		return nil
+	})
+}
+
+func buildParamChangeMsg(cfg engine.ExecutionConfig, params GovParamChangeRequest) (*govtypes.MsgSubmitProposal, error) {
+	if cfg.Keyring == nil {
+		return nil, Terminal(errors.New("keyring not configured: set SEI_KEYRING_BACKEND/SEI_KEYRING_PASSPHRASE on the sidecar"))
+	}
+	if params.KeyName == "" {
+		return nil, Terminal(errors.New("keyName required"))
+	}
+	if params.Title == "" {
+		return nil, Terminal(errors.New("title required"))
+	}
+	if params.Description == "" {
+		return nil, Terminal(errors.New("description required"))
+	}
+	if len(params.Changes) == 0 {
+		return nil, Terminal(errors.New("at least one change required"))
+	}
+	changes := make([]proposal.ParamChange, 0, len(params.Changes))
+	for i, c := range params.Changes {
+		if c.Subspace == "" {
+			return nil, Terminal(fmt.Errorf("changes[%d].subspace required", i))
+		}
+		if c.Key == "" {
+			return nil, Terminal(fmt.Errorf("changes[%d].key required", i))
+		}
+		if len(c.Value) == 0 {
+			return nil, Terminal(fmt.Errorf("changes[%d].value required", i))
+		}
+		// The ONLY string() conversion: c.Value is the raw JSON of the
+		// param's registered type (scalar/string/bool/object). The chain
+		// runs UnmarshalAsJSON(value, registeredType) at apply time, so
+		// the bytes must be valid JSON for that type — NOT a re-escaped
+		// string (which would double-encode and fail at apply).
+		changes = append(changes, proposal.NewParamChange(c.Subspace, c.Key, string(c.Value)))
+	}
+	info, err := cfg.Keyring.Key(params.KeyName)
+	if err != nil {
+		return nil, Terminal(fmt.Errorf("keyring entry %q: %w", params.KeyName, err))
+	}
+	deposit, err := sdk.ParseCoinsNormalized(params.InitialDeposit)
+	if err != nil {
+		return nil, Terminal(fmt.Errorf("parse initialDeposit %q: %w", params.InitialDeposit, err))
+	}
+	if len(deposit) == 0 {
+		return nil, Terminal(fmt.Errorf("initialDeposit %q resolves to zero coins", params.InitialDeposit))
+	}
+	if !deposit.IsAllPositive() {
+		return nil, Terminal(fmt.Errorf("initialDeposit %q contains non-positive amounts", params.InitialDeposit))
+	}
+	// Symmetric with checkFeesDenom: deposit denom is fixed by gov params
+	// on Sei (usei); a wrong denom would CheckTx-reject anyway, but
+	// rejecting here saves the sign + broadcast roundtrip.
+	for _, c := range deposit {
+		if c.Denom != feeDenom {
+			return nil, Terminal(fmt.Errorf("initialDeposit %q: denom %q not permitted (only %q)", params.InitialDeposit, c.Denom, feeDenom))
+		}
+	}
+	// isExpedited=false: expedited is deferred (it is honored only via
+	// NewMsgSubmitProposalWithExpedite, not the content field). See LLD.
+	content := proposal.NewParameterChangeProposal(params.Title, params.Description, changes, false)
+	msg, err := govtypes.NewMsgSubmitProposal(content, deposit, info.GetAddress())
+	if err != nil {
+		return nil, Terminal(fmt.Errorf("build MsgSubmitProposal: %w", err))
+	}
+	return msg, nil
+}

--- a/sidecar/tasks/gov_param_change.go
+++ b/sidecar/tasks/gov_param_change.go
@@ -38,6 +38,12 @@ var govParamChangeLog = seilog.NewLogger("seictl", "task", "gov-param-change")
 // paramChange is one (subspace, key, value) entry. Value is raw JSON of
 // whatever shape the param's registered type expects (scalar, string,
 // bool, or object). It is stringified exactly ONCE — see buildParamChangeMsg.
+//
+// Integer-valued params MUST be passed as JSON strings (e.g. "100"), not
+// bare numbers: the sidecar request decode routes values through a
+// map[string]any (float64 numbers), which silently loses precision above
+// 2^53. Sei's large-integer params (durations, windows) are string-encoded
+// by convention, so this is the natural form anyway.
 type paramChange struct {
 	Subspace string          `json:"subspace"`
 	Key      string          `json:"key"`

--- a/sidecar/tasks/gov_param_change_test.go
+++ b/sidecar/tasks/gov_param_change_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -89,11 +90,77 @@ func TestBuildParamChangeMsg(t *testing.T) {
 		}
 	})
 
-	t.Run("empty changes rejected", func(t *testing.T) {
-		req := validParamChangeRequest()
-		req.Changes = nil
-		if _, err := buildParamChangeMsg(cfg, req); err == nil {
-			t.Fatal("expected error for empty changes")
+	t.Run("validation failures are Terminal", func(t *testing.T) {
+		cases := []struct {
+			name string
+			mut  func(*GovParamChangeRequest)
+		}{
+			{"missing keyName", func(r *GovParamChangeRequest) { r.KeyName = "" }},
+			{"missing title", func(r *GovParamChangeRequest) { r.Title = "" }},
+			{"missing description", func(r *GovParamChangeRequest) { r.Description = "" }},
+			{"empty changes", func(r *GovParamChangeRequest) { r.Changes = nil }},
+			{"empty subspace", func(r *GovParamChangeRequest) { r.Changes[0].Subspace = "" }},
+			{"empty key", func(r *GovParamChangeRequest) { r.Changes[0].Key = "" }},
+			{"empty value", func(r *GovParamChangeRequest) { r.Changes[0].Value = nil }},
+			{"non-usei deposit", func(r *GovParamChangeRequest) { r.InitialDeposit = "1uatom" }},
+			{"zero-coin deposit", func(r *GovParamChangeRequest) { r.InitialDeposit = "0usei" }},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				req := validParamChangeRequest()
+				tc.mut(&req)
+				_, err := buildParamChangeMsg(cfg, req)
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if !IsTerminal(err) {
+					t.Errorf("err = %v, want Terminal", err)
+				}
+			})
 		}
 	})
+}
+
+// TestGovParamChangeHandler_HappyPath threads the handler end-to-end
+// through signAndBroadcast with a fake txClient. The MsgSubmitProposal
+// content (a ParameterChangeProposal) is packed as an Any, so reaching
+// the broadcast step proves newSignTxInterfaceRegistry registers the
+// x/params proposal interfaces; a missing registration fails in
+// txCfg.TxEncoder before the fakeTxClient ever sees bytes.
+func TestGovParamChangeHandler_HappyPath(t *testing.T) {
+	cfg, _ := newGuardCfg(t, "arctic-1")
+	tc := &fakeTxClient{
+		accountNumber: 17,
+		sequence:      42,
+		broadcastResp: &sdk.TxResponse{Code: 0, TxHash: "h", Height: 0},
+		queryDefault:  &sdk.TxResponse{Code: 0, Height: 7},
+	}
+
+	req := validParamChangeRequest()
+	msg, err := buildParamChangeMsg(cfg, req)
+	if err != nil {
+		t.Fatalf("buildParamChangeMsg: %v", err)
+	}
+	info, err := cfg.Keyring.Key("node_admin")
+	if err != nil {
+		t.Fatalf("keyring: %v", err)
+	}
+
+	result, err := signAndBroadcast(context.Background(), cfg, tc, SignAndBroadcastInput{
+		ChainID: "arctic-1",
+		KeyName: "node_admin",
+		Msg:     msg,
+		Fees:    req.Fees,
+		Gas:     req.Gas,
+		TaskID:  "00000000-0000-0000-0000-0000000000aa",
+	}, info.GetAddress())
+	if err != nil {
+		t.Fatalf("signAndBroadcast: %v", err)
+	}
+	if result.TxHash != "h" {
+		t.Errorf("TxHash = %q, want %q", result.TxHash, "h")
+	}
+	if tc.broadcasts != 1 {
+		t.Errorf("broadcasts = %d, want 1", tc.broadcasts)
+	}
 }

--- a/sidecar/tasks/gov_param_change_test.go
+++ b/sidecar/tasks/gov_param_change_test.go
@@ -1,0 +1,99 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/sei-protocol/sei-chain/sei-cosmos/types"
+	proposal "github.com/sei-protocol/sei-chain/sei-cosmos/x/params/types/proposal"
+
+	"github.com/sei-protocol/seictl/sidecar/engine"
+)
+
+func validParamChangeRequest() GovParamChangeRequest {
+	return GovParamChangeRequest{
+		ChainID:     "arctic-1",
+		KeyName:     "node_admin",
+		Title:       "Update Consensus Timeout Params",
+		Description: "Tighten consensus timeouts.",
+		Changes: []paramChange{
+			// struct-valued param (object)
+			{Subspace: "baseapp", Key: "TimeoutParams", Value: []byte(`{"propose":"300000000","commit":"200000000"}`)},
+		},
+		InitialDeposit: "10000000usei",
+		Fees:           "8000usei",
+		Gas:            300_000,
+	}
+}
+
+func TestBuildParamChangeMsg(t *testing.T) {
+	kr, addr := testKeyring(t)
+	cfg := engine.ExecutionConfig{Keyring: kr}
+
+	t.Run("happy path", func(t *testing.T) {
+		msg, err := buildParamChangeMsg(cfg, validParamChangeRequest())
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if msg.Proposer != addr.String() {
+			t.Errorf("proposer = %q, want %q", msg.Proposer, addr.String())
+		}
+		want, _ := sdk.ParseCoinsNormalized("10000000usei")
+		if !msg.InitialDeposit.IsEqual(want) {
+			t.Errorf("InitialDeposit = %v, want %v", msg.InitialDeposit, want)
+		}
+		if err := msg.ValidateBasic(); err != nil {
+			t.Errorf("ValidateBasic on returned msg: %v", err)
+		}
+		if _, ok := msg.GetContent().(*proposal.ParameterChangeProposal); !ok {
+			t.Errorf("content type = %T, want *ParameterChangeProposal", msg.GetContent())
+		}
+	})
+
+	// Regression guard for the prop-252 double-encode bug: the raw JSON
+	// value must reach ParamChange.Value stringified exactly ONCE, for any
+	// JSON shape — an object or a bare scalar. A value of {"a":"b"} must
+	// become {"a":"b"}, never "{\"a\":\"b\"}".
+	t.Run("value single-encoded for object and scalar", func(t *testing.T) {
+		cases := []struct {
+			name, raw string
+		}{
+			{"object", `{"propose":"300000000","commit":"200000000"}`},
+			{"scalar-string", `"86400000000000"`},
+			{"scalar-number", `100`},
+			{"scalar-bool", `true`},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				req := validParamChangeRequest()
+				req.Changes = []paramChange{{Subspace: "staking", Key: "K", Value: []byte(tc.raw)}}
+				msg, err := buildParamChangeMsg(cfg, req)
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				pcp := msg.GetContent().(*proposal.ParameterChangeProposal)
+				if got := pcp.Changes[0].Value; got != tc.raw {
+					t.Errorf("ParamChange.Value = %q, want %q (double-encoded?)", got, tc.raw)
+				}
+			})
+		}
+	})
+
+	t.Run("non-usei deposit rejected", func(t *testing.T) {
+		req := validParamChangeRequest()
+		req.InitialDeposit = "10000000uatom"
+		if _, err := buildParamChangeMsg(cfg, req); err == nil {
+			t.Fatal("expected error for non-usei deposit")
+		} else if !strings.Contains(err.Error(), "not permitted") {
+			t.Errorf("err = %v, want denom-not-permitted", err)
+		}
+	})
+
+	t.Run("empty changes rejected", func(t *testing.T) {
+		req := validParamChangeRequest()
+		req.Changes = nil
+		if _, err := buildParamChangeMsg(cfg, req); err == nil {
+			t.Fatal("expected error for empty changes")
+		}
+	})
+}

--- a/sidecar/tasks/transactions.go
+++ b/sidecar/tasks/transactions.go
@@ -20,6 +20,7 @@ import (
 	authtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/auth/types"
 	banktypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/bank/types"
 	govtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/gov/types"
+	proposal "github.com/sei-protocol/sei-chain/sei-cosmos/x/params/types/proposal"
 	stakingtypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/staking/types"
 	upgradetypes "github.com/sei-protocol/sei-chain/sei-cosmos/x/upgrade/types"
 
@@ -156,6 +157,9 @@ func newSignTxInterfaceRegistry() codectypes.InterfaceRegistry {
 	stakingtypes.RegisterInterfaces(registry)
 	govtypes.RegisterInterfaces(registry)
 	upgradetypes.RegisterInterfaces(registry)
+	// x/params ParameterChangeProposal as a gov Content impl (gov-param-change
+	// task). proposal does not pull x/wasm, so CGO_ENABLED=0 builds stay clean.
+	proposal.RegisterInterfaces(registry)
 	return registry
 }
 


### PR DESCRIPTION
Adds a `gov-param-change` sidecar task — submits a v1beta1 `ParameterChangeProposal` signed by the operator account, mirroring `gov-software-upgrade`.

**The load-bearing decision:** the per-change `value` is carried as `json.RawMessage` and `string()`-converted **exactly once** in `buildParamChangeMsg`. So any JSON shape — scalar `100`, string `"86400000000000"`, bool, or object — reaches the chain single-encoded. This structurally prevents the double-encode-at-apply bug that consumed the deposit on the arctic-1 prop-252 first draft.

- usei-denom deposit guard (mirrors gov-software-upgrade)
- param-change-specific **REHYDRATION WARNING** — unlike software-upgrade, a param-change has no apply-once safety net, so a rehydration double-submit is two real proposals + two deposits
- `isExpedited` deferred (honored only via `NewMsgSubmitProposalWithExpedite`, not the content field)
- Test covers the single-encode regression (object + scalar + string + bool), non-usei deposit rejection, empty-changes rejection

Wires `engine.TaskGovParamChange`, `client.GovParamChangeTask`, and the `serve.go` registry. `go build`/`go vet`/tests green.

Design (Coral-signed-off, Brandon-approved): `bdchatham-designs designs/wave/seinode-govparamchange-submit-proposal.md`. First half of PLT-487 (seictl → release → controller bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)