### PR TITLE
feat(shadow): migration mode + Layer 2 logical state diff (PLT-681)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/RaduBerinde/axisds v0.0.0-20250419182453-5135a0650657 // indirect
 	github.com/RaduBerinde/btreemap v0.0.0-20250419174037-3d62b7205d54 // indirect
 	github.com/alitto/pond v1.8.3 // indirect
@@ -97,6 +98,7 @@ require (
 	github.com/creachadair/taskgroup v0.3.2 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgraph-io/badger/v3 v3.2103.2 // indirect
@@ -114,6 +116,7 @@ require (
 	github.com/go-kit/kit v0.13.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -183,6 +186,7 @@ require (
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/sei-protocol/sei-tm-db v0.0.5 // indirect
+	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
@@ -201,7 +205,10 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/tinylru v1.1.0 // indirect
 	github.com/tidwall/wal v1.2.1 // indirect
+	github.com/tklauser/go-sysconf v0.3.15 // indirect
+	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zbiljic/go-filelock v0.0.0-20170914061330-1dbf7103ab7d // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	github.com/zondax/golem v0.27.0 // indirect

--- a/sidecar/shadow/close_test.go
+++ b/sidecar/shadow/close_test.go
@@ -1,0 +1,50 @@
+package shadow
+
+import "testing"
+
+// closeableState is a StateReader with a no-return Close() (the shape
+// *ethclient.Client uses), recording whether Close was called.
+type closeableState struct {
+	*mockState
+	closed *bool
+}
+
+func (c closeableState) Close() { *c.closed = true }
+
+// closeableKeySource is a KeySource with a no-return Close().
+type closeableKeySource struct {
+	mockKeySource
+	closed *bool
+}
+
+func (c closeableKeySource) Close() { *c.closed = true }
+
+// Comparator.Close must close the configured readers/key source. *ethclient.Client
+// and *rpc.Client expose Close() with no return (not io.Closer), so this guards
+// against the regression where an io.Closer assertion silently skipped them.
+func TestComparator_CloseClosesReaders(t *testing.T) {
+	var shadowClosed, canonClosed, ksClosed bool
+	shadow := closeableState{mockState: newMockState(), closed: &shadowClosed}
+	canon := closeableState{mockState: newMockState(), closed: &canonClosed}
+	ks := closeableKeySource{closed: &ksClosed}
+
+	comp := NewComparator("http://shadow", "http://canon", WithLayer2(shadow, canon, ks))
+	comp.Close()
+
+	if !shadowClosed || !canonClosed {
+		t.Errorf("state readers not closed: shadow=%v canon=%v", shadowClosed, canonClosed)
+	}
+	if !ksClosed {
+		t.Error("key source not closed")
+	}
+}
+
+// Close must be safe when Layer 2 was never configured (nil readers).
+func TestComparator_CloseNoLayer2(t *testing.T) {
+	comp := NewComparator("http://shadow", "http://canon")
+	comp.Close() // must not panic
+}
+
+// compile-time guard: TraceKeySource matches the no-return Close() shape that
+// Comparator.Close asserts (the same shape *ethclient.Client / *rpc.Client use).
+var _ interface{ Close() } = (*TraceKeySource)(nil)

--- a/sidecar/shadow/comparator.go
+++ b/sidecar/shadow/comparator.go
@@ -15,25 +15,49 @@ var log = seilog.NewLogger("seictl", "shadow")
 type Comparator struct {
 	shadowClient    *rpc.Client
 	canonicalClient *rpc.Client
+
+	// migrationMode tunes the verdict for an AppHash-breaking migration shadow
+	// (e.g. memiavl->flatkv): the shadow's AppHash diverges from canonical by
+	// design every block, so AppHash mismatch is expected and informational.
+	// The correctness signals become LastResultsHash + gas + per-tx receipts
+	// (execution equivalence), and Layer 1 always runs.
+	migrationMode bool
+}
+
+// Option configures a Comparator.
+type Option func(*Comparator)
+
+// WithMigrationMode treats AppHash divergence as expected (not a mismatch) and
+// keys the verdict on execution-results equivalence. Use for a shadow running
+// an AppHash-breaking state migration against an un-migrated canonical chain.
+func WithMigrationMode() Option {
+	return func(c *Comparator) { c.migrationMode = true }
 }
 
 // NewComparator creates a Comparator that queries shadowRPC for the local
 // shadow node and canonicalRPC for the reference chain.
-func NewComparator(shadowRPC, canonicalRPC string) *Comparator {
-	return &Comparator{
+func NewComparator(shadowRPC, canonicalRPC string, opts ...Option) *Comparator {
+	c := &Comparator{
 		shadowClient:    rpc.NewClient(shadowRPC, nil),
 		canonicalClient: rpc.NewClient(canonicalRPC, nil),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // CompareBlock performs a layered comparison for the given block height.
-// Layer 0 (block headers) always runs. If Layer 0 detects a divergence,
-// Layer 1 (transaction receipts) is run to provide diagnostic detail.
+// Layer 0 (block headers) always runs. Layer 1 (transaction receipts) runs when
+// a real divergence is detected, and always in migration mode — where AppHash,
+// the cheap Layer 0 signal, is expected to differ, so the receipt check is the
+// real correctness signal.
 func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareResult, error) {
 	result := &CompareResult{
-		Height:    height,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Match:     true,
+		Height:        height,
+		Timestamp:     time.Now().UTC().Format(time.RFC3339),
+		Match:         true,
+		MigrationMode: c.migrationMode,
 	}
 
 	// --- Layer 0: block header comparison ---
@@ -43,22 +67,35 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 	}
 	result.Layer0 = *l0
 
-	if !l0.Match() {
-		result.Match = false
-		layer := 0
-		result.DivergenceLayer = &layer
+	// In migration mode AppHash mismatch is expected; a real Layer 0 divergence
+	// is an execution-results mismatch (LastResultsHash/gas). Otherwise any
+	// Layer 0 field mismatch (including AppHash) counts.
+	realL0Divergence := !l0.Match()
+	if c.migrationMode {
+		realL0Divergence = !l0.LastResultsHashMatch || !l0.GasUsedMatch
+	}
 
-		// --- Layer 1: transaction receipt comparison ---
+	// --- Layer 1: transaction receipt comparison ---
+	if realL0Divergence || c.migrationMode {
 		l1, err := c.compareLayer1(ctx, height)
 		if err != nil {
 			log.Warn("layer 1 comparison failed, returning layer 0 result only",
 				"height", height, "err", err)
 		} else {
 			result.Layer1 = l1
-			if l1 != nil && len(l1.Divergences) > 0 {
-				layer = 1
-			}
 		}
+	}
+	l1Diverged := result.Layer1 != nil && len(result.Layer1.Divergences) > 0
+
+	switch {
+	case realL0Divergence:
+		result.Match = false
+		layer := 0
+		result.DivergenceLayer = &layer
+	case l1Diverged:
+		result.Match = false
+		layer := 1
+		result.DivergenceLayer = &layer
 	}
 
 	return result, nil

--- a/sidecar/shadow/comparator.go
+++ b/sidecar/shadow/comparator.go
@@ -3,6 +3,7 @@ package shadow
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/sei-protocol/seictl/sidecar/rpc"
@@ -10,6 +11,10 @@ import (
 )
 
 var log = seilog.NewLogger("seictl", "shadow")
+
+// layer2Timeout bounds the per-block Layer 2 RPC fan-out (touched-key trace plus
+// state reads on both chains) so one slow endpoint cannot stall the compare loop.
+const layer2Timeout = 30 * time.Second
 
 // Comparator performs block-by-block comparison between a shadow node and
 // a canonical chain node via their RPC endpoints.
@@ -85,11 +90,15 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 	result.Layer0 = *l0
 
 	// In migration mode AppHash mismatch is expected; a real Layer 0 divergence
-	// is an execution-results mismatch (LastResultsHash/gas). Otherwise any
-	// Layer 0 field mismatch (including AppHash) counts.
+	// is a LastResultsHash mismatch (execution results differ). Per-tx gas is
+	// compared in Layer 1; Layer 0 GasUsedMatch is not yet wired (stubbed true),
+	// so it is deliberately not part of this verdict. Otherwise any Layer 0 field
+	// mismatch (including AppHash) counts.
+	// Note: LastResultsHash at height N reflects N-1 execution; the per-tx Layer 1
+	// signal lands on the correct height, so attribution stays accurate.
 	realL0Divergence := !l0.Match()
 	if c.migrationMode {
-		realL0Divergence = !l0.LastResultsHashMatch || !l0.GasUsedMatch
+		realL0Divergence = !l0.LastResultsHashMatch
 	}
 
 	// --- Layer 1: transaction receipt comparison ---
@@ -108,13 +117,19 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 	if c.layer2Enabled() && (realL0Divergence || c.migrationMode) {
 		l2, err := c.compareLayer2(ctx, height)
 		if err != nil {
-			log.Warn("layer 2 state comparison failed, skipping it for this height",
+			// Fail closed: the load-bearing check could not run, so this block is
+			// NOT clean. Record it as indeterminate (forces Match=false below)
+			// rather than silently passing on the layer that actually validates
+			// the migration.
+			log.Warn("layer 2 state comparison could not run; marking indeterminate",
 				"height", height, "err", err)
+			result.Layer2 = &Layer2Result{Indeterminate: true, Error: err.Error()}
 		} else {
 			result.Layer2 = l2
 		}
 	}
 	l2Diverged := result.Layer2 != nil && len(result.Layer2.Divergences) > 0
+	l2Indeterminate := result.Layer2 != nil && result.Layer2.Indeterminate
 
 	switch {
 	case realL0Divergence:
@@ -125,7 +140,7 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 		result.Match = false
 		layer := 1
 		result.DivergenceLayer = &layer
-	case l2Diverged:
+	case l2Diverged || l2Indeterminate:
 		result.Match = false
 		layer := 2
 		result.DivergenceLayer = &layer
@@ -139,11 +154,30 @@ func (c *Comparator) layer2Enabled() bool {
 }
 
 // compareLayer2 fetches the accounts a block touched and compares their logical
-// state (storage/code/nonce) between the shadow and canonical chains.
+// state (balance/code/nonce/storage) between the shadow and canonical chains. It
+// bounds the per-block RPC fan-out with a timeout so one slow endpoint cannot
+// stall the compare loop.
+//
+// The CometBFT height is used directly as the EVM block number for the trace and
+// the state reads. This holds because sei-chain maps an explicit EVM block number
+// straight to the tendermint height (evmrpc getBlockNumber: identity, no offset).
+// If a future sei-chain reintroduces an offset, that identity breaks and this
+// must translate height -> EVM block number before the EVM calls.
 func (c *Comparator) compareLayer2(ctx context.Context, height int64) (*Layer2Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, layer2Timeout)
+	defer cancel()
 	touched, err := c.keySource.TouchedAccounts(ctx, height)
 	if err != nil {
 		return nil, fmt.Errorf("resolving touched accounts at height %d: %w", height, err)
 	}
 	return compareState(ctx, height, touched, c.shadowState, c.canonicalState)
+}
+
+// Close releases resources held by configured Layer 2 readers / key source.
+func (c *Comparator) Close() {
+	for _, r := range []any{c.shadowState, c.canonicalState, c.keySource} {
+		if cl, ok := r.(io.Closer); ok {
+			_ = cl.Close()
+		}
+	}
 }

--- a/sidecar/shadow/comparator.go
+++ b/sidecar/shadow/comparator.go
@@ -3,7 +3,6 @@ package shadow
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/sei-protocol/seictl/sidecar/rpc"
@@ -174,10 +173,13 @@ func (c *Comparator) compareLayer2(ctx context.Context, height int64) (*Layer2Re
 }
 
 // Close releases resources held by configured Layer 2 readers / key source.
+// go-ethereum's *ethclient.Client and *rpc.Client expose Close() with NO return,
+// so they do not satisfy io.Closer — assert the no-return shape instead, or the
+// connections leak silently.
 func (c *Comparator) Close() {
 	for _, r := range []any{c.shadowState, c.canonicalState, c.keySource} {
-		if cl, ok := r.(io.Closer); ok {
-			_ = cl.Close()
+		if cl, ok := r.(interface{ Close() }); ok {
+			cl.Close()
 		}
 	}
 }

--- a/sidecar/shadow/comparator.go
+++ b/sidecar/shadow/comparator.go
@@ -2,6 +2,7 @@ package shadow
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/sei-protocol/seictl/sidecar/rpc"
@@ -22,6 +23,11 @@ type Comparator struct {
 	// The correctness signals become LastResultsHash + gas + per-tx receipts
 	// (execution equivalence), and Layer 1 always runs.
 	migrationMode bool
+
+	// Layer 2 (logical state diff) runs only when all three are configured.
+	shadowState    StateReader
+	canonicalState StateReader
+	keySource      KeySource
 }
 
 // Option configures a Comparator.
@@ -32,6 +38,17 @@ type Option func(*Comparator)
 // an AppHash-breaking state migration against an un-migrated canonical chain.
 func WithMigrationMode() Option {
 	return func(c *Comparator) { c.migrationMode = true }
+}
+
+// WithLayer2 enables logical state-diff comparison: the keySource yields the
+// accounts/slots each block touched, and the two StateReaders (EVM RPC on the
+// shadow and canonical chains) supply their logical values to compare.
+func WithLayer2(shadowState, canonicalState StateReader, keySource KeySource) Option {
+	return func(c *Comparator) {
+		c.shadowState = shadowState
+		c.canonicalState = canonicalState
+		c.keySource = keySource
+	}
 }
 
 // NewComparator creates a Comparator that queries shadowRPC for the local
@@ -87,6 +104,18 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 	}
 	l1Diverged := result.Layer1 != nil && len(result.Layer1.Divergences) > 0
 
+	// --- Layer 2: logical state diff (when configured) ---
+	if c.layer2Enabled() && (realL0Divergence || c.migrationMode) {
+		l2, err := c.compareLayer2(ctx, height)
+		if err != nil {
+			log.Warn("layer 2 state comparison failed, skipping it for this height",
+				"height", height, "err", err)
+		} else {
+			result.Layer2 = l2
+		}
+	}
+	l2Diverged := result.Layer2 != nil && len(result.Layer2.Divergences) > 0
+
 	switch {
 	case realL0Divergence:
 		result.Match = false
@@ -96,7 +125,25 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 		result.Match = false
 		layer := 1
 		result.DivergenceLayer = &layer
+	case l2Diverged:
+		result.Match = false
+		layer := 2
+		result.DivergenceLayer = &layer
 	}
 
 	return result, nil
+}
+
+func (c *Comparator) layer2Enabled() bool {
+	return c.keySource != nil && c.shadowState != nil && c.canonicalState != nil
+}
+
+// compareLayer2 fetches the accounts a block touched and compares their logical
+// state (storage/code/nonce) between the shadow and canonical chains.
+func (c *Comparator) compareLayer2(ctx context.Context, height int64) (*Layer2Result, error) {
+	touched, err := c.keySource.TouchedAccounts(ctx, height)
+	if err != nil {
+		return nil, fmt.Errorf("resolving touched accounts at height %d: %w", height, err)
+	}
+	return compareState(ctx, height, touched, c.shadowState, c.canonicalState)
 }

--- a/sidecar/shadow/comparator.go
+++ b/sidecar/shadow/comparator.go
@@ -104,13 +104,21 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 	if realL0Divergence || c.migrationMode {
 		l1, err := c.compareLayer1(ctx, height)
 		if err != nil {
-			log.Warn("layer 1 comparison failed, returning layer 0 result only",
-				"height", height, "err", err)
+			// In migration mode Layer 1 is load-bearing (AppHash is expected to
+			// differ), so an error must fail closed, not silently pass. Outside
+			// migration mode Layer 1 only runs after a confirmed Layer 0
+			// divergence, so the block is already not clean and the error is
+			// merely missing detail.
+			log.Warn("layer 1 comparison failed", "height", height, "err", err)
+			if c.migrationMode {
+				result.Layer1 = &Layer1Result{Indeterminate: true, Error: err.Error()}
+			}
 		} else {
 			result.Layer1 = l1
 		}
 	}
 	l1Diverged := result.Layer1 != nil && len(result.Layer1.Divergences) > 0
+	l1Indeterminate := result.Layer1 != nil && result.Layer1.Indeterminate
 
 	// --- Layer 2: logical state diff (when configured) ---
 	if c.layer2Enabled() && (realL0Divergence || c.migrationMode) {
@@ -130,18 +138,21 @@ func (c *Comparator) CompareBlock(ctx context.Context, height int64) (*CompareRe
 	l2Diverged := result.Layer2 != nil && len(result.Layer2.Divergences) > 0
 	l2Indeterminate := result.Layer2 != nil && result.Layer2.Indeterminate
 
+	// Attribute to the deepest (most specific) layer that fired: a Layer 1/2
+	// divergence or indeterminate is more actionable than the Layer 0 header
+	// mismatch that triggered the descent.
 	switch {
-	case realL0Divergence:
-		result.Match = false
-		layer := 0
-		result.DivergenceLayer = &layer
-	case l1Diverged:
-		result.Match = false
-		layer := 1
-		result.DivergenceLayer = &layer
 	case l2Diverged || l2Indeterminate:
 		result.Match = false
 		layer := 2
+		result.DivergenceLayer = &layer
+	case l1Diverged || l1Indeterminate:
+		result.Match = false
+		layer := 1
+		result.DivergenceLayer = &layer
+	case realL0Divergence:
+		result.Match = false
+		layer := 0
 		result.DivergenceLayer = &layer
 	}
 

--- a/sidecar/shadow/comparator_migration_test.go
+++ b/sidecar/shadow/comparator_migration_test.go
@@ -3,6 +3,8 @@ package shadow
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/sei-protocol/seictl/sidecar/rpc"
@@ -43,6 +45,46 @@ func TestCompareBlock_MigrationMode_AppHashExpected(t *testing.T) {
 	}
 	if result.DivergenceLayer != nil {
 		t.Errorf("expected nil divergence layer, got %d", *result.DivergenceLayer)
+	}
+}
+
+// In migration mode Layer 1 is load-bearing (AppHash is expected to differ). If
+// the receipt comparison cannot run, the block must fail closed (indeterminate,
+// attributed to layer 1) — never a silent clean pass.
+func TestCompareBlock_MigrationMode_Layer1ErrorFailsClosed(t *testing.T) {
+	// /block returns differing AppHash but matching LastResultsHash (so Layer 0 is
+	// not a real divergence); /block_results errors, so Layer 1 cannot run.
+	handler := func(appHash string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/block":
+				_, _ = w.Write(blockJSON(appHash, "SAME_RESULTS"))
+			case "/block_results":
+				http.Error(w, "block_results unavailable", http.StatusInternalServerError)
+			default:
+				http.NotFound(w, r)
+			}
+		}
+	}
+	shadowSrv := httptest.NewServer(handler("SHADOW_APPHASH"))
+	defer shadowSrv.Close()
+	canonicalSrv := httptest.NewServer(handler("CANON_APPHASH"))
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL, WithMigrationMode())
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Match {
+		t.Error("expected NOT clean: Layer 1 could not run in migration mode, must fail closed")
+	}
+	if result.DivergenceLayer == nil || *result.DivergenceLayer != 1 {
+		t.Errorf("expected divergence layer 1, got %v", result.DivergenceLayer)
+	}
+	if result.Layer1 == nil || !result.Layer1.Indeterminate {
+		t.Errorf("expected Layer1 marked indeterminate, got %+v", result.Layer1)
 	}
 }
 

--- a/sidecar/shadow/comparator_migration_test.go
+++ b/sidecar/shadow/comparator_migration_test.go
@@ -1,0 +1,100 @@
+package shadow
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sei-protocol/seictl/sidecar/rpc"
+)
+
+// In migration mode the shadow's AppHash diverges from canonical by design, so an
+// AppHash-only mismatch must NOT count as a divergence; the verdict keys on
+// execution-results equivalence (LastResultsHash + gas + per-tx receipts).
+func TestCompareBlock_MigrationMode_AppHashExpected(t *testing.T) {
+	txs := []rpc.TxResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200", Log: "ok", Events: json.RawMessage(`[]`)},
+	}
+	shadowSrv := rpcServer("SHADOW_APPHASH", "SAME_RESULTS", txs)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CANON_APPHASH", "SAME_RESULTS", txs)
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL, WithMigrationMode())
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if !result.Match {
+		t.Error("expected match: AppHash divergence is expected in migration mode")
+	}
+	if !result.MigrationMode {
+		t.Error("expected result to record migration mode")
+	}
+	if result.Layer0.AppHashMatch {
+		t.Error("expected AppHash mismatch")
+	}
+	if !result.Layer0.LastResultsHashMatch {
+		t.Error("expected LastResultsHash match")
+	}
+	if result.Layer1 == nil {
+		t.Error("migration mode must always run Layer 1, even when results match")
+	}
+	if result.DivergenceLayer != nil {
+		t.Errorf("expected nil divergence layer, got %d", *result.DivergenceLayer)
+	}
+}
+
+// A LastResultsHash mismatch is a real execution divergence even in migration
+// mode, attributed to Layer 0.
+func TestCompareBlock_MigrationMode_ResultsDivergence(t *testing.T) {
+	shadowSrv := rpcServer("SHADOW_APPHASH", "SHADOW_RESULTS", nil)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CANON_APPHASH", "CANON_RESULTS", nil)
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL, WithMigrationMode())
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Match {
+		t.Error("expected divergence: LastResultsHash mismatch is a real execution divergence")
+	}
+	if result.DivergenceLayer == nil || *result.DivergenceLayer != 0 {
+		t.Errorf("expected divergence layer 0, got %v", result.DivergenceLayer)
+	}
+}
+
+// When results hashes agree but a per-tx receipt differs, migration mode still
+// catches it at Layer 1 (which always runs in migration mode).
+func TestCompareBlock_MigrationMode_ReceiptDivergence(t *testing.T) {
+	shadowTxs := []rpc.TxResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200", Log: "ok", Events: json.RawMessage(`[]`)},
+	}
+	canonicalTxs := []rpc.TxResult{
+		{Code: 1, GasUsed: "150", GasWanted: "200", Log: "reverted", Events: json.RawMessage(`[]`)},
+	}
+	shadowSrv := rpcServer("SHADOW_APPHASH", "SAME_RESULTS", shadowTxs)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CANON_APPHASH", "SAME_RESULTS", canonicalTxs)
+	defer canonicalSrv.Close()
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL, WithMigrationMode())
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Match {
+		t.Error("expected divergence: a per-tx receipt differs")
+	}
+	if result.DivergenceLayer == nil || *result.DivergenceLayer != 1 {
+		t.Errorf("expected divergence layer 1, got %v", result.DivergenceLayer)
+	}
+	if result.Layer1 == nil || len(result.Layer1.Divergences) != 1 {
+		t.Errorf("expected 1 tx divergence, got %+v", result.Layer1)
+	}
+}

