### PR TITLE
feat(sidecar): evm-logical-digest task + shared S3 emission seal + task panic isolation

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -125,6 +125,7 @@ var serveCmd = cli.Command{
 			engine.TaskGovVote:                  tasks.NewGovVoter(execCfg).Handler(),
 			engine.TaskGovSoftwareUpgrade:       tasks.NewGovSoftwareUpgrader(execCfg).Handler(),
 			engine.TaskGovParamChange:           tasks.NewGovParamChanger(execCfg).Handler(),
+			engine.TaskEvmLogicalDigest:         tasks.NewEvmLogicalDigester(nil).Handler(),
 		}
 
 		eng := engine.NewEngine(ctx, handlers, store)

--- a/sidecar/engine/engine.go
+++ b/sidecar/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -147,7 +148,7 @@ func (e *Engine) runTask(id string, taskType TaskType, handler TaskHandler, para
 		// without changing the TaskHandler signature.
 		sink := &resultSink{}
 		ctx := withResultSink(WithTaskID(e.ctx, id), sink)
-		err := e.execute(ctx, taskType, handler, params)
+		err := e.executeRecovered(ctx, taskType, handler, params)
 
 		t := time.Now().UTC()
 		tr := &TaskResult{
@@ -172,6 +173,22 @@ func (e *Engine) runTask(id string, taskType TaskType, handler TaskHandler, para
 			log.Error("failed to persist task result", "id", id, "err", storeErr)
 		}
 	}()
+}
+
+// executeRecovered runs execute under a recover so a handler panic becomes a
+// failed TaskResult instead of taking down the shared sidecar process. It
+// guards only the handler goroutine; a task that spawns its own goroutines must
+// recover within them (e.g. s3.streamGzip's writer).
+func (e *Engine) executeRecovered(ctx context.Context, taskType TaskType, handler TaskHandler, params map[string]any) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("task handler panicked", "type", taskType, "panic", r, "stack", string(debug.Stack()))
+			taskPanics.WithLabelValues(string(taskType)).Inc()
+			taskFailures.WithLabelValues(string(taskType)).Inc()
+			err = fmt.Errorf("task handler panicked: %v", r)
+		}
+	}()
+	return e.execute(ctx, taskType, handler, params)
 }
 
 // execute runs a handler synchronously and logs the outcome.

--- a/sidecar/engine/engine_test.go
+++ b/sidecar/engine/engine_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func newTestEngine(t *testing.T, handlers map[TaskType]TaskHandler) *Engine {
@@ -810,5 +812,33 @@ func TestTaskErrorProducesRichErrorString(t *testing.T) {
 	}
 	if !strings.Contains(r.Error, "hint:") {
 		t.Errorf("error should contain hint, got: %s", r.Error)
+	}
+}
+
+func TestSubmitHandlerPanicBecomesFailedTask(t *testing.T) {
+	before := testutil.ToFloat64(taskPanics.WithLabelValues(string(TaskConfigPatch)))
+
+	eng := newTestEngine(t, map[TaskType]TaskHandler{
+		TaskConfigPatch: func(_ context.Context, _ map[string]any) error {
+			panic("kaboom")
+		},
+	})
+
+	id, err := eng.Submit(Task{Type: TaskConfigPatch})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	r := waitForResult(t, eng, id)
+	if r.Status != TaskStatusFailed {
+		t.Fatalf("panicking handler should produce Failed, got %s", r.Status)
+	}
+	if !strings.Contains(r.Error, "panicked") || !strings.Contains(r.Error, "kaboom") {
+		t.Errorf("error should describe the panic, got: %s", r.Error)
+	}
+
+	after := testutil.ToFloat64(taskPanics.WithLabelValues(string(TaskConfigPatch)))
+	if after != before+1 {
+		t.Errorf("taskPanics delta = %v, want 1", after-before)
 	}
 }

--- a/sidecar/engine/metrics.go
+++ b/sidecar/engine/metrics.go
@@ -33,10 +33,22 @@ var (
 		},
 		[]string{"type"},
 	)
+
+	// taskPanics counts handler panics recovered by the engine. A non-zero
+	// value means a handler crashed and was converted to a failed task rather
+	// than taking the sidecar down; it also increments taskFailures.
+	taskPanics = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "seictl_task_panics_total",
+			Help: "Total number of task handler panics recovered by the engine.",
+		},
+		[]string{"type"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(taskDuration)
 	prometheus.MustRegister(taskSubmissions)
 	prometheus.MustRegister(taskFailures)
+	prometheus.MustRegister(taskPanics)
 }

--- a/sidecar/engine/types.go
+++ b/sidecar/engine/types.go
@@ -35,6 +35,7 @@ const (
 	TaskGovVote                  TaskType = "gov-vote"
 	TaskGovSoftwareUpgrade       TaskType = "gov-software-upgrade"
 	TaskGovParamChange           TaskType = "gov-param-change"
+	TaskEvmLogicalDigest         TaskType = "evm-logical-digest"
 )
 
 // Task is a unit of work submitted by the controller. When ID is set, the

