### PR TITLE
fix(sidecar): genesis download SHA-256 verification + in-band hash delivery

### DIFF
--- a/sidecar/api/openapi.yaml
+++ b/sidecar/api/openapi.yaml
@@ -234,6 +234,14 @@ components:
         params:
           type: object
           additionalProperties: true
+        result:
+          type: object
+          additionalProperties: true
+          description: |
+            Handler's structured result, present only when the task
+            succeeded and emitted one (e.g. assemble-and-upload-genesis
+            returns {"genesisHash":"<bare-hex>"}). Delivered over this
+            trusted channel rather than via shared storage.
         error:
           type: string
           description: Error message if the task failed.

--- a/sidecar/client/sidecar.gen.go
+++ b/sidecar/client/sidecar.gen.go
@@ -73,6 +73,12 @@ type TaskResult struct {
 	Id     openapi_types.UUID      `json:"id"`
 	Params *map[string]interface{} `json:"params,omitempty"`
 
+	// Result Handler's structured result, present only when the task
+	// succeeded and emitted one (e.g. assemble-and-upload-genesis
+	// returns {"genesisHash":"<bare-hex>"}). Delivered over this
+	// trusted channel rather than via shared storage.
+	Result *map[string]interface{} `json:"result,omitempty"`
+
 	// Status Current task lifecycle state.
 	Status      TaskResultStatus `json:"status"`
 	SubmittedAt time.Time        `json:"submittedAt"`

--- a/sidecar/client/tasks.go
+++ b/sidecar/client/tasks.go
@@ -107,8 +107,14 @@ func (t SnapshotUploadTask) ToTaskRequest() TaskRequest {
 // ConfigureGenesisTask instructs the sidecar to resolve and write genesis.json.
 // The sidecar resolves genesis from its chain ID: embedded config is checked
 // first, then S3 fallback at {bucket}/{chainID}/genesis.json using env vars.
-// No parameters are needed from the controller.
+//
+// ExpectedGenesisHash is the bare SHA-256 hex digest (no "sha256:" prefix) the
+// downloaded genesis.json must match. When set it gates the S3 download and the
+// sidecar fails closed on mismatch. When empty the download is unverified —
+// callers that omit it (and the field is omitted from the wire request) keep
+// the sidecar's pre-verification behavior.
 type ConfigureGenesisTask struct {
+	ExpectedGenesisHash string
 }
 
 func (t ConfigureGenesisTask) TaskType() string { return TaskTypeConfigureGenesis }
@@ -116,8 +122,11 @@ func (t ConfigureGenesisTask) TaskType() string { return TaskTypeConfigureGenesi
 func (t ConfigureGenesisTask) Validate() error { return nil }
 
 func (t ConfigureGenesisTask) ToTaskRequest() TaskRequest {
-	req := TaskRequest{Type: t.TaskType()}
-	return req
+	if t.ExpectedGenesisHash == "" {
+		return TaskRequest{Type: t.TaskType()}
+	}
+	p := map[string]interface{}{"expectedGenesisHash": t.ExpectedGenesisHash}
+	return TaskRequest{Type: t.TaskType(), Params: &p}
 }
 
 // ConfigPatchTask applies generic TOML merge-patches to seid config files.
@@ -457,6 +466,13 @@ func validateGenesisAccounts(prefix string, accounts []GenesisAccountEntry) erro
 // JSON values, applied to the assembled genesis after collect-gentxs runs.
 // The controller validates keys (immutability post-bootstrap) via CEL; the
 // sidecar applies them verbatim and fails loudly on bad paths.
+//
+// RESULT: this task produces the assembled genesis.json's bare SHA-256 hex
+// digest (the value the controller writes to status.genesisHash and plumbs
+// into followers' ConfigureGenesisTask.ExpectedGenesisHash). The digest is
+// returned in-band on the task result as {"genesisHash":"<bare-hex>"}, which
+// the controller reads over the trusted GET /v0/tasks/{id} channel. It is
+// never written to S3, where the prefix is attacker-writable.
 type AssembleAndUploadGenesisTask struct {
 	AccountBalance string
 	Namespace      string

--- a/sidecar/engine/engine.go
+++ b/sidecar/engine/engine.go
@@ -142,9 +142,11 @@ func (e *Engine) Submit(task Task) (string, error) {
 // runTask spawns a goroutine to run the handler and persist the result.
 func (e *Engine) runTask(id string, taskType TaskType, handler TaskHandler, params map[string]any, submittedAt time.Time, run int) {
 	go func() {
-		// Thread id through ctx for handlers that need it (e.g., sign-tx
-		// memo tagging) without changing the TaskHandler signature.
-		ctx := WithTaskID(e.ctx, id)
+		// Thread id and a result sink through ctx for handlers that need
+		// them (e.g., sign-tx memo tagging, assemble-genesis hash emission)
+		// without changing the TaskHandler signature.
+		sink := &resultSink{}
+		ctx := withResultSink(WithTaskID(e.ctx, id), sink)
 		err := e.execute(ctx, taskType, handler, params)
 
 		t := time.Now().UTC()
@@ -161,6 +163,9 @@ func (e *Engine) runTask(id string, taskType TaskType, handler TaskHandler, para
 			tr.Status = TaskStatusFailed
 		} else {
 			tr.Status = TaskStatusCompleted
+			// Capture only on success — a partial result from a failed
+			// run must not be stamped as authoritative.
+			tr.Result = sink.payload
 		}
 
 		if storeErr := e.store.Save(tr); storeErr != nil {

--- a/sidecar/engine/engine_test.go
+++ b/sidecar/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -72,6 +73,81 @@ func TestSubmitAccepts(t *testing.T) {
 	}
 	if id == "" {
 		t.Fatal("expected non-empty ID")
+	}
+}
+
+func TestSubmitCapturesInBandResult(t *testing.T) {
+	eng := newTestEngine(t, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(ctx context.Context, _ map[string]any) error {
+			SetTaskResult(ctx, json.RawMessage(`{"genesisHash":"deadbeef"}`))
+			return nil
+		},
+	})
+
+	id, err := eng.Submit(Task{Type: TaskConfigPatch})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	result := waitForResult(t, eng, id)
+	if result.Status != TaskStatusCompleted {
+		t.Fatalf("status = %q, want completed", result.Status)
+	}
+	if string(result.Result) != `{"genesisHash":"deadbeef"}` {
+		t.Fatalf("result payload = %q, want in-band genesisHash", string(result.Result))
+	}
+}
+
+func TestSubmitNoResultPayloadIsNil(t *testing.T) {
+	// Backward-compat: a handler that emits nothing leaves Result nil and
+	// the field is omitted from the wire, so the deployed controller is
+	// unaffected.
+	eng := newTestEngine(t, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(_ context.Context, _ map[string]any) error { return nil },
+	})
+
+	id, err := eng.Submit(Task{Type: TaskConfigPatch})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	result := waitForResult(t, eng, id)
+	if result.Status != TaskStatusCompleted {
+		t.Fatalf("status = %q, want completed", result.Status)
+	}
+	if result.Result != nil {
+		t.Fatalf("result payload = %q, want nil for a handler that emits nothing", string(result.Result))
+	}
+	out, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), `"result"`) {
+		t.Fatalf("nil result must be omitted from the wire; got %s", out)
+	}
+}
+
+func TestSubmitFailedTaskDropsResult(t *testing.T) {
+	// A partial result from a failed run must not be stamped as
+	// authoritative.
+	eng := newTestEngine(t, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(ctx context.Context, _ map[string]any) error {
+			SetTaskResult(ctx, json.RawMessage(`{"genesisHash":"partial"}`))
+			return errors.New("boom")
+		},
+	})
+
+	id, err := eng.Submit(Task{Type: TaskConfigPatch})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	result := waitForResult(t, eng, id)
+	if result.Status != TaskStatusFailed {
+		t.Fatalf("status = %q, want failed", result.Status)
+	}
+	if result.Result != nil {
+		t.Fatalf("failed task must not carry a result; got %q", string(result.Result))
 	}
 }
 

--- a/sidecar/engine/sqlite_migrations.go
+++ b/sidecar/engine/sqlite_migrations.go
@@ -90,5 +90,29 @@ func migrate(db *sql.DB) error {
 		}
 	}
 
+	if version < 4 {
+		tx, err := db.Begin()
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		// result holds a handler's structured output as raw JSON; NULL
+		// for the common case of a handler that emits no result.
+		if _, err := tx.Exec(`
+			ALTER TABLE task_results ADD COLUMN result TEXT;
+		`); err != nil {
+			return err
+		}
+
+		if _, err := tx.Exec("PRAGMA user_version = 4"); err != nil {
+			return err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/sidecar/engine/sqlite_store.go
+++ b/sidecar/engine/sqlite_store.go
@@ -70,13 +70,14 @@ func (s *SQLiteStore) Save(r *TaskResult) error {
 
 	_, err = s.db.Exec(`
 		INSERT OR REPLACE INTO task_results
-			(id, type, status, run, params, error, submitted_at, completed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			(id, type, status, run, params, result, error, submitted_at, completed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.ID,
 		r.Type,
 		string(r.Status),
 		r.Run,
 		string(params),
+		nullableRawJSON(r.Result),
 		r.Error,
 		r.SubmittedAt.UTC().Format(time.RFC3339Nano),
 		formatNullableTime(r.CompletedAt),
@@ -125,7 +126,7 @@ func (s *SQLiteStore) Close() error {
 // --- query helpers ---
 
 const selectColumns = `
-	SELECT id, type, status, run, params, error, submitted_at, completed_at
+	SELECT id, type, status, run, params, result, error, submitted_at, completed_at
 	FROM task_results`
 
 // queryMany executes a query and scans all rows into TaskResults.
@@ -157,12 +158,13 @@ func scanTaskResult(s rowScanner) (*TaskResult, error) {
 		r           TaskResult
 		status      string
 		paramsJSON  string
+		resultJSON  sql.NullString
 		submittedAt string
 		completedAt sql.NullString
 	)
 
 	if err := s.Scan(
-		&r.ID, &r.Type, &status, &r.Run, &paramsJSON,
+		&r.ID, &r.Type, &status, &r.Run, &paramsJSON, &resultJSON,
 		&r.Error, &submittedAt, &completedAt,
 	); err != nil {
 		return nil, err
@@ -174,6 +176,10 @@ func scanTaskResult(s rowScanner) (*TaskResult, error) {
 		if err := json.Unmarshal([]byte(paramsJSON), &r.Params); err != nil {
 			return nil, fmt.Errorf("unmarshal params: %w", err)
 		}
+	}
+
+	if resultJSON.Valid && resultJSON.String != "" {
+		r.Result = json.RawMessage(resultJSON.String)
 	}
 
 	t, err := time.Parse(time.RFC3339Nano, submittedAt)
@@ -198,4 +204,13 @@ func formatNullableTime(t *time.Time) any {
 		return nil
 	}
 	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// nullableRawJSON binds a result payload as SQL NULL when empty so the
+// common no-result case stores NULL rather than an empty string.
+func nullableRawJSON(r json.RawMessage) any {
+	if len(r) == 0 {
+		return nil
+	}
+	return string(r)
 }

--- a/sidecar/engine/sqlite_store_test.go
+++ b/sidecar/engine/sqlite_store_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -249,6 +250,54 @@ func TestStoreRunFieldRoundTrip(t *testing.T) {
 	}
 	if got.Run != 3 {
 		t.Fatalf("Run = %d, want 3", got.Run)
+	}
+}
+
+func TestStoreResultFieldRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().Truncate(time.Nanosecond)
+
+	r := &TaskResult{
+		ID:          "res-rt00-0000-0000-0000-000000000000",
+		Type:        "assemble-and-upload-genesis",
+		Status:      TaskStatusCompleted,
+		Run:         1,
+		Result:      json.RawMessage(`{"genesisHash":"abc123"}`),
+		SubmittedAt: now,
+	}
+	if err := s.Save(r); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := s.Get(r.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got.Result) != `{"genesisHash":"abc123"}` {
+		t.Fatalf("Result = %q, want round-tripped payload", string(got.Result))
+	}
+}
+
+func TestStoreNilResultIsNil(t *testing.T) {
+	// A handler that emits no result stores NULL and reads back as nil.
+	s := newTestStore(t)
+
+	r := &TaskResult{
+		ID:          "res-nil0-0000-0000-0000-000000000000",
+		Type:        "config-patch",
+		Status:      TaskStatusCompleted,
+		SubmittedAt: time.Now(),
+	}
+	if err := s.Save(r); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := s.Get(r.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Result != nil {
+		t.Fatalf("Result = %q, want nil", string(got.Result))
 	}
 }
 

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -67,6 +68,35 @@ func WithTaskID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, taskIDKey{}, id)
 }
 
+// resultSink is the mutable slot a handler writes its structured result
+// into. The engine threads a sink through ctx (alongside the task ID) so a
+// handler can emit an in-band result without changing the TaskHandler
+// signature. The engine reads sink.payload only after the handler returns,
+// on the same goroutine — no concurrent access, no lock needed.
+type resultSink struct {
+	payload json.RawMessage
+}
+
+type resultSinkKey struct{}
+
+// withResultSink attaches a result sink to ctx. The engine calls this in
+// runTask; tests that exercise SetTaskResult directly use it too.
+func withResultSink(ctx context.Context, sink *resultSink) context.Context {
+	return context.WithValue(ctx, resultSinkKey{}, sink)
+}
+
+// SetTaskResult records a handler's structured result for the current task.
+// It is captured by the engine and persisted on the TaskResult's Result
+// field, then surfaced over the trusted controller↔sidecar task-result
+// channel (GET /v0/tasks/{id}). Handlers that emit no result behave exactly
+// as before. A no-op when ctx carries no sink (e.g. a handler invoked
+// outside the engine in a unit test).
+func SetTaskResult(ctx context.Context, result json.RawMessage) {
+	if sink, ok := ctx.Value(resultSinkKey{}).(*resultSink); ok && sink != nil {
+		sink.payload = result
+	}
+}
+
 // TaskStatus represents the lifecycle state of a task.
 type TaskStatus string
 
@@ -96,15 +126,24 @@ func (e *TaskError) Error() string {
 }
 
 // TaskResult records a task and its outcome.
+//
+// Result carries a handler's structured output (e.g. assemble-genesis emits
+// {"genesisHash":"<bare-hex>"}). It is optional and additive: handlers that
+// emit nothing leave it nil and it is omitted from the wire, so the
+// currently-deployed controller is unaffected. This in-band channel — read
+// by the controller over the trusted GET /v0/tasks/{id} path — is the
+// authenticated alternative to publishing results through attacker-writable
+// shared storage.
 type TaskResult struct {
-	ID          string         `json:"id"`
-	Type        string         `json:"type"`
-	Status      TaskStatus     `json:"status"`
-	Run         int            `json:"run"`
-	Params      map[string]any `json:"params,omitempty"`
-	Error       string         `json:"error,omitempty"`
-	SubmittedAt time.Time      `json:"submittedAt"`
-	CompletedAt *time.Time     `json:"completedAt,omitempty"`
+	ID          string          `json:"id"`
+	Type        string          `json:"type"`
+	Status      TaskStatus      `json:"status"`
+	Run         int             `json:"run"`
+	Params      map[string]any  `json:"params,omitempty"`
+	Result      json.RawMessage `json:"result,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	SubmittedAt time.Time       `json:"submittedAt"`
+	CompletedAt *time.Time      `json:"completedAt,omitempty"`
 }
 
 // StatusResponse is the shape returned by the status endpoint.

--- a/sidecar/tasks/assemble_genesis.go
+++ b/sidecar/tasks/assemble_genesis.go
@@ -3,6 +3,8 @@ package tasks
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,6 +56,15 @@ type AssembleNodeEntry struct {
 type GenesisAccountEntry struct {
 	Address string `json:"address"`
 	Balance string `json:"balance"`
+}
+
+// AssembleGenesisResult is the task's structured result, emitted in-band over
+// the trusted controller↔sidecar task-result channel. GenesisHash is the bare
+// SHA-256 hex digest (no "sha256:" prefix) of the exact uploaded genesis.json
+// bytes; the controller stamps status.genesisHash from it and plumbs it into
+// followers' ConfigureGenesisTask.ExpectedGenesisHash.
+type AssembleGenesisResult struct {
+	GenesisHash string `json:"genesisHash"`
 }
 
 // AssembleGenesisRequest holds the typed parameters for the assemble-and-upload-genesis task.
@@ -146,7 +157,8 @@ func (a *GenesisAssembler) Handler() engine.TaskHandler {
 			return err
 		}
 
-		if err := a.uploadGenesis(ctx, cfg); err != nil {
+		genesisHash, err := a.uploadGenesis(ctx, cfg)
+		if err != nil {
 			return err
 		}
 
@@ -154,7 +166,15 @@ func (a *GenesisAssembler) Handler() engine.TaskHandler {
 			return err
 		}
 
-		assembleLog.Info("genesis assembled and uploaded", "nodes", len(nodes))
+		// Hand the hash to the controller over the trusted task-result
+		// channel (GET /v0/tasks/{id}); never via shared S3.
+		result, err := json.Marshal(AssembleGenesisResult{GenesisHash: genesisHash})
+		if err != nil {
+			return fmt.Errorf("assemble-genesis: marshaling result: %w", err)
+		}
+		engine.SetTaskResult(ctx, result)
+
+		assembleLog.Info("genesis assembled and uploaded", "nodes", len(nodes), "genesisHash", genesisHash)
 		return writeMarker(a.homeDir, assembleMarkerFile)
 	})
 }
@@ -432,21 +452,31 @@ func (a *GenesisAssembler) applyOverrides(overrides map[string]json.RawMessage) 
 }
 
 // uploadGenesis reads the assembled genesis.json and uploads it to S3
-// at <prefix>/genesis.json where all validators will fetch it from.
-func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg AssembleGenesisRequest) error {
+// at <prefix>/genesis.json where all validators will fetch it from. It
+// returns the bare SHA-256 hex digest (no "sha256:" prefix) computed over the
+// exact bytes uploaded — the same []byte handed to PutObject, not a re-read or
+// re-serialized form — so the digest matches what a follower will download and
+// verify. The digest travels to the controller only in-band, over the trusted
+// task-result channel; it is never written to S3, where the prefix is
+// attacker-writable and a sibling hash would let a poisoned genesis carry its
+// own matching digest.
+func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg AssembleGenesisRequest) (string, error) {
 	genesisPath := filepath.Join(a.homeDir, "config", "genesis.json")
 	data, err := os.ReadFile(genesisPath)
 	if err != nil {
-		return fmt.Errorf("assemble-genesis: reading genesis.json: %w", err)
+		return "", fmt.Errorf("assemble-genesis: reading genesis.json: %w", err)
 	}
+
+	sum := sha256.Sum256(data)
+	genesisHash := hex.EncodeToString(sum[:])
 
 	uploader, err := a.s3UploaderFactory(ctx, a.region)
 	if err != nil {
-		return fmt.Errorf("assemble-genesis: building S3 uploader: %w", err)
+		return "", fmt.Errorf("assemble-genesis: building S3 uploader: %w", err)
 	}
 
 	key := a.chainID + "/" + "genesis.json"
-	assembleLog.Info("uploading assembled genesis", "key", key)
+	assembleLog.Info("uploading assembled genesis", "key", key, "sha256", genesisHash)
 
 	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket:      aws.String(a.bucket),
@@ -455,9 +485,10 @@ func (a *GenesisAssembler) uploadGenesis(ctx context.Context, cfg AssembleGenesi
 		ContentType: aws.String("application/json"),
 	})
 	if err != nil {
-		return seis3.ClassifyS3Error("assemble-and-upload-genesis", a.bucket, key, a.region, err)
+		return "", seis3.ClassifyS3Error("assemble-and-upload-genesis", a.bucket, key, a.region, err)
 	}
-	return nil
+
+	return genesisHash, nil
 }
 
 // uploadPeers builds a peers.json from each node's identity.json and uploads

