### PR TITLE
fix(statesync): derive witness scheme from port (https for :443)

### DIFF
--- a/sidecar/tasks/statesync.go
+++ b/sidecar/tasks/statesync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -24,6 +25,7 @@ const (
 	trustHeightOffset   = 2000
 	rpcPort             = "26657"
 	witnessProbeTimeout = 10 * time.Second
+	tlsPort             = "443"
 )
 
 // StateSyncConfig holds the trust point and RPC servers for Tendermint state sync.
@@ -251,9 +253,24 @@ func extractRPCHosts(peers []string, maxHosts int) []string {
 	return hosts
 }
 
-// rpcClientForEndpoint builds an rpc.Client targeting a full "host:port" RPC endpoint.
+// rpcClientForEndpoint builds an rpc.Client targeting a full "host:port" RPC
+// endpoint. The scheme is derived from the port: a :443 witness is a public TLS
+// gateway (Istio HTTPRoute) and must be reached over https; every other port is
+// the plaintext in-cluster CometBFT RPC. Hardcoding http:// here previously made
+// a :443 witness fail the /status probe with an immediate EOF (plaintext request
+// to a TLS listener), which blocked every new state-syncing node.
 func (s *StateSyncConfigurer) rpcClientForEndpoint(endpoint string) *rpc.Client {
-	return rpc.NewClient("http://"+endpoint, s.httpClient)
+	return rpc.NewClient(witnessScheme(endpoint)+"://"+endpoint, s.httpClient)
+}
+
+// witnessScheme returns the URL scheme for a "host:port" witness endpoint:
+// https for :443, http otherwise. An endpoint with no parseable port defaults
+// to http (the in-cluster plaintext form).
+func witnessScheme(endpoint string) string {
+	if _, port, err := net.SplitHostPort(endpoint); err == nil && port == tlsPort {
+		return "https"
+	}
+	return "http"
 }
 
 func (s *StateSyncConfigurer) queryLatestHeight(ctx context.Context, endpoint string) (int64, error) {

--- a/sidecar/tasks/statesync_test.go
+++ b/sidecar/tasks/statesync_test.go
@@ -590,6 +590,96 @@ func TestStateSyncConfigurer_PrimaryUnreachableFallsThrough(t *testing.T) {
 	}
 }
 