--- a/sidecar/s3/emit.go
+++ b/sidecar/s3/emit.go
@@ -1,0 +1,150 @@
+package s3
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
+)
+
+// EmitResult reports what was published: the hex SHA-256 over the uncompressed
+// payload, surfaced in the TaskResult/log so an operator can verify the
+// decompressed object after gunzip. It is the canonical reader-verifiable seal;
+// it is not embedded in the object itself (a payload cannot carry the hash of
+// its own bytes).
+type EmitResult struct {
+	// UncompressedSHA256 is the hex digest of the bytes fed into gzip.
+	UncompressedSHA256 string
+}
+
+// StreamGzipNDJSON gzips each record as one NDJSON line and streams it to S3
+// without buffering the whole payload, computing a SHA-256 over the
+// uncompressed bytes as they pass. The integrity seal is twofold:
+//
+//   - ChecksumAlgorithm=SHA256 on the put: the SDK sends a trailing aws-chunked
+//     checksum, so S3 validates a SHA-256 of the compressed bytes it received
+//     without precomputing — the wire seal. For a multipart upload (payload
+//     over the uploader's threshold) S3 stores the composite-of-parts form
+//     (`<hash>-N`), still a valid per-part seal but not a flat SHA-256 of the
+//     body a reader can recompute.
+//   - the returned UncompressedSHA256: the logical seal over the pre-gzip
+//     payload, surfaced via EmitResult so a reader verifies the decompressed
+//     bytes independently. This, not the S3-side checksum, is the canonical
+//     reader-verifiable seal.
+//
+// io.Pipe backpressure is preserved: the marshaling goroutine blocks on the
+// uploader's reads, so memory stays bounded to the uploader's part-buffer pool
+// (~part_size × (concurrency+1)), independent of total payload size.
+func StreamGzipNDJSON[T any](ctx context.Context, uploader Uploader, bucket, key string, records []T) (EmitResult, error) {
+	return streamGzip(ctx, uploader, bucket, key, func(w io.Writer) error {
+		return encodeNDJSON(w, records)
+	})
+}
+
+// StreamGzipJSON gzips a single indented JSON object and streams it to S3 with
+// the same uncompressed-payload seal as StreamGzipNDJSON.
+func StreamGzipJSON(ctx context.Context, uploader Uploader, bucket, key string, obj any) (EmitResult, error) {
+	return streamGzip(ctx, uploader, bucket, key, func(w io.Writer) error {
+		return encodeIndentedJSON(w, obj)
+	})
+}
+
+// StreamGzipFunc gzips and streams whatever write emits, under the same seal as
+// StreamGzipNDJSON. It exists for producers that generate the payload lazily
+// (e.g. querying one block at a time) and so must not materialize the whole
+// record set in memory first. write receives the destination writer and must
+// emit the complete uncompressed payload.
+func StreamGzipFunc(ctx context.Context, uploader Uploader, bucket, key string, write func(io.Writer) error) (EmitResult, error) {
+	return streamGzip(ctx, uploader, bucket, key, write)
+}
+
+// streamGzip wires the io.Pipe -> hash-tee -> gzip pipeline and the S3 upload.
+// write emits the uncompressed payload into the supplied writer.
+func streamGzip(ctx context.Context, uploader Uploader, bucket, key string, write func(io.Writer) error) (EmitResult, error) {
+	pr, pw := io.Pipe()
+	h := sha256.New()
+
+	writeErr := make(chan error, 1)
+	go func() {
+		writeErr <- writeGzip(pw, h, write)
+	}()
+
+	_, uploadErr := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
+		Bucket:            aws.String(bucket),
+		Key:               aws.String(key),
+		Body:              pr,
+		ContentType:       aws.String("application/gzip"),
+		ChecksumAlgorithm: tmtypes.ChecksumAlgorithmSha256,
+	})
+	if uploadErr != nil {
+		// Unblock the writer goroutine if the upload aborted early.
+		pr.CloseWithError(uploadErr)
+	}
+
+	wErr := <-writeErr
+	if uploadErr != nil {
+		return EmitResult{}, uploadErr
+	}
+	if wErr != nil {
+		return EmitResult{}, wErr
+	}
+	return EmitResult{UncompressedSHA256: hex.EncodeToString(h.Sum(nil))}, nil
+}
+
+// writeGzip tees the uncompressed payload through h (the integrity hash) while
+// gzipping it into the pipe. The pipe is closed with the terminal error so the
+// uploader observes it instead of a truncated, silently-valid object.
+func writeGzip(pw *io.PipeWriter, h hash.Hash, write func(io.Writer) error) (retErr error) {
+	defer func() {
+		if retErr != nil {
+			pw.CloseWithError(retErr)
+		} else {
+			_ = pw.Close()
+		}
+	}()
+
+	gw := gzip.NewWriter(pw)
+	defer func() {
+		if err := gw.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing gzip writer: %w", err)
+		}
+	}()
+
+	// Registered last so it runs first: a panic in write (e.g. a record's
+	// MarshalJSON over attacker-adjacent chain data) becomes retErr, so the
+	// pipe-close defer does CloseWithError — the uploader aborts instead of
+	// publishing a truncated object, and the panic never escapes this
+	// task-spawned goroutine to crash the sidecar.
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("panic in payload writer: %v", r)
+		}
+	}()
+
+	return write(io.MultiWriter(gw, h))
+}
+
+func encodeNDJSON[T any](w io.Writer, records []T) error {
+	enc := json.NewEncoder(w)
+	for i := range records {
+		// Encoder.Encode appends '\n', yielding one record per line.
+		if err := enc.Encode(records[i]); err != nil {
+			return fmt.Errorf("marshaling record %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func encodeIndentedJSON(w io.Writer, obj any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(obj)
+}

--- a/sidecar/s3/emit_test.go
+++ b/sidecar/s3/emit_test.go
@@ -1,0 +1,167 @@
+package s3
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
+)
+
+// captureUploader records the put input and drains the streamed body into a
+// buffer, mimicking S3 reading the gzip stream off the pipe.
+type captureUploader struct {
+	in   *transfermanager.UploadObjectInput
+	body []byte
+	err  error
+}
+
+func (u *captureUploader) UploadObject(_ context.Context, in *transfermanager.UploadObjectInput, _ ...func(*transfermanager.Options)) (*transfermanager.UploadObjectOutput, error) {
+	u.in = in
+	if u.err != nil {
+		// Don't drain — exercise the early-abort path where the writer
+		// goroutine must be unblocked via CloseWithError.
+		return nil, u.err
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, in.Body); err != nil {
+		return nil, err
+	}
+	u.body = buf.Bytes()
+	return &transfermanager.UploadObjectOutput{}, nil
+}
+
+func gunzip(t *testing.T, b []byte) []byte {
+	t.Helper()
+	r, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading gzip: %v", err)
+	}
+	return out
+}
+
+func TestStreamGzipNDJSON_RoundTripAndSeal(t *testing.T) {
+	up := &captureUploader{}
+	records := []map[string]any{
+		{"height": 1, "ok": true},
+		{"height": 2, "ok": false},
+	}
+
+	res, err := StreamGzipNDJSON(context.Background(), up, "bkt", "k.ndjson.gz", records)
+	if err != nil {
+		t.Fatalf("StreamGzipNDJSON: %v", err)
+	}
+
+	payload := gunzip(t, up.body)
+	lines := strings.Split(strings.TrimRight(string(payload), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d NDJSON lines, want 2: %q", len(lines), payload)
+	}
+
+	// The returned seal must equal SHA-256 over the uncompressed payload.
+	want := sha256.Sum256(payload)
+	if res.UncompressedSHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("UncompressedSHA256 = %s, want %s", res.UncompressedSHA256, hex.EncodeToString(want[:]))
+	}
+
+	// The put must request a SHA-256 checksum (the wire seal over stored bytes).
+	if up.in.ChecksumAlgorithm != tmtypes.ChecksumAlgorithmSha256 {
+		t.Errorf("ChecksumAlgorithm = %q, want SHA256", up.in.ChecksumAlgorithm)
+	}
+}
+
+func TestStreamGzipJSON_RoundTripAndSeal(t *testing.T) {
+	up := &captureUploader{}
+	obj := map[string]any{"match": true, "height": 42}
+
+	res, err := StreamGzipJSON(context.Background(), up, "bkt", "k.json.gz", obj)
+	if err != nil {
+		t.Fatalf("StreamGzipJSON: %v", err)
+	}
+
+	payload := gunzip(t, up.body)
+	want := sha256.Sum256(payload)
+	if res.UncompressedSHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("UncompressedSHA256 = %s, want %s", res.UncompressedSHA256, hex.EncodeToString(want[:]))
+	}
+	if !strings.Contains(string(payload), "\"match\": true") {
+		t.Errorf("payload not indented JSON: %q", payload)
+	}
+}
+
+func TestStreamGzipFunc_LazyWriter(t *testing.T) {
+	up := &captureUploader{}
+	res, err := StreamGzipFunc(context.Background(), up, "bkt", "k", func(w io.Writer) error {
+		_, err := io.WriteString(w, "line-a\nline-b\n")
+		return err
+	})
+	if err != nil {
+		t.Fatalf("StreamGzipFunc: %v", err)
+	}
+	payload := gunzip(t, up.body)
+	if string(payload) != "line-a\nline-b\n" {
+		t.Errorf("payload = %q", payload)
+	}
+	want := sha256.Sum256(payload)
+	if res.UncompressedSHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("seal mismatch")
+	}
+}
+
+func TestStreamGzip_WriterErrorPropagates(t *testing.T) {
+	up := &captureUploader{}
+	sentinel := errors.New("boom")
+	_, err := StreamGzipFunc(context.Background(), up, "bkt", "k", func(io.Writer) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want wrap of sentinel", err)
+	}
+}
+
+func TestStreamGzip_WriterPanicBecomesError(t *testing.T) {
+	// A panic in the payload writer (e.g. a record's MarshalJSON over
+	// attacker-adjacent chain data) runs on a task-spawned goroutine outside the
+	// engine's handler recover. It must convert to a returned error — not crash
+	// the sidecar. Reaching this assertion at all proves the process survived.
+	up := &captureUploader{}
+	_, err := StreamGzipFunc(context.Background(), up, "bkt", "k", func(io.Writer) error {
+		panic("marshal blew up")
+	})
+	if err == nil {
+		t.Fatal("expected an error from a panicking writer, got nil")
+	}
+	if !strings.Contains(err.Error(), "panic in payload writer") {
+		t.Fatalf("err = %v, want it to name the recovered panic", err)
+	}
+}
+
+func TestStreamGzip_UploadErrorUnblocksWriter(t *testing.T) {
+	// A writer large enough to fill the pipe and gzip buffers would deadlock if
+	// the pipe were never closed on upload failure. Reaching the return without
+	// hanging proves CloseWithError unblocked it (go test's timeout is the
+	// backstop if it does not).
+	up := &captureUploader{err: errors.New("s3 down")}
+	_, err := StreamGzipFunc(context.Background(), up, "bkt", "k", func(w io.Writer) error {
+		for i := 0; i < 100000; i++ {
+			if _, werr := io.WriteString(w, "padding-line\n"); werr != nil {
+				return werr
+			}
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected upload error, got nil")
+	}
+}

--- a/sidecar/tasks/evm_logical_digest.go
+++ b/sidecar/tasks/evm_logical_digest.go
@@ -1,0 +1,334 @@
+package tasks
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+	"github.com/sei-protocol/seilog"
+)
+
+var evmDigestLog = seilog.NewLogger("seictl", "task", "evm-logical-digest")
+
+const defaultSeidbPath = "seidb"
+
+// defaultNormalizations are the memiavl normalization modes proved per run.
+// "semantic" decodes raw memiavl EVM leaves independently; "translator" runs
+// them through flatkv.ImportTranslator. Proving both guards against a bug in
+// either decoder masking a real divergence.
+var defaultNormalizations = []string{"semantic", "translator"}
+
+// EvmLogicalDigestRequest parameters the evm-logical-digest task. It shells out
+// to seidb's evm-logical-digest for a flatkv clone and a memiavl snapshot at the
+// same height, compares the backend-independent logical digests, and publishes
+// the verdict to S3.
+type EvmLogicalDigestRequest struct {
+	FlatKVDir  string `json:"flatkvDir"`
+	MemIAVLDir string `json:"memiavlDir"`
+	Height     int64  `json:"height"`
+	Bucket     string `json:"bucket"`
+	Prefix     string `json:"prefix"`
+	Region     string `json:"region"`
+
+	// Normalizations is the set of memiavl normalization modes to prove.
+	// Defaults to ["semantic","translator"] when empty.
+	Normalizations []string `json:"normalizations"`
+
+	// SeidbPath is the seidb binary to exec. Defaults to "seidb" (PATH lookup).
+	SeidbPath string `json:"seidbPath"`
+}
+
+// bucketDigests holds the per-bucket and final logical digests parsed from one
+// seidb run. All values are lowercase hex as printed by seidb.
+type bucketDigests struct {
+	Account string `json:"account"`
+	Code    string `json:"code"`
+	Storage string `json:"storage"`
+	Legacy  string `json:"legacy"`
+	Final   string `json:"final"`
+	Version int64  `json:"version"`
+}
+
+// EndpointDigestRecord is the published verdict for one (height, normalization)
+// comparison — the durable artifact a reader trusts. Its own SHA-256 seal lives
+// out-of-band (the s3 helper's EmitResult, logged + in the TaskResult): a record
+// cannot carry the hash of its own published bytes.
+type EndpointDigestRecord struct {
+	Height        int64             `json:"height"`
+	Normalization string            `json:"normalization"`
+	FlatKVDigest  string            `json:"flatkv_digest"`
+	MemIAVLDigest string            `json:"memiavl_digest"`
+	PerBucket     map[string]bucket `json:"per_bucket"`
+	Match         bool              `json:"match"`
+	AxesProved    []string          `json:"axes_proved"`
+	GeneratedAt   string            `json:"generated_at"`
+}
+
+// bucket pairs the flatkv and memiavl digest for one canonical bucket.
+type bucket struct {
+	FlatKV  string `json:"flatkv"`
+	MemIAVL string `json:"memiavl"`
+	Match   bool   `json:"match"`
+}
+
+// EvmLogicalDigester runs the comparison. It holds no per-request state.
+type EvmLogicalDigester struct {
+	s3UploaderFactory seis3.UploaderFactory
+}
+
+// NewEvmLogicalDigester builds the task handler dependency. A nil factory uses
+// the default real-S3 uploader.
+func NewEvmLogicalDigester(factory seis3.UploaderFactory) *EvmLogicalDigester {
+	if factory == nil {
+		factory = seis3.DefaultUploaderFactory
+	}
+	return &EvmLogicalDigester{s3UploaderFactory: factory}
+}
+
+func (d *EvmLogicalDigester) Handler() engine.TaskHandler {
+	return engine.TypedHandler(func(ctx context.Context, req EvmLogicalDigestRequest) error {
+		return d.run(ctx, req)
+	})
+}
+
+func (d *EvmLogicalDigester) run(ctx context.Context, req EvmLogicalDigestRequest) error {
+	if err := validateDigestRequest(&req); err != nil {
+		return err
+	}
+
+	uploader, err := d.s3UploaderFactory(ctx, req.Region)
+	if err != nil {
+		return fmt.Errorf("evm-logical-digest: building S3 uploader: %w", err)
+	}
+	prefix := normalizePrefix(req.Prefix)
+
+	// FlatKV is normalization-independent (native physical keyspace), so it is
+	// digested once and compared against each memiavl normalization.
+	flatkv, err := d.runSeidb(ctx, req.SeidbPath, "flatkv", req.FlatKVDir, req.Height, "")
+	if err != nil {
+		return fmt.Errorf("evm-logical-digest: flatkv digest: %w", err)
+	}
+	// Trust the run, not the request: a digest taken at the wrong height is a
+	// silent false match. seidb WAL-replays flatkv to --height, so the opened
+	// version MUST equal the requested height.
+	if flatkv.Version != req.Height {
+		return fmt.Errorf("evm-logical-digest: flatkv opened version %d != requested height %d", flatkv.Version, req.Height)
+	}
+
+	for _, norm := range req.Normalizations {
+		memiavl, err := d.runSeidb(ctx, req.SeidbPath, "memiavl", req.MemIAVLDir, req.Height, norm)
+		if err != nil {
+			return fmt.Errorf("evm-logical-digest: memiavl digest (%s): %w", norm, err)
+		}
+		// Symmetric with the flatkv check: if seidb clamps to the nearest
+		// available snapshot instead of erroring, the comparison would run at
+		// the wrong height — a silent false match in the degenerate case.
+		if memiavl.Version != req.Height {
+			return fmt.Errorf("evm-logical-digest: memiavl opened version %d != requested height %d (%s)", memiavl.Version, req.Height, norm)
+		}
+
+		record := buildEndpointDigest(req.Height, norm, flatkv, memiavl)
+		key := fmt.Sprintf("%sendpoint-digest-%d-%s.json.gz", prefix, req.Height, norm)
+
+		emit, err := seis3.StreamGzipJSON(ctx, uploader, req.Bucket, key, record)
+		if err != nil {
+			return seis3.ClassifyS3Error("evm-logical-digest", req.Bucket, key, req.Region, err)
+		}
+
+		evmDigestLog.Info("published endpoint digest",
+			"height", req.Height,
+			"normalization", norm,
+			"match", record.Match,
+			"flatkv-digest", record.FlatKVDigest,
+			"memiavl-digest", record.MemIAVLDigest,
+			"key", key,
+			"sha256", emit.UncompressedSHA256)
+	}
+
+	return nil
+}
+
+func validateDigestRequest(req *EvmLogicalDigestRequest) error {
+	if req.Bucket == "" {
+		return fmt.Errorf("evm-logical-digest: missing required param 'bucket'")
+	}
+	if req.Region == "" {
+		return fmt.Errorf("evm-logical-digest: missing required param 'region'")
+	}
+	if req.Height <= 0 {
+		return fmt.Errorf("evm-logical-digest: 'height' must be a positive block height, got %d", req.Height)
+	}
+	if req.FlatKVDir == "" {
+		return fmt.Errorf("evm-logical-digest: missing required param 'flatkvDir'")
+	}
+	if req.MemIAVLDir == "" {
+		return fmt.Errorf("evm-logical-digest: missing required param 'memiavlDir'")
+	}
+	if req.SeidbPath == "" {
+		req.SeidbPath = defaultSeidbPath
+	}
+	if len(req.Normalizations) == 0 {
+		req.Normalizations = defaultNormalizations
+	}
+	for _, n := range req.Normalizations {
+		if n != "semantic" && n != "translator" {
+			return fmt.Errorf("evm-logical-digest: unknown normalization %q (want semantic|translator)", n)
+		}
+	}
+	return nil
+}
+
+// runSeidb execs `seidb evm-logical-digest` for one backend and parses the
+// per-bucket + FINAL_DIGEST lines and the opened version from its stdout.
+func (d *EvmLogicalDigester) runSeidb(ctx context.Context, seidbPath, backend, dir string, height int64, normalization string) (bucketDigests, error) {
+	args := []string{
+		"evm-logical-digest",
+		"--backend", backend,
+		"-d", dir,
+		"--height", strconv.FormatInt(height, 10),
+	}
+	if backend == "memiavl" && normalization != "" {
+		args = append(args, "--memiavl-normalization", normalization)
+	}
+
+	cmd := exec.CommandContext(ctx, seidbPath, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return bucketDigests{}, fmt.Errorf("running %s %s: %w%s", seidbPath, strings.Join(args, " "), err, stderrTail(err))
+	}
+	return parseDigestOutput(string(out))
+}
+
+// stderrTail surfaces the captured stderr from an *exec.ExitError so a seidb
+// failure is actionable instead of a bare "exit status 1".
+func stderrTail(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return fmt.Sprintf(" (stderr: %s)", strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return ""
+}
+
+// parseDigestOutput extracts the per-bucket digests, the final digest, and the
+// opened version from one seidb run's stdout. It is fail-closed: a missing
+// FINAL_DIGEST, a missing bucket, or a missing version is an error, never a
+// zero-valued "match".
+func parseDigestOutput(out string) (bucketDigests, error) {
+	var bd bucketDigests
+	var (
+		haveVersion bool
+		haveAccount bool
+		haveCode    bool
+		haveStorage bool
+		haveLegacy  bool
+		haveFinal   bool
+	)
+
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	// seidb prints raw bytecode/values nowhere on stdout, but bump the buffer
+	// so a long context/progress line never trips the default 64 KiB cap.
+	scanner.Buffer(make([]byte, 0, 1024*1024), 4*1024*1024)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
+		}
+		switch fields[0] {
+		case "version:":
+			if len(fields) < 2 {
+				return bucketDigests{}, fmt.Errorf("seidb output: malformed 'version:' line %q", scanner.Text())
+			}
+			v, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return bucketDigests{}, fmt.Errorf("parsing version %q: %w", fields[1], err)
+			}
+			bd.Version = v
+			haveVersion = true
+		case "account":
+			if v, ok := digestField(fields, "bucket_digest="); ok {
+				bd.Account = v
+				haveAccount = true
+			}
+		case "code":
+			if v, ok := digestField(fields, "bucket_digest="); ok {
+				bd.Code = v
+				haveCode = true
+			}
+		case "storage":
+			if v, ok := digestField(fields, "bucket_digest="); ok {
+				bd.Storage = v
+				haveStorage = true
+			}
+		case "legacy":
+			if v, ok := digestField(fields, "bucket_digest="); ok {
+				bd.Legacy = v
+				haveLegacy = true
+			}
+		case "FINAL_DIGEST":
+			if v, ok := digestField(fields, "digest="); ok {
+				bd.Final = v
+				haveFinal = true
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return bucketDigests{}, fmt.Errorf("scanning seidb output: %w", err)
+	}
+
+	switch {
+	case !haveVersion:
+		return bucketDigests{}, fmt.Errorf("seidb output missing 'version:' line")
+	case !haveFinal:
+		return bucketDigests{}, fmt.Errorf("seidb output missing FINAL_DIGEST line")
+	case !haveAccount || !haveCode || !haveStorage || !haveLegacy:
+		return bucketDigests{}, fmt.Errorf("seidb output missing a per-bucket digest (account=%t code=%t storage=%t legacy=%t)",
+			haveAccount, haveCode, haveStorage, haveLegacy)
+	}
+	return bd, nil
+}
+
+// digestField returns the hex value of the field with the given prefix
+// (e.g. "bucket_digest=<hex>"), and false if no such field is present.
+func digestField(fields []string, prefix string) (string, bool) {
+	for _, f := range fields {
+		if rest, ok := strings.CutPrefix(f, prefix); ok {
+			return rest, true
+		}
+	}
+	return "", false
+}
+
+func buildEndpointDigest(height int64, normalization string, flatkv, memiavl bucketDigests) EndpointDigestRecord {
+	perBucket := map[string]bucket{
+		"account": {FlatKV: flatkv.Account, MemIAVL: memiavl.Account, Match: flatkv.Account == memiavl.Account},
+		"code":    {FlatKV: flatkv.Code, MemIAVL: memiavl.Code, Match: flatkv.Code == memiavl.Code},
+		"storage": {FlatKV: flatkv.Storage, MemIAVL: memiavl.Storage, Match: flatkv.Storage == memiavl.Storage},
+		"legacy":  {FlatKV: flatkv.Legacy, MemIAVL: memiavl.Legacy, Match: flatkv.Legacy == memiavl.Legacy},
+	}
+	return EndpointDigestRecord{
+		Height:        height,
+		Normalization: normalization,
+		FlatKVDigest:  flatkv.Final,
+		MemIAVLDigest: memiavl.Final,
+		PerBucket:     perBucket,
+		Match:         flatkv.Final == memiavl.Final,
+		AxesProved:    axesProved(normalization),
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// axesProved records which logical axes this digest actually proves. The
+// memiavl EVM keyspace carries no balance, and the semantic account decoder
+// zeroes the balance field of the account payload, so neither normalization's
+// account digest attests balance equivalence — that is the per-block
+// comparator's job. We never claim "balance" here; a reader must not infer it.
+func axesProved(_ string) []string {
+	return []string{"nonce", "code", "code_hash", "storage", "legacy"}
+}

--- a/sidecar/tasks/evm_logical_digest.go
+++ b/sidecar/tasks/evm_logical_digest.go
@@ -199,6 +199,8 @@ func (d *EvmLogicalDigester) runSeidb(ctx context.Context, seidbPath, backend, d
 	}
 
 	cmd := exec.CommandContext(ctx, seidbPath, args...)
+	// Stderr is left nil so Output() captures it into ExitError.Stderr, which
+	// stderrTail surfaces on failure.
 	out, err := cmd.Output()
 	if err != nil {
 		return bucketDigests{}, fmt.Errorf("running %s %s: %w%s", seidbPath, strings.Join(args, " "), err, stderrTail(err))

--- a/sidecar/tasks/evm_logical_digest_test.go
+++ b/sidecar/tasks/evm_logical_digest_test.go
@@ -1,0 +1,329 @@
+package tasks
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+
+	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
+)
+
+// digestRecordingUploader captures every put body keyed by S3 key.
+type digestRecordingUploader struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+}
+
+func (u *digestRecordingUploader) UploadObject(_ context.Context, in *transfermanager.UploadObjectInput, _ ...func(*transfermanager.Options)) (*transfermanager.UploadObjectOutput, error) {
+	var buf bytes.Buffer
+	if in.Body != nil {
+		if _, err := io.Copy(&buf, in.Body); err != nil {
+			return nil, err
+		}
+	}
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.objects == nil {
+		u.objects = map[string][]byte{}
+	}
+	u.objects[*in.Key] = buf.Bytes()
+	return &transfermanager.UploadObjectOutput{}, nil
+}
+
+func (u *digestRecordingUploader) factory() seis3.UploaderFactory {
+	return func(context.Context, string) (seis3.Uploader, error) { return u, nil }
+}
+
+func (u *digestRecordingUploader) record(t *testing.T, key string) EndpointDigestRecord {
+	t.Helper()
+	u.mu.Lock()
+	raw, ok := u.objects[key]
+	u.mu.Unlock()
+	if !ok {
+		t.Fatalf("no object published at key %q; have %v", key, u.keys())
+	}
+	gr, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	dec := json.NewDecoder(gr)
+	var rec EndpointDigestRecord
+	if err := dec.Decode(&rec); err != nil {
+		t.Fatalf("decode record: %v", err)
+	}
+	return rec
+}
+
+func (u *digestRecordingUploader) keys() []string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	ks := make([]string, 0, len(u.objects))
+	for k := range u.objects {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+// fakeSeidb writes an executable shim that prints canned digest output. The
+// shim branches on --backend and --memiavl-normalization and echoes the version
+// it was asked for via --height so version-assertion paths can be exercised.
+// flatkvVersionOverride / memiavlVersionOverride, when non-empty, replace the
+// printed version for that backend's run to simulate a height mismatch (e.g. a
+// snapshot tool clamping to the nearest available height).
+func fakeSeidb(t *testing.T, flatkvVersionOverride, memiavlVersionOverride string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell shim not portable to windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "seidb")
+	flatkvVer := `$height`
+	if flatkvVersionOverride != "" {
+		flatkvVer = flatkvVersionOverride
+	}
+	memiavlVer := `$height`
+	if memiavlVersionOverride != "" {
+		memiavlVer = memiavlVersionOverride
+	}
+	// The shim parses --backend, --height, --memiavl-normalization from argv and
+	// prints a digest block whose values depend on backend+normalization.
+	script := fmt.Sprintf(`#!/bin/sh
+backend=""
+height=""
+norm=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --backend) backend="$2"; shift 2;;
+    --height) height="$2"; shift 2;;
+    --memiavl-normalization) norm="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+acct=aaaa
+code=cccc
+stor=5555
+leg=1111
+if [ "$backend" = "memiavl" ] && [ "$norm" = "translator" ]; then
+  stor=9999
+fi
+final=ffff
+if [ "$backend" = "memiavl" ] && [ "$norm" = "translator" ]; then
+  final=eeee
+fi
+if [ "$backend" = "memiavl" ]; then ver=%s; else ver=%s; fi
+echo "EVM logical digest start"
+echo "backend: $backend"
+echo "version: $ver"
+echo ""
+echo "Bucket digests (final digest inputs)"
+echo "account  count=10 bucket_digest=$acct"
+echo "code     count=2 bucket_digest=$code"
+echo "storage  count=99 bucket_digest=$stor"
+echo "legacy   count=3 bucket_digest=$leg"
+echo ""
+echo "FINAL_DIGEST account+code+storage+legacy count=114 digest=$final"
+`, memiavlVer, flatkvVer)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	return path
+}
+
+func baseRequest(seidbPath string) EvmLogicalDigestRequest {
+	return EvmLogicalDigestRequest{
+		FlatKVDir:  "/data/flatkv",
+		MemIAVLDir: "/data/memiavl",
+		Height:     213200000,
+		Bucket:     "digest-bucket",
+		Prefix:     "digests",
+		Region:     "us-east-1",
+		SeidbPath:  seidbPath,
+	}
+}
+
+func TestEvmLogicalDigest_SemanticMatchTranslatorMismatch(t *testing.T) {
+	up := &digestRecordingUploader{}
+	d := NewEvmLogicalDigester(up.factory())
+	req := baseRequest(fakeSeidb(t, "", ""))
+
+	if err := d.run(context.Background(), req); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// semantic: flatkv final ffff == memiavl final ffff -> match.
+	sem := up.record(t, "digests/endpoint-digest-213200000-semantic.json.gz")
+	if !sem.Match {
+		t.Errorf("semantic should match, got %+v", sem)
+	}
+	if !sem.PerBucket["storage"].Match {
+		t.Error("semantic storage should match")
+	}
+
+	// translator: memiavl storage/final diverge -> no match. This is the
+	// fail-closed proof that a real divergence is reported, not masked.
+	tr := up.record(t, "digests/endpoint-digest-213200000-translator.json.gz")
+	if tr.Match {
+		t.Errorf("translator should NOT match, got %+v", tr)
+	}
+	if tr.PerBucket["storage"].Match {
+		t.Error("translator storage should not match")
+	}
+	if tr.PerBucket["account"].Match != true {
+		t.Error("translator account should still match")
+	}
+
+	// axes_proved must never claim balance.
+	for _, axis := range sem.AxesProved {
+		if axis == "balance" {
+			t.Fatal("axes_proved must not claim balance for the semantic path")
+		}
+	}
+}
+
+func TestEvmLogicalDigest_VersionMismatchFailsClosed(t *testing.T) {
+	up := &digestRecordingUploader{}
+	d := NewEvmLogicalDigester(up.factory())
+	// flatkv shim prints version 999, but the request asks for 213200000.
+	req := baseRequest(fakeSeidb(t, "999", ""))
+
+	err := d.run(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected version-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Errorf("error should mention version, got: %v", err)
+	}
+	if len(up.keys()) != 0 {
+		t.Errorf("nothing should be published on version mismatch, got %v", up.keys())
+	}
+}
+
+func TestEvmLogicalDigest_MemiavlVersionMismatchFailsClosed(t *testing.T) {
+	up := &digestRecordingUploader{}
+	d := NewEvmLogicalDigester(up.factory())
+	// flatkv opens at the requested height, but the memiavl snapshot resolves
+	// to 888 (e.g. seidb clamped to the nearest available snapshot). The
+	// comparison must not publish — a wrong-height memiavl side is a silent
+	// false match in the degenerate case.
+	req := baseRequest(fakeSeidb(t, "", "888"))
+
+	err := d.run(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected memiavl version-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "memiavl opened version") {
+		t.Errorf("error should name the memiavl version mismatch, got: %v", err)
+	}
+	if len(up.keys()) != 0 {
+		t.Errorf("nothing should be published on memiavl version mismatch, got %v", up.keys())
+	}
+}
+
+func TestEvmLogicalDigest_Validation(t *testing.T) {
+	d := NewEvmLogicalDigester((&digestRecordingUploader{}).factory())
+	cases := map[string]func(*EvmLogicalDigestRequest){
+		"missing bucket":      func(r *EvmLogicalDigestRequest) { r.Bucket = "" },
+		"missing region":      func(r *EvmLogicalDigestRequest) { r.Region = "" },
+		"missing flatkvDir":   func(r *EvmLogicalDigestRequest) { r.FlatKVDir = "" },
+		"missing memiavlDir":  func(r *EvmLogicalDigestRequest) { r.MemIAVLDir = "" },
+		"non-positive height": func(r *EvmLogicalDigestRequest) { r.Height = 0 },
+		"bad normalization":   func(r *EvmLogicalDigestRequest) { r.Normalizations = []string{"bogus"} },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := baseRequest("seidb")
+			mutate(&req)
+			if err := d.run(context.Background(), req); err == nil {
+				t.Fatalf("%s should fail validation", name)
+			}
+		})
+	}
+}
+
+func TestEvmLogicalDigest_DefaultsApplied(t *testing.T) {
+	req := EvmLogicalDigestRequest{
+		FlatKVDir: "/a", MemIAVLDir: "/b", Height: 1, Bucket: "x", Region: "y",
+	}
+	if err := validateDigestRequest(&req); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if req.SeidbPath != defaultSeidbPath {
+		t.Errorf("SeidbPath default = %q, want %q", req.SeidbPath, defaultSeidbPath)
+	}
+	if len(req.Normalizations) != 2 || req.Normalizations[0] != "semantic" || req.Normalizations[1] != "translator" {
+		t.Errorf("Normalizations default = %v", req.Normalizations)
+	}
+}
+
+func TestParseDigestOutput_HappyPath(t *testing.T) {
+	out := strings.Join([]string{
+		"EVM logical digest start",
+		"backend: flatkv",
+		"version: 213200000",
+		"",
+		"account  count=10 bucket_digest=aabb",
+		"code     count=2 bucket_digest=ccdd",
+		"storage  count=99 bucket_digest=eeff",
+		"legacy   count=3 bucket_digest=1122",
+		"",
+		"FINAL_DIGEST account+code+storage+legacy count=114 digest=deadbeef",
+	}, "\n")
+	bd, err := parseDigestOutput(out)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if bd.Version != 213200000 {
+		t.Errorf("version = %d", bd.Version)
+	}
+	if bd.Account != "aabb" || bd.Code != "ccdd" || bd.Storage != "eeff" || bd.Legacy != "1122" {
+		t.Errorf("bucket digests = %+v", bd)
+	}
+	if bd.Final != "deadbeef" {
+		t.Errorf("final = %q", bd.Final)
+	}
+}
+
+func TestParseDigestOutput_FailClosed(t *testing.T) {
+	cases := map[string]string{
+		"missing final": strings.Join([]string{
+			"version: 5",
+			"account  count=1 bucket_digest=aa",
+			"code     count=1 bucket_digest=bb",
+			"storage  count=1 bucket_digest=cc",
+			"legacy   count=1 bucket_digest=dd",
+		}, "\n"),
+		"missing version": strings.Join([]string{
+			"account  count=1 bucket_digest=aa",
+			"code     count=1 bucket_digest=bb",
+			"storage  count=1 bucket_digest=cc",
+			"legacy   count=1 bucket_digest=dd",
+			"FINAL_DIGEST account+code+storage+legacy count=4 digest=ee",
+		}, "\n"),
+		"missing a bucket": strings.Join([]string{
+			"version: 5",
+			"account  count=1 bucket_digest=aa",
+			"storage  count=1 bucket_digest=cc",
+			"legacy   count=1 bucket_digest=dd",
+			"FINAL_DIGEST account+code+storage+legacy count=3 digest=ee",
+		}, "\n"),
+		"empty": "",
+	}
+	for name, out := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseDigestOutput(out); err == nil {
+				t.Fatalf("%s should be a parse error", name)
+			}
+		})
+	}
+}