--- a/sidecar/tasks/assemble_genesis_test.go
+++ b/sidecar/tasks/assemble_genesis_test.go
@@ -3,6 +3,8 @@ package tasks
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -123,6 +125,64 @@ func TestParseAssembleNodes_MissingName(t *testing.T) {
 	// The node should unmarshal but with empty Name — the handler validates this.
 	if nodes[0].Name != "" {
 		t.Fatalf("expected empty name, got %q", nodes[0].Name)
+	}
+}
+
+func TestAssembler_UploadGenesis_ReturnsHashOfUploadedBytes(t *testing.T) {
+	homeDir := t.TempDir()
+	configDir := filepath.Join(homeDir, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := []byte(`{"chain_id":"test-chain-1","app_state":{"staking":{"params":{}}}}`)
+	if err := os.WriteFile(filepath.Join(configDir, "genesis.json"), body, 0o644); err != nil {
+		t.Fatalf("write genesis: %v", err)
+	}
+
+	mock := newMockS3Uploader()
+	a := NewGenesisAssembler(homeDir, "my-bucket", "us-west-2", "test-chain-1", nil, mockUploaderFactory(mock))
+
+	gotHash, err := a.uploadGenesis(context.Background(), AssembleGenesisRequest{})
+	if err != nil {
+		t.Fatalf("uploadGenesis: %v", err)
+	}
+
+	// The returned hash is the SHA-256 of the exact uploaded bytes.
+	uploaded, ok := mock.uploads["my-bucket/test-chain-1/genesis.json"]
+	if !ok {
+		t.Fatal("genesis.json was not uploaded")
+	}
+	sum := sha256.Sum256(uploaded)
+	wantHash := hex.EncodeToString(sum[:])
+	if gotHash != wantHash {
+		t.Errorf("returned hash = %q, want sha256(uploaded bytes) = %q", gotHash, wantHash)
+	}
+	// Byte-exactness: the uploaded bytes equal the on-disk genesis (no re-marshal).
+	if !bytes.Equal(uploaded, body) {
+		t.Errorf("uploaded bytes differ from on-disk genesis; got %q", uploaded)
+	}
+	// No "sha256:" prefix — bare hex.
+	if strings.Contains(gotHash, ":") {
+		t.Errorf("hash %q must be bare hex (no algorithm prefix)", gotHash)
+	}
+	// The hash travels only in-band: no sibling .sha256 object is written
+	// to the attacker-writable prefix.
+	if _, ok := mock.uploads["my-bucket/test-chain-1/genesis.json.sha256"]; ok {
+		t.Error("sibling genesis.json.sha256 object must not be uploaded; the hash travels in-band only")
+	}
+
+	// The in-band result the handler emits is {"genesisHash":"<bare-hex>"}
+	// carrying exactly sha256(uploaded bytes).
+	resultJSON, err := json.Marshal(AssembleGenesisResult{GenesisHash: gotHash})
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var decoded AssembleGenesisResult
+	if err := json.Unmarshal(resultJSON, &decoded); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if decoded.GenesisHash != wantHash {
+		t.Errorf("in-band result genesisHash = %q, want sha256(uploaded) = %q", decoded.GenesisHash, wantHash)
 	}
 }
 

--- a/sidecar/tasks/genesis.go
+++ b/sidecar/tasks/genesis.go
@@ -2,6 +2,8 @@ package tasks
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -45,9 +47,15 @@ type GenesisS3Config struct {
 }
 
 // ConfigureGenesisRequest holds the typed parameters for the configure-genesis task.
-// All fields are optional — the fetcher resolves genesis from the chain ID using
-// embedded config or S3 fallback.
-type ConfigureGenesisRequest struct{}
+// The fetcher resolves genesis from the chain ID using embedded config or S3 fallback.
+//
+// ExpectedGenesisHash is the bare SHA-256 hex digest (no "sha256:" prefix) the
+// downloaded genesis.json must match. When non-empty it gates the S3 download:
+// a mismatch fails closed. When empty (what the current controller sends) the
+// download is unverified, preserving today's behavior.
+type ConfigureGenesisRequest struct {
+	ExpectedGenesisHash string `json:"expectedGenesisHash,omitempty"`
+}
 
 // GenesisFetcher writes genesis.json to the config directory. It first checks
 // for an embedded genesis in sei-config for the chain ID. If not found, it
@@ -80,7 +88,7 @@ func NewGenesisFetcher(homeDir, chainID, genesisBucket, genesisRegion string, fa
 // Handler returns an engine.TaskHandler that resolves genesis from embedded
 // config or S3 fallback. No task parameters are required.
 func (g *GenesisFetcher) Handler() engine.TaskHandler {
-	return engine.TypedHandler(func(ctx context.Context, _ ConfigureGenesisRequest) error {
+	return engine.TypedHandler(func(ctx context.Context, req ConfigureGenesisRequest) error {
 		if markerExists(g.homeDir, genesisMarkerFile) {
 			genesisLog.Debug("already completed, skipping")
 			return nil
@@ -98,22 +106,27 @@ func (g *GenesisFetcher) Handler() engine.TaskHandler {
 
 		key := g.chainID + "/genesis.json"
 		genesisLog.Info("chain not embedded, fetching from S3", "chainId", g.chainID, "bucket", g.genesisBucket, "key", key)
-		return g.fetchFromS3(ctx, GenesisS3Config{Bucket: g.genesisBucket, Key: key, Region: g.genesisRegion})
+		return g.fetchFromS3(ctx, GenesisS3Config{Bucket: g.genesisBucket, Key: key, Region: g.genesisRegion}, req.ExpectedGenesisHash)
 	})
 }
 
 // Fetch downloads genesis.json from S3, skipping if the marker file exists.
 // Retained for backward compatibility with callers that build GenesisS3Config
-// directly.
+// directly; such callers do not verify a hash (empty expected hash).
 func (g *GenesisFetcher) Fetch(ctx context.Context, cfg GenesisS3Config) error {
 	if markerExists(g.homeDir, genesisMarkerFile) {
 		genesisLog.Debug("already completed, skipping")
 		return nil
 	}
-	return g.fetchFromS3(ctx, cfg)
+	return g.fetchFromS3(ctx, cfg, "")
 }
 
-func (g *GenesisFetcher) fetchFromS3(ctx context.Context, cfg GenesisS3Config) error {
+// fetchFromS3 downloads genesis.json, tee-ing the bytes through SHA-256 as they
+// land on disk. When expectedHash is non-empty the digest is verified BEFORE the
+// completion marker is written: a mismatch deletes the partial file, skips the
+// marker, and returns a terminal (non-retryable) error so a poisoned-then-retried
+// node always re-verifies and never skips via a stale marker.
+func (g *GenesisFetcher) fetchFromS3(ctx context.Context, cfg GenesisS3Config, expectedHash string) error {
 	genesisLog.Info("downloading genesis.json from S3", "bucket", cfg.Bucket, "key", cfg.Key)
 	s3Client, err := g.s3ClientFactory(ctx, cfg.Region)
 	if err != nil {
@@ -129,13 +142,35 @@ func (g *GenesisFetcher) fetchFromS3(ctx context.Context, cfg GenesisS3Config) e
 	}
 	defer func() { _ = output.Body.Close() }()
 
+	// Hash the exact downloaded bytes inline with the copy — no re-read, no
+	// JSON re-marshal between download and digest.
+	hasher := sha256.New()
 	if err := g.writeGenesisFile(func(f *os.File) error {
-		_, err := io.Copy(f, output.Body)
+		_, err := io.Copy(io.MultiWriter(f, hasher), output.Body)
 		return err
 	}); err != nil {
 		return err
 	}
+	gotHash := hex.EncodeToString(hasher.Sum(nil))
 
+	if expectedHash != "" && gotHash != expectedHash {
+		destPath := filepath.Join(g.homeDir, "config", "genesis.json")
+		_ = os.Remove(destPath)
+		genesisLog.Error("genesis hash mismatch — failing closed",
+			"bucket", cfg.Bucket, "key", cfg.Key, "expected", expectedHash, "got", gotHash)
+		return &engine.TaskError{
+			Task:      "configure-genesis",
+			Operation: "verify-hash",
+			Message: fmt.Sprintf("downloaded genesis.json from s3://%s/%s has SHA-256 %s, expected %s",
+				cfg.Bucket, cfg.Key, gotHash, expectedHash),
+			Hint:      "the genesis trust root does not match the expected hash; the S3 object may have been replaced — refusing to use it",
+			Retryable: false,
+		}
+	}
+
+	if expectedHash != "" {
+		genesisLog.Info("genesis hash verified", "sha256", gotHash)
+	}
 	genesisLog.Info("genesis download complete (S3)")
 	return writeMarker(g.homeDir, genesisMarkerFile)
 }

--- a/sidecar/tasks/genesis_test.go
+++ b/sidecar/tasks/genesis_test.go
@@ -2,12 +2,102 @@ package tasks
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/sei-protocol/seictl/sidecar/engine"
 )
+
+// genesisFetchFixture wires a GenesisFetcher to a mock S3 holding a single
+// genesis.json under the unknown chain's key, returning the fetcher plus the
+// bytes' true SHA-256 hex digest. The chain ID is intentionally not embedded so
+// the handler takes the S3 fallback path.
+func genesisFetchFixture(t *testing.T, body []byte) (*GenesisFetcher, string, string) {
+	t.Helper()
+	homeDir := t.TempDir()
+	const chainID = "custom-devnet-1"
+	key := chainID + "/genesis.json"
+	s3 := &mockS3GetObject{objects: map[string][]byte{key: body}}
+	factory := func(_ context.Context, _ string) (S3GetObjectAPI, error) { return s3, nil }
+	fetcher := NewGenesisFetcher(homeDir, chainID, "genesis-bucket", "us-east-2", factory)
+	sum := sha256.Sum256(body)
+	return fetcher, hex.EncodeToString(sum[:]), homeDir
+}
+
+func TestGenesisFetcher_S3_MatchingHashSucceeds(t *testing.T) {
+	body := []byte(`{"chain_id":"custom-devnet-1","app_state":{}}`)
+	fetcher, wantHash, homeDir := genesisFetchFixture(t, body)
+
+	err := fetcher.Handler()(context.Background(), map[string]any{"expectedGenesisHash": wantHash})
+	if err != nil {
+		t.Fatalf("matching hash should succeed, got: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(homeDir, "config", "genesis.json"))
+	if err != nil {
+		t.Fatalf("reading genesis.json: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("genesis bytes = %q, want %q", got, body)
+	}
+	if !markerExists(homeDir, genesisMarkerFile) {
+		t.Error("expected completion marker to be written on verified download")
+	}
+}
+
+func TestGenesisFetcher_S3_MismatchedHashFailsClosed(t *testing.T) {
+	body := []byte(`{"chain_id":"custom-devnet-1","app_state":{}}`)
+	fetcher, _, homeDir := genesisFetchFixture(t, body)
+
+	err := fetcher.Handler()(context.Background(), map[string]any{
+		"expectedGenesisHash": "0000000000000000000000000000000000000000000000000000000000000000",
+	})
+	if err == nil {
+		t.Fatal("mismatched hash must fail closed, got nil error")
+	}
+
+	var te *engine.TaskError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *engine.TaskError", err)
+	}
+	if te.Retryable {
+		t.Error("hash-mismatch error must be terminal (non-retryable)")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(homeDir, "config", "genesis.json")); !os.IsNotExist(statErr) {
+		t.Error("partial genesis.json must be deleted on mismatch")
+	}
+	if markerExists(homeDir, genesisMarkerFile) {
+		t.Error("completion marker must NOT be written on mismatch (re-verify safety)")
+	}
+}
+
+func TestGenesisFetcher_S3_EmptyHashPreservesBehavior(t *testing.T) {
+	body := []byte(`{"chain_id":"custom-devnet-1","app_state":{}}`)
+	fetcher, _, homeDir := genesisFetchFixture(t, body)
+
+	// No expectedGenesisHash in params — the current controller's wire shape.
+	if err := fetcher.Handler()(context.Background(), map[string]any{}); err != nil {
+		t.Fatalf("empty expected hash should download unverified, got: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(homeDir, "config", "genesis.json"))
+	if err != nil {
+		t.Fatalf("reading genesis.json: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("genesis bytes = %q, want %q", got, body)
+	}
+	if !markerExists(homeDir, genesisMarkerFile) {
+		t.Error("expected completion marker on unverified download")
+	}
+}
 
 func TestGenesisFetcher_EmbeddedChain(t *testing.T) {
 	homeDir := t.TempDir()


### PR DESCRIPTION
## What

Closes the genesis-trust gate for the SeiNetwork work: a node booting from the S3 genesis fallback now verifies the downloaded `genesis.json` against an expected SHA-256, and the authoritative hash travels to the controller over the trusted in-cluster task-result channel — never through the attacker-writable S3 prefix.

Two halves:
- **Download verification** (`sidecar/tasks/genesis.go`): `fetchFromS3` tees the body through `sha256` during the copy, verifies before writing the completion marker, and on mismatch deletes the partial file, skips the marker, and returns a terminal (non-retryable) error. An empty expected hash preserves today's behavior (migration affordance).
- **Trusted hash delivery**: `assemble-genesis` computes the hash over the exact uploaded bytes and returns it **in-band** via a new optional `TaskResult.Result` payload (engine + OpenAPI client, additive/backward-compatible; SQLite migration v4 adds a nullable column). The controller reads it from the task result to populate `status.genesisHash`.

## Why

`status.genesisHash` was a dead field — nothing computed it and the download path never checked it, so anyone who could write the `genesisS3URI` prefix could swap a node's trust root undetected. A first cut delivered the hash via a sibling `.sha256` S3 object, but that sits in the *same attacker-writable prefix* and hands the attacker both sides of the comparison — security review flagged it DEFEATS-THE-GATE. This routes the hash over the in-cluster controller↔sidecar channel instead; the `.sha256` object is removed.

## Review

Security-specialist reviewed both the download-verify path (SOUND) and the delivery channel (the in-band fix CONFIRMED — gate closed). All sidecar packages build + test green.

## Rollout note (not a blocker for merge)

This is the `seictl` half. The controller-side consumer (read `GetTask().Result.genesisHash` → write `status.genesisHash` → pass into followers' `ConfigureGenesisTask.ExpectedGenesisHash`) lands on the SeiNetwork controller and must be in place before the SeiNetwork deploy gate opens. The empty-hash passthrough and the controller actually sending the hash must not both lag in prod, or the gate is armed but not engaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