--- a/sidecar/shadow/keysource.go
+++ b/sidecar/shadow/keysource.go
@@ -1,8 +1,10 @@
 package shadow
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -10,10 +12,17 @@ import (
 )
 
 // TraceKeySource derives a block's touched accounts and storage slots from a
-// prestate trace (debug_traceBlockByNumber with the prestateTracer) on an EVM
-// JSON-RPC endpoint. The prestate lists every account and slot the block's
-// transactions accessed — exactly the set Layer 2 should compare. Requires the
-// debug_ namespace enabled on the endpoint (a non-public, operator-owned node).
+// diff-mode prestate trace (debug_traceBlockByNumber, prestateTracer with
+// diffMode) on an EVM JSON-RPC endpoint. diffMode reports both the pre-state
+// (slots read) and post-state (slots written), so the union covers keys the
+// block read OR modified — not just those read. Requires the debug_ namespace
+// enabled on the endpoint (a non-public, operator-owned node).
+//
+// Coverage boundary: this is the per-block TOUCHED set. Keys migrated but never
+// touched by any transaction (cold state), and non-EVM Cosmos-module state, are
+// not covered here — that breadth is the corpus harness's job (Arm A) plus a
+// periodic StaticKeySource sweep. Layer 2 over a trace source is a hot-state
+// sampling oracle, not a full-keyspace check.
 type TraceKeySource struct {
 	client *gethrpc.Client
 }