--- a/sidecar/tasks/result_compare.go
+++ b/sidecar/tasks/result_compare.go
@@ -1,15 +1,10 @@
 package tasks
 
 import (
-	"compress/gzip"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
@@ -208,7 +203,8 @@ func (l *comparisonLoop) uploadDivergenceReport(ctx context.Context, result shad
 	}
 
 	key := fmt.Sprintf("%sdivergence-%d.report.json.gz", l.prefix, l.height)
-	return uploadGzipJSON(ctx, l.uploader, l.cfg.Bucket, key, report)
+	_, err = seis3.StreamGzipJSON(ctx, l.uploader, l.cfg.Bucket, key, report)
+	return err
 }
 
 func (l *comparisonLoop) flushPageIfFull(ctx context.Context) error {
@@ -245,106 +241,8 @@ func flushComparePage(ctx context.Context, uploader seis3.Uploader, bucket, pref
 	key := fmt.Sprintf("%s%d-%d.compare.ndjson.gz", prefix, start, end)
 
 	exportLog.Info("flushing comparison page", "key", key, "blocks", len(results))
-	return streamGzipNDJSON(ctx, uploader, bucket, key, results)
-}
-
-func streamGzipNDJSON(ctx context.Context, uploader seis3.Uploader, bucket, key string, results []shadow.CompareResult) error {
-	pr, pw := io.Pipe()
-
-	writeErr := make(chan error, 1)
-	go func() {
-		writeErr <- writeGzipNDJSON(results, pw)
-	}()
-
-	_, uploadErr := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
-		Bucket:      aws.String(bucket),
-		Key:         aws.String(key),
-		Body:        pr,
-		ContentType: aws.String("application/gzip"),
-	})
-	if uploadErr != nil {
-		pr.CloseWithError(uploadErr)
-	}
-
-	wErr := <-writeErr
-	if uploadErr != nil {
-		return uploadErr
-	}
-	return wErr
-}
-
-func writeGzipNDJSON(results []shadow.CompareResult, wc io.WriteCloser) (retErr error) {
-	defer func() {
-		if retErr != nil {
-			wc.(*io.PipeWriter).CloseWithError(retErr)
-		} else {
-			_ = wc.Close()
-		}
-	}()
-
-	gw := gzip.NewWriter(wc)
-	defer func() {
-		if err := gw.Close(); err != nil && retErr == nil {
-			retErr = fmt.Errorf("closing gzip writer: %w", err)
-		}
-	}()
-
-	for _, r := range results {
-		line, err := json.Marshal(r)
-		if err != nil {
-			return fmt.Errorf("marshaling comparison at height %d: %w", r.Height, err)
-		}
-		if _, err := gw.Write(append(line, '\n')); err != nil {
-			return fmt.Errorf("writing comparison at height %d: %w", r.Height, err)
-		}
-	}
-	return nil
-}
-
-func uploadGzipJSON(ctx context.Context, uploader seis3.Uploader, bucket, key string, v any) error {
-	pr, pw := io.Pipe()
-
-	writeErr := make(chan error, 1)
-	go func() {
-		writeErr <- writeGzipSingleJSON(v, pw)
-	}()
-
-	_, uploadErr := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
-		Bucket:      aws.String(bucket),
-		Key:         aws.String(key),
-		Body:        pr,
-		ContentType: aws.String("application/gzip"),
-	})
-	if uploadErr != nil {
-		pr.CloseWithError(uploadErr)
-	}
-
-	wErr := <-writeErr
-	if uploadErr != nil {
-		return uploadErr
-	}
-	return wErr
-}
-
-func writeGzipSingleJSON(v any, wc io.WriteCloser) (retErr error) {
-	defer func() {
-		if retErr != nil {
-			wc.(*io.PipeWriter).CloseWithError(retErr)
-		} else {
-			_ = wc.Close()
-		}
-	}()
-
-	gw := gzip.NewWriter(wc)
-	defer func() {
-		if err := gw.Close(); err != nil && retErr == nil {
-			retErr = fmt.Errorf("closing gzip writer: %w", err)
-		}
-	}()
-
-	enc := json.NewEncoder(gw)
-	enc.SetIndent("", "  ")
-	return enc.Encode(v)
+	_, err := seis3.StreamGzipNDJSON(ctx, uploader, bucket, key, results)
+	return err
 }
 
 func sleep(ctx context.Context, d time.Duration) error {

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -178,11 +178,20 @@ func (e *ResultExporter) exportPage(
 ) error {
 	key := fmt.Sprintf("%s%d-%d.ndjson.gz", prefix, start, end)
 
-	_, err := seis3.StreamGzipFunc(ctx, uploader, bucket, key, func(w io.Writer) error {
-		return e.collectResults(ctx, client, w, start, end)
+	var collectErr error
+	_, uploadErr := seis3.StreamGzipFunc(ctx, uploader, bucket, key, func(w io.Writer) error {
+		collectErr = e.collectResults(ctx, client, w, start, end)
+		return collectErr
 	})
-	if err != nil {
-		return seis3.ClassifyS3Error("result-export", bucket, key, region, err)
+	// A producer failure (block_results RPC, marshaling, ctx cancel) is not an S3
+	// problem — return it as-is so it isn't mislabeled with S3 access hints.
+	// collectErr is set iff the producer failed; if S3 dies mid-stream the error
+	// surfaces into collectErr through the closed pipe, so it is never swallowed.
+	if collectErr != nil {
+		return collectErr
+	}
+	if uploadErr != nil {
+		return seis3.ClassifyS3Error("result-export", bucket, key, region, uploadErr)
 	}
 	return nil
 }

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +27,12 @@ const (
 )
 
 var defaultRPCEndpoint = fmt.Sprintf("http://localhost:%d", seiconfig.PortRPC)
+
+// errSinkWrite tags a failure writing to the export sink (the gzip/upload pipe),
+// distinguishing a downstream/S3 cause from a genuine producer fault (RPC,
+// marshaling, ctx). When the sink fails mid-stream the real cause is the upload
+// error, so the write error must not be returned as if the producer failed.
+var errSinkWrite = errors.New("writing to export sink")
 
 // ResultExportRequest holds the parameters for the result-export task.
 type ResultExportRequest struct {
@@ -183,15 +190,18 @@ func (e *ResultExporter) exportPage(
 		collectErr = e.collectResults(ctx, client, w, start, end)
 		return collectErr
 	})
-	// A producer failure (block_results RPC, marshaling, ctx cancel) is not an S3
-	// problem — return it as-is so it isn't mislabeled with S3 access hints.
-	// collectErr is set iff the producer failed; if S3 dies mid-stream the error
-	// surfaces into collectErr through the closed pipe, so it is never swallowed.
-	if collectErr != nil {
+	switch {
+	case collectErr != nil && !errors.Is(collectErr, errSinkWrite):
+		// Genuine producer fault (block_results RPC, marshaling, ctx cancel) —
+		// not an S3 problem; return it as-is, never mislabeled with S3 hints.
 		return collectErr
-	}
-	if uploadErr != nil {
+	case uploadErr != nil:
+		// Upload failed, including mid-stream (which also shows up as a tagged
+		// errSinkWrite in collectErr). Keep the S3 classification + Retryable hint.
 		return seis3.ClassifyS3Error("result-export", bucket, key, region, uploadErr)
+	case collectErr != nil:
+		// A sink write failed without the upload reporting an error — surface it.
+		return collectErr
 	}
 	return nil
 }
@@ -223,7 +233,7 @@ func (e *ResultExporter) collectResults(ctx context.Context, client *rpc.Client,
 		line = append(line, '\n')
 
 		if _, err := w.Write(line); err != nil {
-			return fmt.Errorf("writing result at height %d: %w", h, err)
+			return fmt.Errorf("%w at height %d: %w", errSinkWrite, h, err)
 		}
 	}
 

--- a/sidecar/tasks/result_export.go
+++ b/sidecar/tasks/result_export.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	seiconfig "github.com/sei-protocol/sei-config"
 	"github.com/sei-protocol/seictl/sidecar/engine"
 	"github.com/sei-protocol/seictl/sidecar/rpc"
@@ -181,50 +178,19 @@ func (e *ResultExporter) exportPage(
 ) error {
 	key := fmt.Sprintf("%s%d-%d.ndjson.gz", prefix, start, end)
 
-	pr, pw := io.Pipe()
-
-	collectErr := make(chan error, 1)
-	go func() {
-		collectErr <- e.collectResults(ctx, client, pw, start, end)
-	}()
-
-	_, uploadErr := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
-		Bucket:      aws.String(bucket),
-		Key:         aws.String(key),
-		Body:        pr,
-		ContentType: aws.String("application/gzip"),
+	_, err := seis3.StreamGzipFunc(ctx, uploader, bucket, key, func(w io.Writer) error {
+		return e.collectResults(ctx, client, w, start, end)
 	})
-
-	if uploadErr != nil {
-		pr.CloseWithError(uploadErr)
+	if err != nil {
+		return seis3.ClassifyS3Error("result-export", bucket, key, region, err)
 	}
-
-	cErr := <-collectErr
-	if uploadErr != nil {
-		return seis3.ClassifyS3Error("result-export", bucket, key, region, uploadErr)
-	}
-	return cErr
+	return nil
 }
 
-// collectResults queries block_results for each height and writes gzipped
-// NDJSON to wc. Each line is a JSON object with height, time, and the raw
-// block_results response.
-func (e *ResultExporter) collectResults(ctx context.Context, client *rpc.Client, wc io.WriteCloser, start, end int64) (retErr error) {
-	defer func() {
-		if retErr != nil {
-			wc.(*io.PipeWriter).CloseWithError(retErr)
-		} else {
-			_ = wc.Close()
-		}
-	}()
-
-	gw := gzip.NewWriter(wc)
-	defer func() {
-		if err := gw.Close(); err != nil && retErr == nil {
-			retErr = fmt.Errorf("closing gzip writer: %w", err)
-		}
-	}()
-
+// collectResults queries block_results for each height and writes one NDJSON
+// line per block to w. Each line is a JSON object with height, time, and the
+// raw block_results response. gzip/pipe/checksum are owned by the s3 helper.
+func (e *ResultExporter) collectResults(ctx context.Context, client *rpc.Client, w io.Writer, start, end int64) error {
 	for h := start; h <= end; h++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -247,7 +213,7 @@ func (e *ResultExporter) collectResults(ctx context.Context, client *rpc.Client,
 		}
 		line = append(line, '\n')
 
-		if _, err := gw.Write(line); err != nil {
+		if _, err := w.Write(line); err != nil {
 			return fmt.Errorf("writing result at height %d: %w", h, err)
 		}
 	}

--- a/sidecar/tasks/result_export_test.go
+++ b/sidecar/tasks/result_export_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
+	"github.com/sei-protocol/seictl/sidecar/engine"
+	"github.com/sei-protocol/seictl/sidecar/rpc"
 	seis3 "github.com/sei-protocol/seictl/sidecar/s3"
 	"github.com/sei-protocol/seictl/sidecar/shadow"
 )
@@ -38,6 +41,62 @@ func mockResultUploaderFactory() seis3.UploaderFactory {
 func failingUploaderFactory(errMsg string) seis3.UploaderFactory {
 	return func(_ context.Context, _ string) (seis3.Uploader, error) {
 		return nil, fmt.Errorf("%s", errMsg)
+	}
+}
+
+// drainingFailingUploader drains the streamed body (so the writer never blocks)
+// then fails — an S3 error after reading a valid stream.
+type drainingFailingUploader struct{ err error }
+
+func (u drainingFailingUploader) UploadObject(_ context.Context, in *transfermanager.UploadObjectInput, _ ...func(*transfermanager.Options)) (*transfermanager.UploadObjectOutput, error) {
+	if in.Body != nil {
+		_, _ = io.Copy(io.Discard, in.Body)
+	}
+	return nil, u.err
+}
+
+// TestExportPage_ProducerErrorNotClassifiedAsS3 proves a block_results RPC
+// failure is returned as-is, not mislabeled as an S3 access problem.
+func TestExportPage_ProducerErrorNotClassifiedAsS3(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/block_results" {
+			http.Error(w, "block results unavailable", http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":-1,"result":{"sync_info":{"latest_block_height":"100"}}}`)
+	}))
+	defer srv.Close()
+
+	e := NewResultExporter(t.TempDir(), "test-1", "pod-0", mockResultUploaderFactory())
+	err := e.exportPage(context.Background(), rpc.NewClient(srv.URL, nil), &mockResultUploader{}, "bkt", "us-east-1", "p/", 100, 100)
+	if err == nil {
+		t.Fatal("expected a producer error")
+	}
+	var te *engine.TaskError
+	if errors.As(err, &te) && te.Operation == "S3" {
+		t.Fatalf("producer RPC error misclassified as S3: %v", err)
+	}
+	if !strings.Contains(err.Error(), "block_results") {
+		t.Fatalf("expected the block_results producer error, got: %v", err)
+	}
+}
+
+// TestExportPage_UploadErrorKeepsS3Classification proves a genuine upload
+// failure retains its ClassifyS3Error treatment (Operation S3), not lost behind
+// a wrapped sink-write error.
+func TestExportPage_UploadErrorKeepsS3Classification(t *testing.T) {
+	srv := fakeRPCServer(100)
+	defer srv.Close()
+
+	up := drainingFailingUploader{err: errors.New("connection reset by peer")}
+	e := NewResultExporter(t.TempDir(), "test-1", "pod-0", mockResultUploaderFactory())
+	err := e.exportPage(context.Background(), rpc.NewClient(srv.URL, nil), up, "bkt", "us-east-1", "p/", 100, 100)
+	if err == nil {
+		t.Fatal("expected an upload error")
+	}
+	var te *engine.TaskError
+	if !errors.As(err, &te) || te.Operation != "S3" {
+		t.Fatalf("upload failure should be S3-classified, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Adds the **full-keyspace digest gate** ([sei-chain#3611](https://github.com/sei-protocol/sei-chain/pull/3611)'s `seidb evm-logical-digest`) as a discrete sidecar task — the per-segment boundary seal that closes the touched-key comparator's **cold-state blind spot** (a key migrated wrong and never touched again is invisible to per-block Layer 2). Plus three seams the systems-engineering review called for. No "ShadowResultProducer" abstraction — that's deferred to the 3rd producer (YAGNI).

### What's here
- **`sidecar/s3/emit.go`** — one S3 emission helper (`StreamGzipNDJSON`/`StreamGzipJSON`/`StreamGzipFunc`), collapsing 3 duplicated gzip-pipe paths. Twofold integrity seal: an aws-chunked SHA-256 **wire** checksum over the compressed body (io.Pipe streaming/backpressure preserved) + an **uncompressed-payload** SHA-256 surfaced via `EmitResult` for out-of-band verification. `result_compare`/`result_export` refactored onto it (no behavior change).
- **`sidecar/engine`** — `recover()` in `runTask` turns a handler panic into a failed `TaskResult` (+ `seictl_task_panics_total`) instead of crashing the sidecar.
- **`sidecar/tasks/evm_logical_digest.go`** — the discrete task: shells out to `seidb` for flatkv + memiavl (`semantic` + `translator`), asserts **both** backends' opened version `== height` (fail-closed — no wrong-height false match), parses the `FINAL_DIGEST`/per-bucket contract, publishes an `EndpointDigestRecord`. `axes_proved` deliberately omits **balance** (the semantic account digest zeroes it — that axis stays the per-block comparator's job).

### Cross-review (systems-engineer + idiomatic-reviewer) — applied
- **Symmetric memiavl version assertion** (the flatkv-only check left a wrong-height false-match hole if seidb clamps to the nearest snapshot).
- **`recover()` inside the s3 writer goroutine** — a panic there (e.g. `MarshalJSON` over chain data) runs on a task-spawned goroutine *outside* the engine's handler recover; converted to a returned error so the upload aborts (no truncated-but-valid object) and the process survives.
- **Dropped the empty-by-construction `uncompressed_sha256`** from the published record (a record can't carry the hash of its own bytes; the seal is out-of-band in the log/TaskResult).
- comment-precision fixes (memory bound is the uploader part-pool, not "gzip window"; S3 checksum is per-part-composite for multipart) + a `version:`-line length guard.

### Notes
- `seidb` is **shelled out to** (configurable `seidbPath`), not vendored. #3611 also needs a one-line registration fix (`EvmLogicalDigestCmd()` isn't in `seidb`'s root `AddCommand`) — flagged to the author.
- Trigger is the **out-of-band task API**; no controller/CRD change (consistent with the avoided `ResultExportConfig` one-way door).
- **One-way-door surfaces for confirmation before a consumer reads them:** the task-type string `"evm-logical-digest"`, the param field names, and the `EndpointDigestRecord` schema.
- `GOWORK=off go build ./...` clean; `go test ./sidecar/...` green (incl. new memiavl-version-mismatch + writer-panic regression tests); `gofmt -s` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)