+func TestWitnessScheme(t *testing.T) {
+	cases := []struct {
+		name, endpoint, want string
+	}{
+		{"tls gateway on 443", "archive-0-rpc.arctic-1.platform.sei.io:443", "https"},
+		{"in-cluster rpc on 26657", "syncer-0-internal.arctic-1.svc.cluster.local:26657", "http"},
+		{"bare ip rpc", "1.2.3.4:26657", "http"},
+		{"no port defaults to http", "some-host", "http"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := witnessScheme(tc.endpoint); got != tc.want {
+				t.Errorf("witnessScheme(%q) = %q, want %q", tc.endpoint, got, tc.want)
+			}
+		})
+	}
+}
+
+// Regression guard for the state-sync witness scheme/port mismatch that blocked
+// every new K8s state-syncing node: a canonical syncer resolved to the public
+// Istio HTTPRoute hostname on :443 must be probed and queried over https, not
+// the previously-hardcoded http (which EOFed against the TLS listener). The mock
+// only answers the https URL — an http probe would fall through as an
+// "unexpected request" and the configure would fail.
+func TestStateSyncConfigurer_TLSWitnessUsesHTTPS(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, nil)
+
+	const witness = "archive-0-rpc.arctic-1.platform.sei.io:443"
+	hash := generateBlockHash()
+	mock := &mockHTTPDoer{
+		responses: map[string]*http.Response{
+			"https://" + witness + "/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "10000"}
+			}`)),
+			"https://" + witness + "/block?height=8000": jsonResponse(wrapResult(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash))),
+		},
+	}
+
+	configurer := NewStateSyncConfigurer(homeDir, mock)
+	if err := configurer.Configure(context.Background(), StateSyncRequest{
+		RpcServers: []string{witness},
+	}); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	ss := readTOML(t, filepath.Join(homeDir, "config", "config.toml"))["statesync"].(map[string]any)
+	// rpc-servers is written as the bare host:port (seid attaches the scheme).
+	if ss["rpc-servers"] != witness+","+witness {
+		t.Errorf("expected TLS witness padded to two, got %v", ss["rpc-servers"])
+	}
+	if ss["trust-height"] != int64(8000) {
+		t.Errorf("expected trust-height 8000, got %v", ss["trust-height"])
+	}
+}
+
+// The in-cluster plaintext path (a syncer's internal Service on :26657) must
+// stay on http — the forward-compatible counterpart to the TLS guard above.
+func TestStateSyncConfigurer_InternalWitnessUsesHTTP(t *testing.T) {
+	homeDir := t.TempDir()
+	setupPeersInConfig(t, homeDir, nil)
+
+	const witness = "syncer-0-internal.arctic-1.svc.cluster.local:26657"
+	hash := generateBlockHash()
+	mock := &mockHTTPDoer{
+		responses: map[string]*http.Response{
+			"http://" + witness + "/status": jsonResponse(wrapResult(`{
+				"sync_info": {"latest_block_height": "10000"}
+			}`)),
+			"http://" + witness + "/block?height=8000": jsonResponse(wrapResult(fmt.Sprintf(`{
+				"block_id": {"hash": %q}
+			}`, hash))),
+		},
+	}
+
+	configurer := NewStateSyncConfigurer(homeDir, mock)
+	if err := configurer.Configure(context.Background(), StateSyncRequest{
+		RpcServers: []string{witness},
+	}); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	ss := readTOML(t, filepath.Join(homeDir, "config", "config.toml"))["statesync"].(map[string]any)
+	if ss["trust-height"] != int64(8000) {
+		t.Errorf("expected trust-height 8000, got %v", ss["trust-height"])
+	}
+}
+
 // When no candidate witness is reachable, fail at configure time with a clear
 // error rather than writing a config that makes seid exit on "no witnesses".
 func TestStateSyncConfigurer_NoReachableWitness(t *testing.T) {


### PR DESCRIPTION
## Problem

Every NEW state-syncing node on the K8s platform is blocked at `Initializing` — seid waits on the sidecar, whose `configure-state-sync` task loops forever:

```
configure-state-sync: no reachable RPC witness among
  [archive-0-rpc.arctic-1.platform.sei.io:443, syncer-0-rpc.arctic-1.platform.sei.io:443]
  err: Get "http://archive-0-rpc.arctic-1.platform.sei.io:443/status": EOF
```

sei-k8s-controller resolves the canonical syncers (`Status.ResolvedStateSyncers`) to the public Istio HTTPRoute hostnames on `:443` (TLS). The task probed/queried them over **plaintext `http://...:443`** — a plaintext request to a TLS listener returns an immediate EOF, so witness reachability fails and the task never completes. Proven in-cluster: `http://...:443/status` fails (EOF); `https://.../status` returns 200.

rpc-node-0 synced ~18d ago before this syncer config existed in its current form, so only new nodes hit it.

## Fix

`rpcClientForEndpoint` hardcoded `http://`. It now derives the scheme from the port: **`https` for `:443`, `http` otherwise**. This:
- unblocks the current `:443` TLS witnesses immediately (no GitOps/ConfigMap change required for the arctic-1 cutover);
- stays correct for the in-cluster plaintext path (a syncer's internal Service on `:26657`), so a future move to internal endpoints needs no further code change;
- preserves the controller's documented contract — syncers stay bare `host:port`, the sidecar attaches the scheme; `rpc-servers` in `config.toml` is still written as bare `host:port` (seid attaches its own).

## Blast radius

Not arctic-1-specific. The controller resolves canonical syncers chain-agnostically (`canonicalSyncers(chainID)` → verbatim pass-through), and the task hardcoded `http://` for all of them. Every chain whose syncer ConfigMap lists `:443` TLS hostnames was latent-broken for its next state-syncing node; arctic-1's content surfaced it first. This fix covers all chains.

## Tests

- `TestWitnessScheme` — table guard on the port→scheme mapping.
- `TestStateSyncConfigurer_TLSWitnessUsesHTTPS` — regression guard: a `:443` witness is probed and queried over `https`; the mock only answers the https URL.
- `TestStateSyncConfigurer_InternalWitnessUsesHTTP` — the `:26657` in-cluster path stays on http.

Full `./sidecar/...` suite passes; statesync files are lint-clean.

## Cross-reference

Unblocks arctic-1 rpc-node-1 (platform PR #1241 follow-up) and the arctic-1 sei-infra→K8s cutover (Linear PLT-208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)