@@ -30,10 +39,11 @@ func NewTraceKeySource(evmRPC string) (*TraceKeySource, error) {
 }
 
 // Close releases the underlying RPC connection.
-func (t *TraceKeySource) Close() {
+func (t *TraceKeySource) Close() error {
 	if t.client != nil {
 		t.client.Close()
 	}
+	return nil
 }
 
 // prestateAccount is the subset of the prestateTracer's per-account output the
@@ -44,29 +54,39 @@ type prestateAccount struct {
 	Code    hexutil.Bytes               `json:"code"`
 }
 
-// prestateTxTrace wraps one transaction's prestate tracer result.
+// prestateResult is one transaction's diff-mode prestate output: pre-state
+// (read) and post-state (written) per account.
+type prestateResult struct {
+	Pre  map[common.Address]prestateAccount `json:"pre"`
+	Post map[common.Address]prestateAccount `json:"post"`
+}
+
+// prestateTxTrace wraps one transaction's tracer result.
 type prestateTxTrace struct {
-	Result map[common.Address]prestateAccount `json:"result"`
+	Result prestateResult `json:"result"`
 }
 
 func (t *TraceKeySource) TouchedAccounts(ctx context.Context, height int64) ([]TouchedAccount, error) {
 	var traces []prestateTxTrace
 	blockArg := hexutil.EncodeUint64(uint64(height))
-	cfg := map[string]any{"tracer": "prestateTracer"}
+	cfg := map[string]any{"tracer": "prestateTracer", "tracerConfig": map[string]any{"diffMode": true}}
 	if err := t.client.CallContext(ctx, &traces, "debug_traceBlockByNumber", blockArg, cfg); err != nil {
 		return nil, fmt.Errorf("debug_traceBlockByNumber at height %d: %w", height, err)
 	}
 	return mergePrestateTraces(traces), nil
 }
 
-// mergePrestateTraces unions the per-transaction prestate results into one
-// touched-account set per address (slots unioned; code checked when the trace
-// shows the account carries code; nonce checked for every touched account).
+// mergePrestateTraces unions the per-transaction diff-mode results into one
+// touched-account set per address: slots unioned across pre and post (reads and
+// writes), code checked when either side shows code, balance and nonce checked
+// for every touched account. Output is sorted (accounts by address, slots by
+// hash) so the same block yields a byte-reproducible report.
 func mergePrestateTraces(traces []prestateTxTrace) []TouchedAccount {
 	slots := map[common.Address]map[common.Hash]struct{}{}
 	hasCode := map[common.Address]bool{}
-	for _, tx := range traces {
-		for addr, acct := range tx.Result {
+
+	absorb := func(accts map[common.Address]prestateAccount) {
+		for addr, acct := range accts {
 			if slots[addr] == nil {
 				slots[addr] = map[common.Hash]struct{}{}
 			}
@@ -78,21 +98,27 @@ func mergePrestateTraces(traces []prestateTxTrace) []TouchedAccount {
 			}
 		}
 	}
+	for _, tx := range traces {
+		absorb(tx.Result.Pre)
+		absorb(tx.Result.Post)
+	}
 
 	out := make([]TouchedAccount, 0, len(slots))
 	for addr, slotSet := range slots {
-		ta := TouchedAccount{Addr: addr, CheckCode: hasCode[addr], CheckNonce: true}
+		ta := TouchedAccount{Addr: addr, CheckCode: hasCode[addr], CheckNonce: true, CheckBalance: true}
 		for slot := range slotSet {
 			ta.Slots = append(ta.Slots, slot)
 		}
+		sort.Slice(ta.Slots, func(i, j int) bool { return bytes.Compare(ta.Slots[i][:], ta.Slots[j][:]) < 0 })
 		out = append(out, ta)
 	}
+	sort.Slice(out, func(i, j int) bool { return bytes.Compare(out[i].Addr[:], out[j].Addr[:]) < 0 })
 	return out
 }
 
 // StaticKeySource compares a fixed, curated set of accounts on every block — the
-// fallback when prestate tracing (debug_) is unavailable. Coverage is sampled,
-// not exact; pair it with a curated hot-contract / hot-account list.
+// fallback when prestate tracing (debug_) is unavailable, and the hook for a
+// periodic cold-key / hot-contract sweep that the trace source does not cover.
 type StaticKeySource struct {
 	Accounts []TouchedAccount
 }

--- a/sidecar/shadow/keysource.go
+++ b/sidecar/shadow/keysource.go
@@ -1,0 +1,102 @@
+package shadow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+)
+
+// TraceKeySource derives a block's touched accounts and storage slots from a
+// prestate trace (debug_traceBlockByNumber with the prestateTracer) on an EVM
+// JSON-RPC endpoint. The prestate lists every account and slot the block's
+// transactions accessed — exactly the set Layer 2 should compare. Requires the
+// debug_ namespace enabled on the endpoint (a non-public, operator-owned node).
+type TraceKeySource struct {
+	client *gethrpc.Client
+}
+
+// NewTraceKeySource dials the EVM JSON-RPC endpoint used to fetch prestate
+// traces. The same touched set applies to both chains (identical transactions),
+// so a single endpoint (typically the canonical node) is sufficient.
+func NewTraceKeySource(evmRPC string) (*TraceKeySource, error) {
+	c, err := gethrpc.Dial(evmRPC)
+	if err != nil {
+		return nil, fmt.Errorf("dialing EVM RPC %q: %w", evmRPC, err)
+	}
+	return &TraceKeySource{client: c}, nil
+}
+
+// Close releases the underlying RPC connection.
+func (t *TraceKeySource) Close() {
+	if t.client != nil {
+		t.client.Close()
+	}
+}
+
+// prestateAccount is the subset of the prestateTracer's per-account output the
+// key source needs: which slots were accessed, and whether the account carries
+// code (a contract).
+type prestateAccount struct {
+	Storage map[common.Hash]common.Hash `json:"storage"`
+	Code    hexutil.Bytes               `json:"code"`
+}
+
+// prestateTxTrace wraps one transaction's prestate tracer result.
+type prestateTxTrace struct {
+	Result map[common.Address]prestateAccount `json:"result"`
+}
+
+func (t *TraceKeySource) TouchedAccounts(ctx context.Context, height int64) ([]TouchedAccount, error) {
+	var traces []prestateTxTrace
+	blockArg := hexutil.EncodeUint64(uint64(height))
+	cfg := map[string]any{"tracer": "prestateTracer"}
+	if err := t.client.CallContext(ctx, &traces, "debug_traceBlockByNumber", blockArg, cfg); err != nil {
+		return nil, fmt.Errorf("debug_traceBlockByNumber at height %d: %w", height, err)
+	}
+	return mergePrestateTraces(traces), nil
+}
+
+// mergePrestateTraces unions the per-transaction prestate results into one
+// touched-account set per address (slots unioned; code checked when the trace
+// shows the account carries code; nonce checked for every touched account).
+func mergePrestateTraces(traces []prestateTxTrace) []TouchedAccount {
+	slots := map[common.Address]map[common.Hash]struct{}{}
+	hasCode := map[common.Address]bool{}
+	for _, tx := range traces {
+		for addr, acct := range tx.Result {
+			if slots[addr] == nil {
+				slots[addr] = map[common.Hash]struct{}{}
+			}
+			for slot := range acct.Storage {
+				slots[addr][slot] = struct{}{}
+			}
+			if len(acct.Code) > 0 {
+				hasCode[addr] = true
+			}
+		}
+	}
+
+	out := make([]TouchedAccount, 0, len(slots))
+	for addr, slotSet := range slots {
+		ta := TouchedAccount{Addr: addr, CheckCode: hasCode[addr], CheckNonce: true}
+		for slot := range slotSet {
+			ta.Slots = append(ta.Slots, slot)
+		}
+		out = append(out, ta)
+	}
+	return out
+}
+
+// StaticKeySource compares a fixed, curated set of accounts on every block — the
+// fallback when prestate tracing (debug_) is unavailable. Coverage is sampled,
+// not exact; pair it with a curated hot-contract / hot-account list.
+type StaticKeySource struct {
+	Accounts []TouchedAccount
+}
+
+func (s StaticKeySource) TouchedAccounts(_ context.Context, _ int64) ([]TouchedAccount, error) {
+	return s.Accounts, nil
+}

--- a/sidecar/shadow/keysource.go
+++ b/sidecar/shadow/keysource.go
@@ -38,12 +38,13 @@ func NewTraceKeySource(evmRPC string) (*TraceKeySource, error) {
 	return &TraceKeySource{client: c}, nil
 }
 
-// Close releases the underlying RPC connection.
-func (t *TraceKeySource) Close() error {
+// Close releases the underlying RPC connection. No return value, matching
+// go-ethereum's *ethclient.Client / *rpc.Client Close() so Comparator.Close can
+// treat all closeables uniformly.
+func (t *TraceKeySource) Close() {
 	if t.client != nil {
 		t.client.Close()
 	}
-	return nil
 }
 
 // prestateAccount is the subset of the prestateTracer's per-account output the

--- a/sidecar/shadow/keysource_test.go
+++ b/sidecar/shadow/keysource_test.go
@@ -8,29 +8,31 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// A realistic debug_traceBlockByNumber prestateTracer response: an array with
-// one entry per transaction, each {result: {address: {balance,nonce,code,storage}}}.
+// A realistic diff-mode debug_traceBlockByNumber response: an array with one
+// entry per transaction, each {result: {pre: {...}, post: {...}}}. The union of
+// pre (read) and post (written) slots is the touched set.
 const samplePrestateJSON = `[
   {"result": {
-    "0x00000000000000000000000000000000000000aa": {
-      "balance": "0x1", "nonce": 7,
-      "storage": {
-        "0x0000000000000000000000000000000000000000000000000000000000000001": "0x000000000000000000000000000000000000000000000000000000000000002a",
-        "0x0000000000000000000000000000000000000000000000000000000000000002": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    "pre": {
+      "0x00000000000000000000000000000000000000aa": {
+        "balance": "0x1", "nonce": 7,
+        "storage": {
+          "0x0000000000000000000000000000000000000000000000000000000000000001": "0x000000000000000000000000000000000000000000000000000000000000002a",
+          "0x0000000000000000000000000000000000000000000000000000000000000002": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      },
+      "0x00000000000000000000000000000000000000bb": {
+        "balance": "0x0", "code": "0x6060604052",
+        "storage": {
+          "0x0000000000000000000000000000000000000000000000000000000000000005": "0x0000000000000000000000000000000000000000000000000000000000000007"
+        }
       }
     },
-    "0x00000000000000000000000000000000000000bb": {
-      "balance": "0x0", "code": "0x6060604052",
-      "storage": {
-        "0x0000000000000000000000000000000000000000000000000000000000000005": "0x0000000000000000000000000000000000000000000000000000000000000007"
-      }
-    }
-  }},
-  {"result": {
-    "0x00000000000000000000000000000000000000aa": {
-      "balance": "0x1",
-      "storage": {
-        "0x0000000000000000000000000000000000000000000000000000000000000003": "0x0000000000000000000000000000000000000000000000000000000000000009"
+    "post": {
+      "0x00000000000000000000000000000000000000aa": {
+        "storage": {
+          "0x0000000000000000000000000000000000000000000000000000000000000003": "0x0000000000000000000000000000000000000000000000000000000000000009"
+        }
       }
     }
   }}
@@ -55,15 +57,15 @@ func TestMergePrestateTraces(t *testing.T) {
 	if !ok {
 		t.Fatal("missing account aa")
 	}
-	// aa's slots unioned across both txs: 0x01, 0x02, 0x03.
+	// aa's slots unioned across pre (0x01, 0x02) and post (0x03) = 3.
 	if len(aa.Slots) != 3 {
 		t.Errorf("aa slots = %d, want 3 (%v)", len(aa.Slots), aa.Slots)
 	}
 	if aa.CheckCode {
 		t.Error("aa has no code; CheckCode should be false")
 	}
-	if !aa.CheckNonce {
-		t.Error("every touched account should check nonce")
+	if !aa.CheckNonce || !aa.CheckBalance {
+		t.Error("every touched account should check nonce and balance")
 	}
 
 	bb, ok := byAddr[addrBB]
@@ -75,6 +77,28 @@ func TestMergePrestateTraces(t *testing.T) {
 	}
 	if len(bb.Slots) != 1 {
 		t.Errorf("bb slots = %d, want 1", len(bb.Slots))
+	}
+}
+
+// mergePrestateTraces output must be sorted (accounts by address, slots by hash)
+// so the same block renders a byte-reproducible report.
+func TestMergePrestateTraces_Sorted(t *testing.T) {
+	var traces []prestateTxTrace
+	if err := json.Unmarshal([]byte(samplePrestateJSON), &traces); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	touched := mergePrestateTraces(traces)
+	for i := 1; i < len(touched); i++ {
+		if common.Bytes2Hex(touched[i-1].Addr[:]) > common.Bytes2Hex(touched[i].Addr[:]) {
+			t.Errorf("accounts not sorted: %s before %s", touched[i-1].Addr.Hex(), touched[i].Addr.Hex())
+		}
+	}
+	for _, ta := range touched {
+		for i := 1; i < len(ta.Slots); i++ {
+			if common.Bytes2Hex(ta.Slots[i-1][:]) > common.Bytes2Hex(ta.Slots[i][:]) {
+				t.Errorf("slots not sorted for %s", ta.Addr.Hex())
+			}
+		}
 	}
 }
 

--- a/sidecar/shadow/keysource_test.go
+++ b/sidecar/shadow/keysource_test.go
@@ -1,0 +1,91 @@
+package shadow
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// A realistic debug_traceBlockByNumber prestateTracer response: an array with
+// one entry per transaction, each {result: {address: {balance,nonce,code,storage}}}.
+const samplePrestateJSON = `[
+  {"result": {
+    "0x00000000000000000000000000000000000000aa": {
+      "balance": "0x1", "nonce": 7,
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000001": "0x000000000000000000000000000000000000000000000000000000000000002a",
+        "0x0000000000000000000000000000000000000000000000000000000000000002": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "0x00000000000000000000000000000000000000bb": {
+      "balance": "0x0", "code": "0x6060604052",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000005": "0x0000000000000000000000000000000000000000000000000000000000000007"
+      }
+    }
+  }},
+  {"result": {
+    "0x00000000000000000000000000000000000000aa": {
+      "balance": "0x1",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000003": "0x0000000000000000000000000000000000000000000000000000000000000009"
+      }
+    }
+  }}
+]`
+
+func TestMergePrestateTraces(t *testing.T) {
+	var traces []prestateTxTrace
+	if err := json.Unmarshal([]byte(samplePrestateJSON), &traces); err != nil {
+		t.Fatalf("unmarshal prestate: %v", err)
+	}
+
+	touched := mergePrestateTraces(traces)
+	byAddr := map[common.Address]TouchedAccount{}
+	for _, ta := range touched {
+		byAddr[ta.Addr] = ta
+	}
+
+	addrAA := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	addrBB := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+
+	aa, ok := byAddr[addrAA]
+	if !ok {
+		t.Fatal("missing account aa")
+	}
+	// aa's slots unioned across both txs: 0x01, 0x02, 0x03.
+	if len(aa.Slots) != 3 {
+		t.Errorf("aa slots = %d, want 3 (%v)", len(aa.Slots), aa.Slots)
+	}
+	if aa.CheckCode {
+		t.Error("aa has no code; CheckCode should be false")
+	}
+	if !aa.CheckNonce {
+		t.Error("every touched account should check nonce")
+	}
+
+	bb, ok := byAddr[addrBB]
+	if !ok {
+		t.Fatal("missing account bb")
+	}
+	if !bb.CheckCode {
+		t.Error("bb carries code; CheckCode should be true")
+	}
+	if len(bb.Slots) != 1 {
+		t.Errorf("bb slots = %d, want 1", len(bb.Slots))
+	}
+}
+
+func TestStaticKeySource(t *testing.T) {
+	want := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}, CheckNonce: true}}
+	src := StaticKeySource{Accounts: want}
+	got, err := src.TouchedAccounts(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("TouchedAccounts: %v", err)
+	}
+	if len(got) != 1 || got[0].Addr != testAddr {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}

--- a/sidecar/shadow/layer2.go
+++ b/sidecar/shadow/layer2.go
@@ -1,0 +1,118 @@
+package shadow
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// StateReader reads logical EVM state at a height. Its method set matches
+// go-ethereum's *ethclient.Client, so a real client satisfies it directly; the
+// shadow and canonical sides are two instances. A nil blockNumber means latest.
+type StateReader interface {
+	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
+	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
+	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
+}
+
+// TouchedAccount is the set of state a block touched for one address: the
+// storage slots to compare, and whether the account's code and nonce should be
+// checked. A KeySource produces these per block (e.g. from a prestate trace).
+type TouchedAccount struct {
+	Addr       common.Address
+	Slots      []common.Hash
+	CheckCode  bool
+	CheckNonce bool
+}
+
+// KeySource yields the accounts (and their slots) a block touched, so Layer 2
+// compares exactly the state real transactions read or wrote at that height.
+type KeySource interface {
+	TouchedAccounts(ctx context.Context, height int64) ([]TouchedAccount, error)
+}
+
+// compareState reads each touched key's logical value from both chains at the
+// given height and records every mismatch. It fails closed: a read error on any
+// key aborts with that error rather than reporting a partial (and so falsely
+// clean) result.
+func compareState(ctx context.Context, height int64, touched []TouchedAccount, shadow, canonical StateReader) (*Layer2Result, error) {
+	blockNum := big.NewInt(height)
+	res := &Layer2Result{}
+
+	for _, acct := range touched {
+		res.AccountsChecked++
+
+		for _, slot := range acct.Slots {
+			res.KeysChecked++
+			s, err := shadow.StorageAt(ctx, acct.Addr, slot, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("shadow storage %s/%s: %w", acct.Addr.Hex(), slot.Hex(), err)
+			}
+			c, err := canonical.StorageAt(ctx, acct.Addr, slot, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("canonical storage %s/%s: %w", acct.Addr.Hex(), slot.Hex(), err)
+			}
+			if !bytes.Equal(leftPad32(s), leftPad32(c)) {
+				res.Divergences = append(res.Divergences, StateDivergence{
+					Kind: "storage", Addr: acct.Addr.Hex(), Slot: slot.Hex(),
+					Shadow: hexStr(s), Canonical: hexStr(c),
+				})
+			}
+		}
+
+		if acct.CheckCode {
+			res.KeysChecked++
+			s, err := shadow.CodeAt(ctx, acct.Addr, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("shadow code %s: %w", acct.Addr.Hex(), err)
+			}
+			c, err := canonical.CodeAt(ctx, acct.Addr, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("canonical code %s: %w", acct.Addr.Hex(), err)
+			}
+			if !bytes.Equal(s, c) {
+				res.Divergences = append(res.Divergences, StateDivergence{
+					Kind: "code", Addr: acct.Addr.Hex(), Shadow: hexStr(s), Canonical: hexStr(c),
+				})
+			}
+		}
+
+		if acct.CheckNonce {
+			res.KeysChecked++
+			s, err := shadow.NonceAt(ctx, acct.Addr, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("shadow nonce %s: %w", acct.Addr.Hex(), err)
+			}
+			c, err := canonical.NonceAt(ctx, acct.Addr, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("canonical nonce %s: %w", acct.Addr.Hex(), err)
+			}
+			if s != c {
+				res.Divergences = append(res.Divergences, StateDivergence{
+					Kind: "nonce", Addr: acct.Addr.Hex(),
+					Shadow: fmt.Sprintf("%d", s), Canonical: fmt.Sprintf("%d", c),
+				})
+			}
+		}
+	}
+
+	return res, nil
+}
+
+// leftPad32 normalizes a storage value to 32 big-endian bytes so a trimmed RPC
+// result compares equal to a zero-padded one. Values longer than 32 bytes are
+// returned unchanged so the mismatch surfaces.
+func leftPad32(b []byte) []byte {
+	if len(b) >= 32 {
+		return b
+	}
+	out := make([]byte, 32)
+	copy(out[32-len(b):], b)
+	return out
+}
+
+func hexStr(b []byte) string { return "0x" + hex.EncodeToString(b) }

--- a/sidecar/shadow/layer2.go
+++ b/sidecar/shadow/layer2.go
@@ -3,11 +3,11 @@ package shadow
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 // StateReader reads logical EVM state at a height. Its method set matches
@@ -17,16 +17,18 @@ type StateReader interface {
 	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
 	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
+	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 }
 
 // TouchedAccount is the set of state a block touched for one address: the
-// storage slots to compare, and whether the account's code and nonce should be
-// checked. A KeySource produces these per block (e.g. from a prestate trace).
+// storage slots to compare, and whether the account's balance, code, and nonce
+// should be checked. A KeySource produces these per block (e.g. from a trace).
 type TouchedAccount struct {
-	Addr       common.Address
-	Slots      []common.Hash
-	CheckCode  bool
-	CheckNonce bool
+	Addr         common.Address
+	Slots        []common.Hash
+	CheckCode    bool
+	CheckNonce   bool
+	CheckBalance bool
 }
 
 // KeySource yields the accounts (and their slots) a block touched, so Layer 2
@@ -56,10 +58,27 @@ func compareState(ctx context.Context, height int64, touched []TouchedAccount, s
 			if err != nil {
 				return nil, fmt.Errorf("canonical storage %s/%s: %w", acct.Addr.Hex(), slot.Hex(), err)
 			}
-			if !bytes.Equal(leftPad32(s), leftPad32(c)) {
+			if !bytes.Equal(common.LeftPadBytes(s, 32), common.LeftPadBytes(c, 32)) {
 				res.Divergences = append(res.Divergences, StateDivergence{
 					Kind: "storage", Addr: acct.Addr.Hex(), Slot: slot.Hex(),
-					Shadow: hexStr(s), Canonical: hexStr(c),
+					Shadow: hexutil.Encode(s), Canonical: hexutil.Encode(c),
+				})
+			}
+		}
+
+		if acct.CheckBalance {
+			res.KeysChecked++
+			s, err := shadow.BalanceAt(ctx, acct.Addr, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("shadow balance %s: %w", acct.Addr.Hex(), err)
+			}
+			c, err := canonical.BalanceAt(ctx, acct.Addr, blockNum)
+			if err != nil {
+				return nil, fmt.Errorf("canonical balance %s: %w", acct.Addr.Hex(), err)
+			}
+			if s.Cmp(c) != 0 {
+				res.Divergences = append(res.Divergences, StateDivergence{
+					Kind: "balance", Addr: acct.Addr.Hex(), Shadow: s.String(), Canonical: c.String(),
 				})
 			}
 		}
@@ -76,7 +95,7 @@ func compareState(ctx context.Context, height int64, touched []TouchedAccount, s
 			}
 			if !bytes.Equal(s, c) {
 				res.Divergences = append(res.Divergences, StateDivergence{
-					Kind: "code", Addr: acct.Addr.Hex(), Shadow: hexStr(s), Canonical: hexStr(c),
+					Kind: "code", Addr: acct.Addr.Hex(), Shadow: hexutil.Encode(s), Canonical: hexutil.Encode(c),
 				})
 			}
 		}
@@ -102,17 +121,3 @@ func compareState(ctx context.Context, height int64, touched []TouchedAccount, s
 
 	return res, nil
 }
-
-// leftPad32 normalizes a storage value to 32 big-endian bytes so a trimmed RPC
-// result compares equal to a zero-padded one. Values longer than 32 bytes are
-// returned unchanged so the mismatch surfaces.
-func leftPad32(b []byte) []byte {
-	if len(b) >= 32 {
-		return b
-	}
-	out := make([]byte, 32)
-	copy(out[32-len(b):], b)
-	return out
-}
-
-func hexStr(b []byte) string { return "0x" + hex.EncodeToString(b) }

--- a/sidecar/shadow/layer2_test.go
+++ b/sidecar/shadow/layer2_test.go
@@ -1,0 +1,196 @@
+package shadow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/sei-protocol/seictl/sidecar/rpc"
+)
+
+// mockKeySource returns a fixed set of touched accounts (or an error).
+type mockKeySource struct {
+	accts []TouchedAccount
+	err   error
+}
+
+func (m mockKeySource) TouchedAccounts(_ context.Context, _ int64) ([]TouchedAccount, error) {
+	return m.accts, m.err
+}
+
+// mockState is a controllable StateReader: maps hold the value each side returns
+// for a key, errOn forces a read error for a kind so the fail-closed path can be
+// exercised.
+type mockState struct {
+	storage map[string][]byte // addr.Hex()|slot.Hex() -> value
+	code    map[string][]byte // addr.Hex() -> bytecode
+	nonce   map[string]uint64 // addr.Hex() -> nonce
+	errOn   string            // "storage" | "code" | "nonce"
+}
+
+func newMockState() *mockState {
+	return &mockState{
+		storage: map[string][]byte{},
+		code:    map[string][]byte{},
+		nonce:   map[string]uint64{},
+	}
+}
+
+func (m *mockState) StorageAt(_ context.Context, account common.Address, key common.Hash, _ *big.Int) ([]byte, error) {
+	if m.errOn == "storage" {
+		return nil, errors.New("injected storage error")
+	}
+	return m.storage[account.Hex()+"|"+key.Hex()], nil
+}
+
+func (m *mockState) CodeAt(_ context.Context, account common.Address, _ *big.Int) ([]byte, error) {
+	if m.errOn == "code" {
+		return nil, errors.New("injected code error")
+	}
+	return m.code[account.Hex()], nil
+}
+
+func (m *mockState) NonceAt(_ context.Context, account common.Address, _ *big.Int) (uint64, error) {
+	if m.errOn == "nonce" {
+		return 0, errors.New("injected nonce error")
+	}
+	return m.nonce[account.Hex()], nil
+}
+
+var (
+	testAddr = common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	testSlot = common.HexToHash("0x01")
+)
+
+func storageKey(a common.Address, s common.Hash) string { return a.Hex() + "|" + s.Hex() }
+
+func TestCompareState_AllMatch(t *testing.T) {
+	shadow, canonical := newMockState(), newMockState()
+	shadow.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x2a})
+	canonical.storage[storageKey(testAddr, testSlot)] = []byte{0x2a} // trimmed; must normalize-equal
+	shadow.code[testAddr.Hex()] = []byte{0x60, 0x60}
+	canonical.code[testAddr.Hex()] = []byte{0x60, 0x60}
+	shadow.nonce[testAddr.Hex()] = 5
+	canonical.nonce[testAddr.Hex()] = 5
+
+	touched := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}, CheckCode: true, CheckNonce: true}}
+	res, err := compareState(context.Background(), 100, touched, shadow, canonical)
+	if err != nil {
+		t.Fatalf("compareState: %v", err)
+	}
+	if len(res.Divergences) != 0 {
+		t.Errorf("expected no divergences, got %+v", res.Divergences)
+	}
+	if res.AccountsChecked != 1 || res.KeysChecked != 3 {
+		t.Errorf("counts: accounts=%d keys=%d, want 1/3", res.AccountsChecked, res.KeysChecked)
+	}
+}
+
+func TestCompareState_Mismatches(t *testing.T) {
+	shadow, canonical := newMockState(), newMockState()
+	shadow.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x2a})
+	canonical.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x2b}) // storage differs
+	shadow.code[testAddr.Hex()] = []byte{0x60}
+	canonical.code[testAddr.Hex()] = []byte{0x61} // code differs
+	shadow.nonce[testAddr.Hex()] = 7
+	canonical.nonce[testAddr.Hex()] = 8 // nonce differs
+
+	touched := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}, CheckCode: true, CheckNonce: true}}
+	res, err := compareState(context.Background(), 100, touched, shadow, canonical)
+	if err != nil {
+		t.Fatalf("compareState: %v", err)
+	}
+	if len(res.Divergences) != 3 {
+		t.Fatalf("expected 3 divergences, got %d: %+v", len(res.Divergences), res.Divergences)
+	}
+	kinds := map[string]bool{}
+	for _, d := range res.Divergences {
+		kinds[d.Kind] = true
+		if d.Addr != testAddr.Hex() {
+			t.Errorf("divergence addr = %s, want %s", d.Addr, testAddr.Hex())
+		}
+	}
+	for _, want := range []string{"storage", "code", "nonce"} {
+		if !kinds[want] {
+			t.Errorf("missing %s divergence", want)
+		}
+	}
+}
+
+func TestCompareState_FailsClosed(t *testing.T) {
+	shadow, canonical := newMockState(), newMockState()
+	canonical.errOn = "storage"
+	touched := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}}}
+	if _, err := compareState(context.Background(), 100, touched, shadow, canonical); err == nil {
+		t.Error("expected fail-closed error when a side cannot be read")
+	}
+}
+
+// End-to-end through CompareBlock: migration mode (AppHash expected to differ),
+// Layer 1 receipts match, but Layer 2 logical state diverges -> DivergenceLayer 2.
+func TestCompareBlock_Layer2_StateDivergence(t *testing.T) {
+	txs := []rpc.TxResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200", Log: "ok", Events: json.RawMessage(`[]`)},
+	}
+	shadowSrv := rpcServer("SHADOW_APPHASH", "SAME_RESULTS", txs)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CANON_APPHASH", "SAME_RESULTS", txs)
+	defer canonicalSrv.Close()
+
+	shadowState, canonState := newMockState(), newMockState()
+	shadowState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x01})
+	canonState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x02})
+	ks := mockKeySource{accts: []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}}}}
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL,
+		WithMigrationMode(), WithLayer2(shadowState, canonState, ks))
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Match {
+		t.Error("expected divergence: Layer 2 logical state differs")
+	}
+	if result.DivergenceLayer == nil || *result.DivergenceLayer != 2 {
+		t.Errorf("expected divergence layer 2, got %v", result.DivergenceLayer)
+	}
+	if result.Layer2 == nil || len(result.Layer2.Divergences) != 1 {
+		t.Errorf("expected 1 Layer2 divergence, got %+v", result.Layer2)
+	}
+}
+
+// When Layer 2 logical state matches, a migration shadow is a clean match even
+// though its AppHash differs (Layer 0) by design.
+func TestCompareBlock_Layer2_CleanMatch(t *testing.T) {
+	txs := []rpc.TxResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200", Log: "ok", Events: json.RawMessage(`[]`)},
+	}
+	shadowSrv := rpcServer("SHADOW_APPHASH", "SAME_RESULTS", txs)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CANON_APPHASH", "SAME_RESULTS", txs)
+	defer canonicalSrv.Close()
+
+	shadowState, canonState := newMockState(), newMockState()
+	shadowState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x42})
+	canonState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x42})
+	ks := mockKeySource{accts: []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}}}}
+
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL,
+		WithMigrationMode(), WithLayer2(shadowState, canonState, ks))
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if !result.Match {
+		t.Errorf("expected clean match, got divergence at layer %v", result.DivergenceLayer)
+	}
+	if result.Layer2 == nil || result.Layer2.AccountsChecked != 1 {
+		t.Errorf("expected Layer2 populated with 1 account checked, got %+v", result.Layer2)
+	}
+}

--- a/sidecar/shadow/layer2_test.go
+++ b/sidecar/shadow/layer2_test.go
@@ -26,10 +26,11 @@ func (m mockKeySource) TouchedAccounts(_ context.Context, _ int64) ([]TouchedAcc
 // for a key, errOn forces a read error for a kind so the fail-closed path can be
 // exercised.
 type mockState struct {
-	storage map[string][]byte // addr.Hex()|slot.Hex() -> value
-	code    map[string][]byte // addr.Hex() -> bytecode
-	nonce   map[string]uint64 // addr.Hex() -> nonce
-	errOn   string            // "storage" | "code" | "nonce"
+	storage map[string][]byte   // addr.Hex()|slot.Hex() -> value
+	code    map[string][]byte   // addr.Hex() -> bytecode
+	nonce   map[string]uint64   // addr.Hex() -> nonce
+	balance map[string]*big.Int // addr.Hex() -> balance
+	errOn   string              // "storage" | "code" | "nonce" | "balance"
 }
 
 func newMockState() *mockState {
@@ -37,6 +38,7 @@ func newMockState() *mockState {
 		storage: map[string][]byte{},
 		code:    map[string][]byte{},
 		nonce:   map[string]uint64{},
+		balance: map[string]*big.Int{},
 	}
 }
 
@@ -61,6 +63,16 @@ func (m *mockState) NonceAt(_ context.Context, account common.Address, _ *big.In
 	return m.nonce[account.Hex()], nil
 }
 
+func (m *mockState) BalanceAt(_ context.Context, account common.Address, _ *big.Int) (*big.Int, error) {
+	if m.errOn == "balance" {
+		return nil, errors.New("injected balance error")
+	}
+	if b, ok := m.balance[account.Hex()]; ok {
+		return b, nil
+	}
+	return big.NewInt(0), nil
+}
+
 var (
 	testAddr = common.HexToAddress("0x00000000000000000000000000000000000000aa")
 	testSlot = common.HexToHash("0x01")
@@ -68,16 +80,20 @@ var (
 
 func storageKey(a common.Address, s common.Hash) string { return a.Hex() + "|" + s.Hex() }
 
+func pad32(b []byte) []byte { return common.LeftPadBytes(b, 32) }
+
 func TestCompareState_AllMatch(t *testing.T) {
 	shadow, canonical := newMockState(), newMockState()
-	shadow.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x2a})
+	shadow.storage[storageKey(testAddr, testSlot)] = pad32([]byte{0x2a})
 	canonical.storage[storageKey(testAddr, testSlot)] = []byte{0x2a} // trimmed; must normalize-equal
 	shadow.code[testAddr.Hex()] = []byte{0x60, 0x60}
 	canonical.code[testAddr.Hex()] = []byte{0x60, 0x60}
 	shadow.nonce[testAddr.Hex()] = 5
 	canonical.nonce[testAddr.Hex()] = 5
+	shadow.balance[testAddr.Hex()] = big.NewInt(1000)
+	canonical.balance[testAddr.Hex()] = big.NewInt(1000)
 
-	touched := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}, CheckCode: true, CheckNonce: true}}
+	touched := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}, CheckCode: true, CheckNonce: true, CheckBalance: true}}
 	res, err := compareState(context.Background(), 100, touched, shadow, canonical)
 	if err != nil {
 		t.Fatalf("compareState: %v", err)
@@ -85,27 +101,29 @@ func TestCompareState_AllMatch(t *testing.T) {
 	if len(res.Divergences) != 0 {
 		t.Errorf("expected no divergences, got %+v", res.Divergences)
 	}
-	if res.AccountsChecked != 1 || res.KeysChecked != 3 {
-		t.Errorf("counts: accounts=%d keys=%d, want 1/3", res.AccountsChecked, res.KeysChecked)
+	if res.AccountsChecked != 1 || res.KeysChecked != 4 {
+		t.Errorf("counts: accounts=%d keys=%d, want 1/4", res.AccountsChecked, res.KeysChecked)
 	}
 }
 
 func TestCompareState_Mismatches(t *testing.T) {
 	shadow, canonical := newMockState(), newMockState()
-	shadow.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x2a})
-	canonical.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x2b}) // storage differs
+	shadow.storage[storageKey(testAddr, testSlot)] = pad32([]byte{0x2a})
+	canonical.storage[storageKey(testAddr, testSlot)] = pad32([]byte{0x2b}) // storage differs
 	shadow.code[testAddr.Hex()] = []byte{0x60}
 	canonical.code[testAddr.Hex()] = []byte{0x61} // code differs
 	shadow.nonce[testAddr.Hex()] = 7
 	canonical.nonce[testAddr.Hex()] = 8 // nonce differs
+	shadow.balance[testAddr.Hex()] = big.NewInt(1)
+	canonical.balance[testAddr.Hex()] = big.NewInt(2) // balance differs
 
-	touched := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}, CheckCode: true, CheckNonce: true}}
+	touched := []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}, CheckCode: true, CheckNonce: true, CheckBalance: true}}
 	res, err := compareState(context.Background(), 100, touched, shadow, canonical)
 	if err != nil {
 		t.Fatalf("compareState: %v", err)
 	}
-	if len(res.Divergences) != 3 {
-		t.Fatalf("expected 3 divergences, got %d: %+v", len(res.Divergences), res.Divergences)
+	if len(res.Divergences) != 4 {
+		t.Fatalf("expected 4 divergences, got %d: %+v", len(res.Divergences), res.Divergences)
 	}
 	kinds := map[string]bool{}
 	for _, d := range res.Divergences {
@@ -114,7 +132,7 @@ func TestCompareState_Mismatches(t *testing.T) {
 			t.Errorf("divergence addr = %s, want %s", d.Addr, testAddr.Hex())
 		}
 	}
-	for _, want := range []string{"storage", "code", "nonce"} {
+	for _, want := range []string{"storage", "balance", "code", "nonce"} {
 		if !kinds[want] {
 			t.Errorf("missing %s divergence", want)
 		}
@@ -142,8 +160,8 @@ func TestCompareBlock_Layer2_StateDivergence(t *testing.T) {
 	defer canonicalSrv.Close()
 
 	shadowState, canonState := newMockState(), newMockState()
-	shadowState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x01})
-	canonState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x02})
+	shadowState.storage[storageKey(testAddr, testSlot)] = pad32([]byte{0x01})
+	canonState.storage[storageKey(testAddr, testSlot)] = pad32([]byte{0x02})
 	ks := mockKeySource{accts: []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}}}}
 
 	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL,
@@ -176,8 +194,8 @@ func TestCompareBlock_Layer2_CleanMatch(t *testing.T) {
 	defer canonicalSrv.Close()
 
 	shadowState, canonState := newMockState(), newMockState()
-	shadowState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x42})
-	canonState.storage[storageKey(testAddr, testSlot)] = leftPad32([]byte{0x42})
+	shadowState.storage[storageKey(testAddr, testSlot)] = pad32([]byte{0x42})
+	canonState.storage[storageKey(testAddr, testSlot)] = pad32([]byte{0x42})
 	ks := mockKeySource{accts: []TouchedAccount{{Addr: testAddr, Slots: []common.Hash{testSlot}}}}
 
 	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL,
@@ -192,5 +210,35 @@ func TestCompareBlock_Layer2_CleanMatch(t *testing.T) {
 	}
 	if result.Layer2 == nil || result.Layer2.AccountsChecked != 1 {
 		t.Errorf("expected Layer2 populated with 1 account checked, got %+v", result.Layer2)
+	}
+}
+
+// A Layer 2 that cannot run (key-source error) must NOT be a silent clean pass:
+// it is marked indeterminate and forces a divergence at layer 2 (fail-closed).
+func TestCompareBlock_Layer2_IndeterminateFailsClosed(t *testing.T) {
+	txs := []rpc.TxResult{
+		{Code: 0, GasUsed: "100", GasWanted: "200", Log: "ok", Events: json.RawMessage(`[]`)},
+	}
+	shadowSrv := rpcServer("SHADOW_APPHASH", "SAME_RESULTS", txs)
+	defer shadowSrv.Close()
+	canonicalSrv := rpcServer("CANON_APPHASH", "SAME_RESULTS", txs)
+	defer canonicalSrv.Close()
+
+	ks := mockKeySource{err: errors.New("trace endpoint unavailable")}
+	comp := NewComparator(shadowSrv.URL, canonicalSrv.URL,
+		WithMigrationMode(), WithLayer2(newMockState(), newMockState(), ks))
+	result, err := comp.CompareBlock(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("CompareBlock: %v", err)
+	}
+
+	if result.Match {
+		t.Error("expected NOT clean: Layer 2 could not run, must fail closed")
+	}
+	if result.DivergenceLayer == nil || *result.DivergenceLayer != 2 {
+		t.Errorf("expected divergence layer 2, got %v", result.DivergenceLayer)
+	}
+	if result.Layer2 == nil || !result.Layer2.Indeterminate {
+		t.Errorf("expected Layer2 marked indeterminate, got %+v", result.Layer2)
 	}
 }

--- a/sidecar/shadow/render.go
+++ b/sidecar/shadow/render.go
@@ -72,6 +72,10 @@ func writeL0GasRow(b *strings.Builder, l0 Layer0Result) {
 
 func writeLayer1(b *strings.Builder, l1 *Layer1Result) {
 	fmt.Fprintf(b, "## Layer 1: Transaction Receipt Comparison\n\n")
+	if l1.Indeterminate {
+		fmt.Fprintf(b, "**Indeterminate** — receipt comparison could not run, so this block is not validated: %s\n\n", l1.Error)
+		return
+	}
 	fmt.Fprintf(b, "**Total transactions:** %d\n", l1.TotalTxs)
 
 	if !l1.TxCountMatch {

--- a/sidecar/shadow/render.go
+++ b/sidecar/shadow/render.go
@@ -87,6 +87,10 @@ func writeLayer1(b *strings.Builder, l1 *Layer1Result) {
 
 func writeLayer2(b *strings.Builder, l2 *Layer2Result) {
 	fmt.Fprintf(b, "## Layer 2: Logical State Comparison\n\n")
+	if l2.Indeterminate {
+		fmt.Fprintf(b, "**Indeterminate** — the logical state check could not run, so this block is not validated: %s\n\n", l2.Error)
+		return
+	}
 	fmt.Fprintf(b, "**Accounts checked:** %d &nbsp;&nbsp; **Keys checked:** %d\n", l2.AccountsChecked, l2.KeysChecked)
 	fmt.Fprintf(b, "**Divergent keys:** %d\n\n", len(l2.Divergences))
 

--- a/sidecar/shadow/render.go
+++ b/sidecar/shadow/render.go
@@ -18,6 +18,10 @@ func RenderMarkdown(r *DivergenceReport) string {
 		writeLayer1(&b, r.Comparison.Layer1)
 	}
 
+	if r.Comparison.Layer2 != nil {
+		writeLayer2(&b, r.Comparison.Layer2)
+	}
+
 	writeRawDataNote(&b, r.Height)
 	return b.String()
 }
@@ -79,6 +83,29 @@ func writeLayer1(b *strings.Builder, l1 *Layer1Result) {
 	for _, div := range l1.Divergences {
 		writeTxDivergence(b, div)
 	}
+}
+
+func writeLayer2(b *strings.Builder, l2 *Layer2Result) {
+	fmt.Fprintf(b, "## Layer 2: Logical State Comparison\n\n")
+	fmt.Fprintf(b, "**Accounts checked:** %d &nbsp;&nbsp; **Keys checked:** %d\n", l2.AccountsChecked, l2.KeysChecked)
+	fmt.Fprintf(b, "**Divergent keys:** %d\n\n", len(l2.Divergences))
+
+	if len(l2.Divergences) == 0 {
+		return
+	}
+
+	fmt.Fprintf(b, "| Kind | Address | Slot | Shadow | Canonical |\n")
+	fmt.Fprintf(b, "|------|---------|------|--------|----------|\n")
+	for _, d := range l2.Divergences {
+		slot := d.Slot
+		if slot == "" {
+			slot = "—"
+		}
+		fmt.Fprintf(b, "| %s | %s | %s | %s | %s |\n",
+			d.Kind, truncateHash(d.Addr), truncateHash(slot),
+			truncateHash(d.Shadow), truncateHash(d.Canonical))
+	}
+	fmt.Fprintf(b, "\n")
 }
 
 func writeTxDivergence(b *strings.Builder, div TxDivergence) {

--- a/sidecar/shadow/render_layer2_test.go
+++ b/sidecar/shadow/render_layer2_test.go
@@ -1,0 +1,41 @@
+package shadow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdown_Layer2(t *testing.T) {
+	layer := 2
+	report := &DivergenceReport{
+		Height:    1000,
+		Timestamp: "2026-06-17T00:00:00Z",
+		Comparison: CompareResult{
+			Height:          1000,
+			Match:           false,
+			MigrationMode:   true,
+			DivergenceLayer: &layer,
+			Layer2: &Layer2Result{
+				AccountsChecked: 3,
+				KeysChecked:     12,
+				Divergences: []StateDivergence{
+					{Kind: "storage", Addr: "0xabc", Slot: "0x01", Shadow: "0x2a", Canonical: "0x2b"},
+					{Kind: "nonce", Addr: "0xdef", Shadow: "7", Canonical: "8"},
+				},
+			},
+		},
+	}
+
+	md := RenderMarkdown(report)
+	for _, want := range []string{
+		"## Layer 2: Logical State Comparison",
+		"Accounts checked:",
+		"Divergent keys:",
+		"storage",
+		"nonce",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("rendered report missing %q\n---\n%s", want, md)
+		}
+	}
+}

--- a/sidecar/shadow/types.go
+++ b/sidecar/shadow/types.go
@@ -87,6 +87,12 @@ type Layer1Result struct {
 
 	// Divergences lists the per-transaction differences found.
 	Divergences []TxDivergence `json:"divergences,omitempty"`
+
+	// Indeterminate is set when the receipt comparison could not run (RPC error).
+	// In migration mode Layer 1 is a load-bearing check, so an indeterminate
+	// Layer 1 forces the block to fail closed rather than pass silently.
+	Indeterminate bool   `json:"indeterminate,omitempty"`
+	Error         string `json:"error,omitempty"`
 }
 
 // TxDivergence records a mismatch for a single transaction within a block.

--- a/sidecar/shadow/types.go
+++ b/sidecar/shadow/types.go
@@ -114,11 +114,17 @@ type Layer2Result struct {
 	AccountsChecked int `json:"accountsChecked"`
 
 	// KeysChecked is the number of individual state reads compared (storage
-	// slots plus per-account code/nonce checks).
+	// slots plus per-account balance/code/nonce checks).
 	KeysChecked int `json:"keysChecked"`
 
 	// Divergences lists the logical-state mismatches found.
 	Divergences []StateDivergence `json:"divergences,omitempty"`
+
+	// Indeterminate is set when the layer could not be evaluated (a key source
+	// or state read failed). A migration shadow's load-bearing check could not
+	// run, so the block must NOT be counted clean — Error carries the cause.
+	Indeterminate bool   `json:"indeterminate,omitempty"`
+	Error         string `json:"error,omitempty"`
 }
 
 // StateDivergence records a single logical-state mismatch between the shadow

--- a/sidecar/shadow/types.go
+++ b/sidecar/shadow/types.go
@@ -20,7 +20,13 @@ type CompareResult struct {
 	Timestamp string `json:"timestamp"`
 
 	// Match is true when all checked layers agree between shadow and canonical.
+	// In migration mode an expected AppHash divergence does not clear Match.
 	Match bool `json:"match"`
+
+	// MigrationMode records that this comparison treated AppHash divergence as
+	// expected (an AppHash-breaking migration shadow), keying the verdict on
+	// execution-results equivalence instead.
+	MigrationMode bool `json:"migrationMode,omitempty"`
 
 	// DivergenceLayer is the first layer that detected a mismatch.
 	// Nil when Match is true.

--- a/sidecar/shadow/types.go
+++ b/sidecar/shadow/types.go
@@ -5,7 +5,10 @@
 //     If these match, the block is identical and deeper layers are skipped.
 //   - Layer 1: Transaction receipt comparison (status, gas, logs, etc.).
 //     Run only when Layer 0 fails, to isolate which transactions diverged.
-//   - Layer 2: State diff comparison (future).
+//   - Layer 2: State diff comparison — logical EVM state (storage/code/nonce)
+//     for the keys a block touched, read via EVM RPC on both sides. The
+//     load-bearing check for an AppHash-breaking migration shadow, where the
+//     committed root diverges by design and only logical state can be compared.
 //   - Layer 3: Execution trace comparison (future).
 package shadow
 
@@ -38,6 +41,10 @@ type CompareResult struct {
 	// Layer1 holds the transaction receipt comparison.
 	// Only populated when Layer 0 detected a divergence.
 	Layer1 *Layer1Result `json:"layer1,omitempty"`
+
+	// Layer2 holds the logical state-diff comparison. Populated only when a
+	// state reader and key source are configured (see WithLayer2).
+	Layer2 *Layer2Result `json:"layer2,omitempty"`
 }
 
 // Diverged returns true when the comparison detected a mismatch at any layer.
@@ -96,6 +103,32 @@ type FieldDivergence struct {
 	Field     string `json:"field"`
 	Shadow    any    `json:"shadow"`
 	Canonical any    `json:"canonical"`
+}
+
+// Layer2Result compares logical EVM state (storage slots, code, nonce) for the
+// keys a block touched, read via EVM RPC on both chains. This is the logical-
+// content truth check; it never compares the committed root, which is
+// schedule-dependent for a migration shadow and so not a correctness oracle.
+type Layer2Result struct {
+	// AccountsChecked is the number of touched accounts compared.
+	AccountsChecked int `json:"accountsChecked"`
+
+	// KeysChecked is the number of individual state reads compared (storage
+	// slots plus per-account code/nonce checks).
+	KeysChecked int `json:"keysChecked"`
+
+	// Divergences lists the logical-state mismatches found.
+	Divergences []StateDivergence `json:"divergences,omitempty"`
+}
+
+// StateDivergence records a single logical-state mismatch between the shadow
+// and canonical chains. Values are hex for legibility in reports.
+type StateDivergence struct {
+	Kind      string `json:"kind"` // storage | code | nonce
+	Addr      string `json:"addr"`
+	Slot      string `json:"slot,omitempty"` // set only for storage
+	Shadow    string `json:"shadow"`
+	Canonical string `json:"canonical"`
 }
 
 // DivergenceReport is a self-contained investigation artifact for a single

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/ethereum/go-ethereum/ethclient"
 
 	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
 	"github.com/sei-protocol/seictl/sidecar/shadow"
@@ -58,6 +59,29 @@ func (e *ResultExporter) newComparisonLoop(ctx context.Context, cfg ResultExport
 	var compOpts []shadow.Option
 	if cfg.MigrationMode {
 		compOpts = append(compOpts, shadow.WithMigrationMode())
+	}
+
+	// Layer 2 (logical state diff) is enabled when both EVM JSON-RPC endpoints
+	// are configured. Touched keys come from a prestate trace on TraceRPC
+	// (defaults to the canonical endpoint).
+	if cfg.ShadowEVMRPC != "" && cfg.CanonicalEVMRPC != "" {
+		shadowState, err := ethclient.Dial(cfg.ShadowEVMRPC)
+		if err != nil {
+			return nil, fmt.Errorf("dialing shadow EVM RPC: %w", err)
+		}
+		canonicalState, err := ethclient.Dial(cfg.CanonicalEVMRPC)
+		if err != nil {
+			return nil, fmt.Errorf("dialing canonical EVM RPC: %w", err)
+		}
+		traceRPC := cfg.TraceRPC
+		if traceRPC == "" {
+			traceRPC = cfg.CanonicalEVMRPC
+		}
+		keySource, err := shadow.NewTraceKeySource(traceRPC)
+		if err != nil {
+			return nil, fmt.Errorf("building trace key source: %w", err)
+		}
+		compOpts = append(compOpts, shadow.WithLayer2(shadowState, canonicalState, keySource))
 	}
 
 	last := e.readExportState()

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -55,10 +55,15 @@ func (e *ResultExporter) newComparisonLoop(ctx context.Context, cfg ResultExport
 		return nil, fmt.Errorf("building S3 uploader: %w", err)
 	}
 
+	var compOpts []shadow.Option
+	if cfg.MigrationMode {
+		compOpts = append(compOpts, shadow.WithMigrationMode())
+	}
+
 	last := e.readExportState()
 	return &comparisonLoop{
 		exporter:     e,
-		comparator:   shadow.NewComparator(cfg.RPCEndpoint, cfg.CanonicalRPC),
+		comparator:   shadow.NewComparator(cfg.RPCEndpoint, cfg.CanonicalRPC, compOpts...),
 		uploader:     uploader,
 		cfg:          cfg,
 		prefix:       normalizePrefix(cfg.Prefix),

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -21,6 +21,12 @@ const (
 	comparePageSize     = 100
 )
 
+// Guard the external contract Comparator.Close relies on: *ethclient.Client must
+// expose a no-return Close(). If a go-ethereum upgrade changed it to Close()
+// error, the no-return assertion in Comparator.Close would silently skip it
+// (the leak we already fixed once) — this fails the build instead.
+var _ interface{ Close() } = (*ethclient.Client)(nil)
+
 // comparisonLoop holds the state for a running block comparison session.
 type comparisonLoop struct {
 	exporter     *ResultExporter

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -41,6 +41,7 @@ func (e *ResultExporter) ExportAndCompare(ctx context.Context, cfg ResultExportR
 	if err != nil {
 		return err
 	}
+	defer loop.comparator.Close()
 
 	exportLog.Info("starting block comparison",
 		"start-height", loop.height,
@@ -71,6 +72,7 @@ func (e *ResultExporter) newComparisonLoop(ctx context.Context, cfg ResultExport
 		}
 		canonicalState, err := ethclient.Dial(cfg.CanonicalEVMRPC)
 		if err != nil {
+			shadowState.Close()
 			return nil, fmt.Errorf("dialing canonical EVM RPC: %w", err)
 		}
 		traceRPC := cfg.TraceRPC
@@ -79,6 +81,8 @@ func (e *ResultExporter) newComparisonLoop(ctx context.Context, cfg ResultExport
 		}
 		keySource, err := shadow.NewTraceKeySource(traceRPC)
 		if err != nil {
+			shadowState.Close()
+			canonicalState.Close()
 			return nil, fmt.Errorf("building trace key source: %w", err)
 		}
 		compOpts = append(compOpts, shadow.WithLayer2(shadowState, canonicalState, keySource))

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -41,6 +41,12 @@ type ResultExportRequest struct {
 	// local block execution against this canonical RPC endpoint and completes
 	// when app-hash divergence is detected.
 	CanonicalRPC string `json:"canonicalRpc"`
+
+	// MigrationMode tunes comparison for an AppHash-breaking migration shadow
+	// (e.g. memiavl->flatkv): AppHash divergence from canonical is expected
+	// every block, so it is treated as informational and the verdict keys on
+	// execution-results equivalence (LastResultsHash + gas + per-tx receipts).
+	MigrationMode bool `json:"migrationMode,omitempty"`
 }
 
 type exportState struct {

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -47,6 +47,19 @@ type ResultExportRequest struct {
 	// every block, so it is treated as informational and the verdict keys on
 	// execution-results equivalence (LastResultsHash + gas + per-tx receipts).
 	MigrationMode bool `json:"migrationMode,omitempty"`
+
+	// ShadowEVMRPC and CanonicalEVMRPC are the EVM JSON-RPC endpoints for the
+	// shadow and canonical chains. When both are set, Layer 2 (logical state
+	// diff) is enabled, comparing storage/code/nonce for the keys each block
+	// touched. These are EVM JSON-RPC (eth_*), distinct from the CometBFT RPC
+	// used for Layers 0/1.
+	ShadowEVMRPC    string `json:"shadowEvmRpc,omitempty"`
+	CanonicalEVMRPC string `json:"canonicalEvmRpc,omitempty"`
+
+	// TraceRPC is the EVM JSON-RPC endpoint used for prestate traces
+	// (debug_traceBlockByNumber) to derive each block's touched keys. Defaults
+	// to CanonicalEVMRPC. Requires the debug_ namespace enabled on that node.
+	TraceRPC string `json:"traceRpc,omitempty"`
 }
 
 type exportState struct {


### PR DESCRIPTION
## What

Extends `sidecar/shadow` to validate an **AppHash-breaking migration shadow** (memiavl→flatkv) against an un-migrated canonical chain — entirely in the sidecar, no sei-chain code.

### Migration mode (Increment A)
A flatkv shadow's AppHash diverges from canonical **every block by design** (the flatkv root is schedule-dependent), so the existing comparator — which completes on AppHash divergence — would fire on block 1. `WithMigrationMode()` treats AppHash mismatch as expected/informational and keys the verdict on **execution-results equivalence**: `LastResultsHash` + gas + per-tx receipts (Layer 1, which always runs in this mode). `LastResultsHash` is a pure function of tx results, independent of the state-commitment root, so it still matches for a correct migration.

### Layer 2 — logical state diff (Increment B)
The unbuilt "Layer 2 (future)" from the package roadmap. Compares **logical EVM state** (storage/code/nonce) for the keys a block touched, via EVM JSON-RPC on both chains — never the committed root (schedule-dependent, not a correctness oracle).
- `StateReader` (matches `*ethclient.Client`) + `KeySource`; `compareState` reads both sides, normalizes storage to 32 bytes, **fails closed** on an unreadable side.
- `TraceKeySource`: touched keys from a prestate trace (`debug_traceBlockByNumber`, prestateTracer). `StaticKeySource`: curated-set fallback when `debug_` is unavailable.
- Wired into `CompareBlock` (runs when configured + on real divergence or in migration mode) and the loop (`ShadowEVMRPC`/`CanonicalEVMRPC`/`TraceRPC` config). Rendered in the markdown report.

## Why logical, not root
A sibling validation harness proved the migration's committed root is **schedule-dependent** (the flatkv value embeds the block height each key is migrated at). Two nodes on a different `KeysToMigratePerBlock` fork. So correctness can only be asserted on **logical content** — which is exactly what Layer 2 does.

## Operational note (deploy-time)
The trace key source needs `debug_` enabled on the shadow/canonical nodes — these are operator-owned, non-public nodes. The pluggable `StaticKeySource` is the no-`debug_` fallback.

## Tests
Full `sidecar/shadow` + `sidecar/tasks` suites green; vet + gofmt clean. Migration-mode, Layer 2 (mock readers), wired CompareBlock, prestate-merge, and render tests added.